### PR TITLE
Add dependency on commons-csv

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -77,6 +77,11 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.3.2</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.5</version>
+		</dependency>
 
 		<!-- Default storage provider -->
 		<dependency>


### PR DESCRIPTION
(workaround for classpath issues in plugin management, which does not
allow the formplugin to use its own version of commons-csv)