### PR TITLE
Force UTF-8 encoding for static admin ui resources

### DIFF
--- a/verticles/admin-gui/src/main/java/com/gentics/mesh/verticle/admin/AdminGUIEndpoint.java
+++ b/verticles/admin-gui/src/main/java/com/gentics/mesh/verticle/admin/AdminGUIEndpoint.java
@@ -83,6 +83,7 @@ public class AdminGUIEndpoint extends AbstractInternalEndpoint {
 
 	private void addMeshUiStaticHandler() {
 		StaticHandler handler = StaticHandler.create("META-INF/resources/webjars/mesh-ui/" + meshAdminUiVersion);
+		handler.setDefaultContentEncoding("UTF-8");
 		handler.setIndexPage("index.html");
 		route("/*").method(GET).blockingHandler(handler);
 	}


### PR DESCRIPTION
On windows (default charset 1252), the admin UI is shown with mangled umlauts. This should instruct vertx to decode the resources as UTF-8 no matter the default locale.

![image](https://user-images.githubusercontent.com/349397/41658233-0ac587cc-7496-11e8-964e-57dc2507b089.png)
