### PR TITLE
feat: add hazelcast kubernetes discovery plugin

### DIFF
--- a/databases/orientdb/pom.xml
+++ b/databases/orientdb/pom.xml
@@ -58,6 +58,19 @@
 			<groupId>com.orientechnologies</groupId>
 			<artifactId>orientdb-distributed</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast-kubernetes</artifactId>
+			<version>1.3.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.hazelcast</groupId>
+					<artifactId>hazelcast</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>


### PR DESCRIPTION
add hazelcast kubernetes autodiscovery plugin:

modify your hazelcast.xml this way:

```
 <network>
        <port auto-increment="true">5701</port>
        <join>
            <!--<multicast enabled="true">-->
                <!--<multicast-group>235.1.1.1</multicast-group>-->
                <!--<multicast-port>2434</multicast-port>-->
            <!--</multicast>-->

            <!-- deactivate normal discovery -->
            <multicast enabled="false"/>
            <tcp-ip enabled="false" />

            <!-- activate the Kubernetes plugin -->
            <discovery-strategies>
                <discovery-strategy enabled="true"
                                    class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">

                    <properties>
                        <!-- SERVICE-NAME.NAMESPACE.svc.cluster.local -->
                        <property name="service-dns">defined by env variable (hazelcast.kubernetes.service-dns)</property>
                        <property name="service-dns-timeout">500</property>
                    </properties>
                </discovery-strategy>
            </discovery-strategies>
        </join>
  </network>
```
