### PR TITLE
NPE when keystore path contains no directory

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,11 @@
 
 icon:plus[] Core: The OrientDB graph database will be updated to version 3.0
 
+[[v0.16.1]]
+== 0.16.1 (TBD)
+
+icon:check[] Core: If the keystore path was only a file name without a directory a NPE was thrown on startup. This has been fixed now.
+
 [[v0.15.0]]
 == 0.15.0 (31.01.2018)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/AuthenticationOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/AuthenticationOptions.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.doc.GenerateDocumentation;
 
+import java.util.Objects;
+
 /**
  * Authentication options POJO.
  */
@@ -131,7 +133,9 @@ public class AuthenticationOptions {
 	}
 
 	public void validate(MeshOptions meshOptions) {
-		// TODO Auto-generated method stub
-
+		Objects.requireNonNull(keystorePath, "The keystore path cannot be null.");
+		if (keystorePath.trim().isEmpty()) {
+			throw new IllegalArgumentException("The keystore path cannot be empty");
+		}
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/cli/MeshImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/MeshImpl.java
@@ -126,8 +126,13 @@ public class MeshImpl implements Mesh {
 		File keystoreFile = new File(keyStorePath);
 		// Copy the demo keystore file to the destination
 		if (!keystoreFile.exists()) {
-			keystoreFile.getParentFile().mkdirs();
 			log.info("Could not find keystore {" + keyStorePath + "}. Creating one for you..");
+			if (keystoreFile.getParentFile() == null) {
+				log.debug("No parent directory for keystore found. Trying to create the keystore in the mesh root directory.");
+			} else {
+				log.debug("Ensure the keystore parent directory exists " + keyStorePath);
+				keystoreFile.getParentFile().mkdirs();
+			}
 			KeyStoreHelper.gen(keyStorePath, options.getAuthenticationOptions().getKeystorePassword());
 			log.info("Keystore {" + keyStorePath + "} created. The keystore password is listed in your {" + MESH_CONF_FILENAME + "} file.");
 		}


### PR DESCRIPTION
NPE on startup when keystore path contains no directory eg: keystorePath: "keystore.jceks"