### PR TITLE
Update the node index mappings when the node index handler is

### DIFF
--- a/core/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandler.java
+++ b/core/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandler.java
@@ -105,6 +105,18 @@ public class NodeIndexHandler extends AbstractIndexHandler<Node> {
 		super(searchProvider, db, boot);
 	}
 
+	@Override
+	public Completable init() {
+		Completable superCompletable = super.init();
+		return superCompletable.andThen(Completable.create(sub -> {
+			db.noTx(() -> {
+				updateNodeIndexMappings();
+				sub.onCompleted();
+				return null;
+			});
+		}));
+	}
+
 	public NodeGraphFieldContainerTransformator getTransformator() {
 		return transformator;
 	}

--- a/doc/src/main/changelog/changes/30e2d2f4-b6de-11e6-8b5d-ea5d8efab9e8.bugfix.md
+++ b/doc/src/main/changelog/changes/30e2d2f4-b6de-11e6-8b5d-ea5d8efab9e8.bugfix.md
@@ -1,0 +1,1 @@
+When the search indices where recreated with the reindex endpoint, the mapping for the raw fields was not added. This has been fixed now.


### PR DESCRIPTION
initialized. This fixes missing mappings when the indices are recreated
with with reindex endpoint.