### PR TITLE
Remove mesh version from node name

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,8 @@ title: Changelog
 [[v0.30.0]]
 == 0.30.0 (TBD)
 
+icon:check[] Clustering: The mesh version will no longer be appended  to the node name used for OrientDB clustering. It is recommended to sanitize the `data/graphdb/storage/distributed-db-config.json` file and remove/rename entries which reference older mesh nodes. Only the active nodes should be listed in the file.
+
 icon:check[] Java Rest Client: The OkHttp implementation has replaced the Vert.x implementation. Some changes to the client interface were necessary to make the client independent of Vert.x. See link:https://getmesh.io/docs/platforms/#_java[this example] and the Javadoc for more information.
 
 icon:check[] Core: Fixed a bug that caused too long responses on binary range requests.

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/OrientDBDatabase.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/OrientDBDatabase.java
@@ -380,18 +380,12 @@ public class OrientDBDatabase extends AbstractDatabase {
 		StringBuilder nameBuilder = new StringBuilder();
 		String nodeName = options.getNodeName();
 		nameBuilder.append(nodeName);
-		nameBuilder.append("@");
-		nameBuilder.append(meshVersion);
 
 		// Sanitize the name
 		String name = nameBuilder.toString();
 		name = name.replaceAll(" ", "_");
 		name = name.replaceAll("\\.", "-");
 		return name;
-	}
-
-	public String getClusterName() {
-		return options.getClusterOptions().getClusterName();
 	}
 
 	private void writeOrientBackupConfig(File configFile) throws IOException {

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/TopologyEventBridge.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/TopologyEventBridge.java
@@ -44,16 +44,7 @@ public class TopologyEventBridge implements ODistributedLifecycleListener {
 		if (Mesh.isVertxReady()) {
 			getEventBus().send(CLUSTER_NODE_JOINING.address, nodeName);
 		}
-		String currentVersion = Mesh.getPlainVersion();
-		if (!nodeName.contains("@")) {
-			log.error("Node with name {" + nodeName + "} does not contain version information in the name. Rejecting request to join for that node.");
-			return false;
-		}
-		int idx = nodeName.indexOf("@");
-		String nodeVersion = nodeName.substring(idx + 1);
-		// nodeVersion.replaceAll("-", ".");
-		// TODO validate that the joining node uses the same mesh version as our node. Otherwise the join should be denied.
-		return currentVersion.equals(nodeVersion);
+		return true;
 	}
 
 	@Override
@@ -71,7 +62,7 @@ public class TopologyEventBridge implements ODistributedLifecycleListener {
 		if (log.isDebugEnabled()) {
 			log.debug("Node {" + iNode + "} left the cluster");
 		}
-//		db.removeNode(iNode);
+		// db.removeNode(iNode);
 		if (Mesh.isVertxReady()) {
 			getEventBus().send(CLUSTER_NODE_LEFT.address, iNode);
 		}


### PR DESCRIPTION
Adding the mesh version to the node name causes orientdb to add bogus entries to its distributed-config.json file which lists all known nodes.