### PR TITLE
Fix build timestamp not displayed on startup

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<projectRoot>${project.basedir}/..</projectRoot>
 		<mesh.version>${project.version}</mesh.version>
-		<mesh.build.timestamp>${maven.build.timestamp}</mesh.build.timestamp>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<skip.cluster.tests>false</skip.cluster.tests>
 		<mesh.database.provider>mesh-orientdb</mesh.database.provider>
 		<mesh.image.provider>mesh-service-image-imgscalr</mesh.image.provider>
+		<mesh.build.timestamp>${maven.build.timestamp}</mesh.build.timestamp>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
Move "mesh.build.timestamp" maven property to root pom to fix build timestamp not displayed on startup.