### PR TITLE
S3 Support / Binary Plugins

### DIFF
--- a/common/src/main/java/com/gentics/mesh/plugin/registry/binary/BinaryStoragePluginRegistry.java
+++ b/common/src/main/java/com/gentics/mesh/plugin/registry/binary/BinaryStoragePluginRegistry.java
@@ -1,0 +1,7 @@
+package com.gentics.mesh.plugin.registry.binary;
+
+import com.gentics.mesh.plugin.registry.PluginRegistry;
+
+public interface BinaryStoragePluginRegistry extends PluginRegistry {
+
+}

--- a/common/src/main/java/com/gentics/mesh/storage/BinaryStorage.java
+++ b/common/src/main/java/com/gentics/mesh/storage/BinaryStorage.java
@@ -30,23 +30,25 @@ public interface BinaryStorage {
 	 * @param stream
 	 * @param uuid
 	 *            Uuid of the binary to be stored
+	 * @param size
 	 * @param temporaryId
 	 * @return
 	 */
-	Completable storeInTemp(Flowable<Buffer> stream, String temporaryId);
+	Completable storeInTemp(Flowable<Buffer> stream, long size, String temporaryId);
 
 	/**
 	 * Store the stream directly.
 	 * 
 	 * @param stream
+	 * @param size
 	 * @param uuid
 	 * @return
-	 * @deprecated Use {@link #storeInTemp(Flowable, String, String)} in combination with {@link #moveInPlace(String, String)} instead.
+	 * @deprecated Use {@link #storeInTemp(Flowable, long, String)} in combination with {@link #moveInPlace(String, String)} instead.
 	 */
 	@Deprecated
-	default Completable store(Flowable<Buffer> stream, String uuid) {
+	default Completable store(Flowable<Buffer> stream, long size, String uuid) {
 		String id = UUIDUtil.randomUUID();
-		return storeInTemp(stream, id).andThen(moveInPlace(uuid, id));
+		return storeInTemp(stream, size, id).andThen(moveInPlace(uuid, id));
 	}
 
 	/**

--- a/common/src/main/java/com/gentics/mesh/storage/BinaryStorage.java
+++ b/common/src/main/java/com/gentics/mesh/storage/BinaryStorage.java
@@ -8,6 +8,7 @@ import com.gentics.mesh.util.UUIDUtil;
 
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
+import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
 
 /**
@@ -66,7 +67,7 @@ public interface BinaryStorage {
 	 * @param binaryField
 	 * @return
 	 */
-	boolean exists(BinaryGraphField field);
+	Single<Boolean> exists(BinaryGraphField field);
 
 	/**
 	 * Read the binary data which is identified by the given binary uuid.

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
@@ -1,7 +1,9 @@
 package com.gentics.mesh.core.endpoint.node;
 
+import static com.gentics.mesh.core.rest.error.Errors.error;
 import static com.gentics.mesh.http.HttpConstants.ETAG;
 import static com.gentics.mesh.util.MimeTypeUtils.DEFAULT_BINARY_MIME_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_MODIFIED;
 
 import javax.inject.Inject;
@@ -21,11 +23,6 @@ import com.gentics.mesh.util.ETag;
 import com.gentics.mesh.util.EncodeUtil;
 import com.gentics.mesh.util.MimeTypeUtils;
 
-import io.reactivex.Flowable;
-import io.vertx.core.buffer.Buffer;
-import io.reactivex.Flowable;
-import io.reactivex.Single;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.MimeMapping;

--- a/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
@@ -40,6 +40,8 @@ import com.gentics.mesh.plugin.manager.MeshPluginManagerImpl;
 import com.gentics.mesh.plugin.pf4j.PluginEnvironmentImpl;
 import com.gentics.mesh.plugin.registry.DelegatingPluginRegistry;
 import com.gentics.mesh.plugin.registry.DelegatingPluginRegistryImpl;
+import com.gentics.mesh.plugin.registry.binary.BinaryStoragePluginRegistry;
+import com.gentics.mesh.plugin.registry.binary.BinaryStoragePluginRegistryImpl;
 import com.gentics.mesh.search.index.common.DropIndexHandler;
 import com.gentics.mesh.search.index.common.DropIndexHandlerImpl;
 import com.gentics.mesh.storage.BinaryStorage;
@@ -116,4 +118,7 @@ public abstract class BindModule {
 
 	@Binds
 	abstract DelegatingPluginRegistry bindPluginRegistry(DelegatingPluginRegistryImpl e);
+
+	@Binds
+	abstract BinaryStoragePluginRegistry bindBinaryStoragePluginRegistry(BinaryStoragePluginRegistryImpl e);
 }

--- a/core/src/main/java/com/gentics/mesh/plugin/registry/DelegatingPluginRegistryImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/registry/DelegatingPluginRegistryImpl.java
@@ -22,6 +22,7 @@ import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.graphql.plugin.GraphQLPluginRegistry;
 import com.gentics.mesh.plugin.MeshPlugin;
 import com.gentics.mesh.plugin.manager.MeshPluginManager;
+import com.gentics.mesh.plugin.registry.binary.BinaryStoragePluginRegistry;
 
 import dagger.Lazy;
 import io.reactivex.Completable;
@@ -48,6 +49,8 @@ public class DelegatingPluginRegistryImpl implements DelegatingPluginRegistry {
 	private final RestPluginRegistry restRegistry;
 
 	private final AuthServicePluginRegistry authServiceRegistry;
+	
+	private final BinaryStoragePluginRegistry binaryStoragePluginRegistry;
 
 	private final MeshOptions options;
 
@@ -62,11 +65,12 @@ public class DelegatingPluginRegistryImpl implements DelegatingPluginRegistry {
 
 	@Inject
 	public DelegatingPluginRegistryImpl(MeshOptions options, RestPluginRegistry restRegistry, GraphQLPluginRegistry graphqlRegistry,
-		AuthServicePluginRegistry authServiceRegistry, Lazy<MeshPluginManager> manager, Lazy<Vertx> rxVertx, Database db) {
+		AuthServicePluginRegistry authServiceRegistry, BinaryStoragePluginRegistry binaryStoragePluginRegistry, Lazy<MeshPluginManager> manager, Lazy<Vertx> rxVertx, Database db) {
 		this.options = options;
 		this.restRegistry = restRegistry;
 		this.graphqlRegistry = graphqlRegistry;
 		this.authServiceRegistry = authServiceRegistry;
+		this.binaryStoragePluginRegistry = binaryStoragePluginRegistry;
 		this.manager = manager;
 		this.rxVertx = rxVertx;
 		this.db = db;
@@ -108,7 +112,7 @@ public class DelegatingPluginRegistryImpl implements DelegatingPluginRegistry {
 	}
 
 	private Observable<PluginRegistry> registries() {
-		return Observable.fromArray(graphqlRegistry, restRegistry, authServiceRegistry);
+		return Observable.fromArray(graphqlRegistry, restRegistry, authServiceRegistry, binaryStoragePluginRegistry);
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/plugin/registry/binary/BinaryStoragePluginRegistryImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/registry/binary/BinaryStoragePluginRegistryImpl.java
@@ -1,0 +1,30 @@
+package com.gentics.mesh.plugin.registry.binary;
+
+import javax.inject.Singleton;
+
+import com.gentics.mesh.plugin.MeshPlugin;
+
+import io.reactivex.Completable;
+
+@Singleton
+public class BinaryStoragePluginRegistryImpl implements BinaryStoragePluginRegistry {
+
+	@Override
+	public Completable register(MeshPlugin plugin) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Completable deregister(MeshPlugin plugin) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void checkForConflict(MeshPlugin plugin) {
+		// TODO Auto-generated method stub
+		
+	}
+
+}

--- a/core/src/main/java/com/gentics/mesh/plugin/registry/binary/BinaryStoragePluginRegistryImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/registry/binary/BinaryStoragePluginRegistryImpl.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.plugin.registry.binary;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.gentics.mesh.plugin.MeshPlugin;
@@ -8,6 +9,10 @@ import io.reactivex.Completable;
 
 @Singleton
 public class BinaryStoragePluginRegistryImpl implements BinaryStoragePluginRegistry {
+
+	@Inject
+	public BinaryStoragePluginRegistryImpl() {
+	}
 
 	@Override
 	public Completable register(MeshPlugin plugin) {

--- a/core/src/test/java/com/gentics/mesh/core/binary/BinaryStoragePluginTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/binary/BinaryStoragePluginTest.java
@@ -1,0 +1,27 @@
+package com.gentics.mesh.core.binary;
+
+import org.junit.Test;
+
+import com.gentics.mesh.plugin.AbstractPluginTest;
+import com.gentics.mesh.plugin.BinaryStorageTestPlugin;
+import com.gentics.mesh.test.TestSize;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+@MeshTestSetting(testSize = TestSize.FULL, startServer = true)
+public class BinaryStoragePluginTest extends AbstractPluginTest {
+
+	@Test
+	public void testBinaryPlugin() {
+		grantAdminRole();
+
+		for (int i = 1; i <= 100; i++) {
+			deployPlugin(BinaryStorageTestPlugin.class, "bin" + i);
+		}
+
+		waitForPluginRegistration();
+		// TODO upload and assert
+		// TODO download and assert
+		// TODO range request and assert
+		// TODO delete and assert
+	}
+}

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldTest.java
@@ -71,7 +71,8 @@ public class BinaryFieldTest extends AbstractFieldTest<BinaryFieldSchema> {
 				input = input.concat("Hallo");
 			}
 			Binary binary = mesh().binaries().create("hashsum", 1L).runInExistingTx(tx);
-			mesh().binaryStorage().store(Flowable.just(Buffer.buffer(input)), binary.getUuid()).blockingAwait();
+			Buffer buffer = Buffer.buffer(input);
+			mesh().binaryStorage().store(Flowable.just(buffer), buffer.length(), binary.getUuid()).blockingAwait();
 			String base64 = binary.getBase64ContentSync();
 			assertEquals(input.toString(), new String(BASE64.decode(base64)));
 		}
@@ -82,7 +83,8 @@ public class BinaryFieldTest extends AbstractFieldTest<BinaryFieldSchema> {
 		try (Tx tx = tx()) {
 			String input = " ";
 			Binary binary = mesh().binaries().create("hashsum", 1L).runInExistingTx(tx);
-			mesh().binaryStorage().store(Flowable.just(Buffer.buffer(input)), binary.getUuid()).blockingAwait();
+			Buffer buffer = Buffer.buffer(input);
+			mesh().binaryStorage().store(Flowable.just(buffer), buffer.length(), binary.getUuid()).blockingAwait();
 			String base64 = binary.getBase64ContentSync();
 			assertEquals(input.toString(), new String(BASE64.decode(base64)));
 		}

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldTest.java
@@ -317,7 +317,7 @@ public class BinaryFieldTest extends AbstractFieldTest<BinaryFieldSchema> {
 		Single<ImageInfo> info = mesh().imageManipulator().readImageInfo(file.getAbsolutePath());
 		// Two obs handler
 		Single<String> hash = FileUtils.hash(obs);
-		Single<String> store = mesh().binaryStorage().store(obs, "bogus").toSingleDefault("null");
+		Single<String> store = mesh().binaryStorage().store(obs, bytes.length, "bogus").toSingleDefault("null");
 
 		TransformationResult result = Single.zip(hash, info, store, (hashV, infoV, storeV) -> {
 			return new TransformationResult(hashV, 0, infoV, "blume.jpg");

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldTestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldTestHelper.java
@@ -33,10 +33,11 @@ public interface BinaryFieldTestHelper {
 		Buffer buffer = Buffer.buffer(FILECONTENTS);
 		String sha512Sum = FileUtils.hash(buffer).blockingGet();
 		Binary binary = mesh.binaries().create(sha512Sum, Long.valueOf(buffer.length())).runInExistingTx(Tx.get());
+		long size = Long.valueOf(buffer.length());
 
 		String tmpId = UUIDUtil.randomUUID();
 		BinaryStorage storage = mesh.binaryStorage();
-		storage.storeInTemp(Flowable.just(buffer), tmpId).blockingAwait();
+		storage.storeInTemp(Flowable.just(buffer), size, tmpId).blockingAwait();
 		storage.moveInPlace(binary.getUuid(), tmpId).blockingAwait();
 
 		BinaryGraphField field = container.createBinary(name, binary);

--- a/core/src/test/java/com/gentics/mesh/core/schema/field/BinaryFieldMigrationTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/field/BinaryFieldMigrationTest.java
@@ -64,7 +64,7 @@ public class BinaryFieldMigrationTest extends AbstractFieldMigrationTest impleme
 		if (store == true) {
 			BinaryStorage storage = meshDagger().binaryStorage();
 			String tmpId = UUIDUtil.randomUUID();
-			storage.storeInTemp(Flowable.just(buffer), tmpId).blockingAwait();
+			storage.storeInTemp(Flowable.just(buffer), buffer.length(), tmpId).blockingAwait();
 			storage.moveInPlace(binary.getUuid(), tmpId).blockingAwait();
 		}
 	};

--- a/core/src/test/java/com/gentics/mesh/plugin/BinaryStorageTestPlugin.java
+++ b/core/src/test/java/com/gentics/mesh/plugin/BinaryStorageTestPlugin.java
@@ -1,0 +1,50 @@
+package com.gentics.mesh.plugin;
+
+import org.pf4j.PluginWrapper;
+
+import com.gentics.mesh.plugin.binary.BinaryStoragePlugin;
+import com.gentics.mesh.plugin.env.PluginEnvironment;
+import com.gentics.mesh.rest.client.MeshRestClient;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.vertx.core.buffer.Buffer;
+
+public class BinaryStorageTestPlugin extends AbstractPlugin implements BinaryStoragePlugin {
+
+	public BinaryStorageTestPlugin(PluginWrapper wrapper, PluginEnvironment env) {
+		super(wrapper, env);
+	}
+
+	@Override
+	public Flowable<Buffer> read(String uuid) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Flowable<Buffer> read(String uuid, long start, long size) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Single<Boolean> exists(String uuid) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Completable store(Flowable<Buffer> stream, long size, String uuid) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Completable delete(String uuid) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/core/src/test/java/com/gentics/mesh/search/NodeBinaryDocumentSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeBinaryDocumentSearchTest.java
@@ -75,7 +75,7 @@ public class NodeBinaryDocumentSearchTest extends AbstractNodeSearchEndpointTest
 			// file
 			Binary binaryB = mesh().binaries().create("someHashB", 200L).runInExistingTx(tx);
 			byte[] bytes = Base64.getDecoder().decode("e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=");
-			mesh().binaryStorage().store(Flowable.fromArray(Buffer.buffer(bytes)), binaryB.getUuid()).blockingAwait();
+			mesh().binaryStorage().store(Flowable.fromArray(Buffer.buffer(bytes)), bytes.length, binaryB.getUuid()).blockingAwait();
 
 			nodeB.getLatestDraftFieldContainer(english()).createBinary("binary", binaryB).setFileName("somefile.dat")
 				.setMimeType("text/plain");
@@ -134,7 +134,8 @@ public class NodeBinaryDocumentSearchTest extends AbstractNodeSearchEndpointTest
 			BinaryGraphField binary = nodeB.getLatestDraftFieldContainer(english()).createBinary("binary", binaryB).setFileName("somefile.dat")
 				.setMimeType("text/plain");
 			byte[] bytes = Base64.getDecoder().decode("e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=");
-			mesh().binaryStorage().store(Flowable.fromArray(Buffer.buffer(bytes)),  data.length(), binary.getBinary().getUuid()).blockingAwait();
+			Buffer buffer = Buffer.buffer(bytes);
+			mesh().binaryStorage().store(Flowable.fromArray(buffer), buffer.length(), binary.getBinary().getUuid()).blockingAwait();
 			tx.success();
 		}
 

--- a/core/src/test/java/com/gentics/mesh/search/NodeBinaryDocumentSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeBinaryDocumentSearchTest.java
@@ -134,7 +134,7 @@ public class NodeBinaryDocumentSearchTest extends AbstractNodeSearchEndpointTest
 			BinaryGraphField binary = nodeB.getLatestDraftFieldContainer(english()).createBinary("binary", binaryB).setFileName("somefile.dat")
 				.setMimeType("text/plain");
 			byte[] bytes = Base64.getDecoder().decode("e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=");
-			mesh().binaryStorage().store(Flowable.fromArray(Buffer.buffer(bytes)), binary.getBinary().getUuid()).blockingAwait();
+			mesh().binaryStorage().store(Flowable.fromArray(Buffer.buffer(bytes)),  data.length(), binary.getBinary().getUuid()).blockingAwait();
 			tx.success();
 		}
 

--- a/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryAuxSourcePlugin.java
+++ b/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryAuxSourcePlugin.java
@@ -1,0 +1,51 @@
+package com.gentics.mesh.plugin.binary;
+
+import com.gentics.mesh.plugin.MeshPlugin;
+
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A {@link BinaryAuxSourcePlugin} provides ways to resolve auxiliary sources that have been defined in the binary sourceId field.
+ * 
+ * When a source has been defined a download from the source will take precedence over the mesh binary storage.
+ */
+public interface BinaryAuxSourcePlugin extends MeshPlugin {
+
+	/**
+	 * Check whether the plugin can handle auxiliary sources for the given prefix.
+	 * 
+	 * @param prefix
+	 * @return
+	 */
+	boolean canHandle(String prefix);
+
+	/**
+	 * Read the binary data which is identified by the given binary uuid.
+	 * 
+	 * @param uuid
+	 * @return
+	 */
+	Flowable<Buffer> read(String uuid);
+
+	/**
+	 * Read a segment of the binary.
+	 * 
+	 * @param uuid
+	 * @param start
+	 * @param size
+	 * @return
+	 */
+	Flowable<Buffer> read(String uuid, long start, long size);
+
+	/**
+	 * Checks whether the binary data for the given binary uuid exists
+	 * 
+	 * @param uuid
+	 * @return
+	 */
+	Single<Boolean> exists(String uuid);
+
+	// Decide whether update / delete should be supported. Sources implies read-only?
+}

--- a/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryProcessorPlugin.java
+++ b/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryProcessorPlugin.java
@@ -1,0 +1,34 @@
+package com.gentics.mesh.plugin.binary;
+
+import java.util.function.Consumer;
+
+import com.gentics.mesh.core.rest.node.field.BinaryField;
+import com.gentics.mesh.plugin.MeshPlugin;
+
+import io.reactivex.Maybe;
+import io.vertx.ext.web.FileUpload;
+
+/**
+ * {@link BinaryProcessorPlugin}'s provide ways to analyze the uploaded data in order to parse and extract additional information from the data.
+ */
+public interface BinaryProcessorPlugin extends MeshPlugin {
+
+	/**
+	 * Check whether the processor accepts the specified content type.
+	 * 
+	 * @param contentType
+	 * @return
+	 */
+	boolean accepts(String contentType);
+
+	/**
+	 * Process the binary data and return a consumer for the binary field.
+	 * 
+	 * @param upload
+	 * @param hash
+	 *            SHA512 sum of the upload
+	 * @return Modifier for the binary field.
+	 */
+	// TODO Maybe use a dedicated container instead of BinaryField since not all fields should be mutable.
+	Maybe<Consumer<BinaryField>> process(FileUpload upload, String hash);
+}

--- a/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryStoragePlugin.java
+++ b/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryStoragePlugin.java
@@ -1,0 +1,57 @@
+package com.gentics.mesh.plugin.binary;
+
+import com.gentics.mesh.plugin.MeshPlugin;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A binary storage plugin provides means to hook into the upload and download process in order to provide custom storage implementations.
+ */
+public interface BinaryStoragePlugin extends MeshPlugin {
+
+	/**
+	 * Read the binary data which is identified by the given binary uuid.
+	 * 
+	 * @param uuid
+	 * @return
+	 */
+	Flowable<Buffer> read(String uuid);
+
+	/**
+	 * Read a segment of the binary.
+	 * 
+	 * @param uuid
+	 * @param start
+	 * @param size
+	 * @return
+	 */
+	Flowable<Buffer> read(String uuid, long start, long size);
+
+	/**
+	 * Checks whether the binary data for the given binary uuid exists
+	 * 
+	 * @param uuid
+	 * @return
+	 */
+	Single<Boolean> exists(String uuid);
+
+	/**
+	 * Store the binary.
+	 * 
+	 * @param stream
+	 * @param size
+	 * @param uuid
+	 * @return
+	 */
+	Completable store(Flowable<Buffer> stream, long size, String uuid);
+
+	/**
+	 * Delete the binary with the given uuid.
+	 * 
+	 * @param uuid
+	 */
+	Completable delete(String uuid);
+}

--- a/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryStoragePlugin.java
+++ b/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryStoragePlugin.java
@@ -36,16 +36,16 @@ public interface BinaryStoragePlugin extends MeshPlugin {
 	 * 
 	 * @param rc
 	 * @param uuid
-	 * @return 
+	 * @return
 	 */
 	// TODO decide whether this should return a completable. It may be better to end the request here since it is terminated at this point?
 	default Completable read(RoutingContext rc, String uuid) {
 		Flowable<Buffer> flow = read(uuid);
 		// TODO set header (content-encoding, content-length, content-type, cache-control)
-		return flow.map(buf -> {
-			rc.response().write(buf);
-			return buf;
-		}).ignoreElements().doFinally(rc.response()::end);
+		return flow.doOnNext(rc.response()::write)
+			.doFinally(rc.response()::end)
+			.doOnError(rc::fail)
+			.ignoreElements();
 	}
 
 	/**

--- a/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryStoragePlugin.java
+++ b/plugin-api/src/main/java/com/gentics/mesh/plugin/binary/BinaryStoragePlugin.java
@@ -6,6 +6,7 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * A binary storage plugin provides means to hook into the upload and download process in order to provide custom storage implementations.
@@ -29,6 +30,23 @@ public interface BinaryStoragePlugin extends MeshPlugin {
 	 * @return
 	 */
 	Flowable<Buffer> read(String uuid, long start, long size);
+
+	/**
+	 * Send the binary data to the client and end the request.
+	 * 
+	 * @param rc
+	 * @param uuid
+	 * @return 
+	 */
+	// TODO decide whether this should return a completable. It may be better to end the request here since it is terminated at this point?
+	default Completable read(RoutingContext rc, String uuid) {
+		Flowable<Buffer> flow = read(uuid);
+		// TODO set header (content-encoding, content-length, content-type, cache-control)
+		return flow.map(buf -> {
+			rc.response().write(buf);
+			return buf;
+		}).ignoreElements().doFinally(rc.response()::end);
+	}
 
 	/**
 	 * Checks whether the binary data for the given binary uuid exists

--- a/services/aws-s3-storage/pom.xml
+++ b/services/aws-s3-storage/pom.xml
@@ -27,7 +27,7 @@
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>aws-sdk-java</artifactId>
-				<version>2.0.0-preview-7</version>
+				<version>${aws.sdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -43,6 +43,18 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.4.10</version>
+		</dependency>
+
+		<!-- 4.4.10 to workaround classpath issue in s3 client -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.4.10</version>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/services/aws-s3-storage/pom.xml
+++ b/services/aws-s3-storage/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<aws.sdk.version>2.4.14</aws.sdk.version>
 	</properties>
 
 	<dependencyManagement>

--- a/services/aws-s3-storage/pom.xml
+++ b/services/aws-s3-storage/pom.xml
@@ -45,11 +45,6 @@
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.4.10</version>
-		</dependency>
 
 		<!-- 4.4.10 to workaround classpath issue in s3 client -->
 		<dependency>

--- a/services/aws-s3-storage/src/main/java/com/gentics/mesh/storage/s3/S3BinaryStorage.java
+++ b/services/aws-s3-storage/src/main/java/com/gentics/mesh/storage/s3/S3BinaryStorage.java
@@ -182,8 +182,8 @@ public class S3BinaryStorage extends AbstractBinaryStorage {
 	public Completable moveInPlace(String uuid, String temporaryId) {
 		CopyObjectRequest copyRequest = CopyObjectRequest.builder()
 			.bucket(bucketName)
-			.key(uuid)
 			.copySource(bucketName + "/" + temporaryId)
+			.key(uuid)
 			.build();
 
 		Completable copy = CompletableInterop.fromFuture(client.copyObject(copyRequest))
@@ -195,6 +195,7 @@ public class S3BinaryStorage extends AbstractBinaryStorage {
 			.bucket(bucketName)
 			.key(temporaryId)
 			.build();
+
 		Completable delete = CompletableInterop.fromFuture(client.deleteObject(deleObjectRequest))
 			.doOnError(e -> {
 				log.error("Error while deleting temporary file {}", temporaryId, e);
@@ -204,7 +205,14 @@ public class S3BinaryStorage extends AbstractBinaryStorage {
 
 	@Override
 	public Completable purgeTemporaryUpload(String temporaryId) {
-		return Completable.complete();
+		DeleteObjectRequest deleObjectRequest = DeleteObjectRequest.builder()
+			.bucket(bucketName)
+			.key(temporaryId)
+			.build();
+		return CompletableInterop.fromFuture(client.deleteObject(deleObjectRequest))
+			.doOnError(e -> {
+				log.error("Error while deleting temporary upload {}", temporaryId, e);
+			});
 	}
 
 	@Override

--- a/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/AbstractMinioTest.java
+++ b/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/AbstractMinioTest.java
@@ -1,0 +1,52 @@
+package com.gentics.mesh.storage.s3;
+
+import static com.gentics.mesh.storage.s3.MinioContainer.MINIO_ACCESS_KEY;
+import static com.gentics.mesh.storage.s3.MinioContainer.MINIO_SECRET_KEY;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+public abstract class AbstractMinioTest {
+
+	public static final String BUCKET_NAME = "mesh-test";
+
+	public static final AwsCredentials credentials = AwsBasicCredentials.create(MINIO_ACCESS_KEY, MINIO_SECRET_KEY);
+
+	@ClassRule
+	public static MinioContainer minio = new MinioContainer();
+
+	private S3Client s3;
+
+	@Before
+	public void setup() {
+		s3 = createS3Client();
+		createBucket("test123");
+	}
+
+	public S3Client createS3Client() {
+		return S3Client.builder()
+			.region(Region.US_EAST_1)
+			.endpointOverride(minio.getURI())
+			.credentialsProvider(StaticCredentialsProvider.create(credentials))
+			.build();
+	}
+
+	public void createBucket(String name) {
+		CreateBucketRequest createBucketRequest = CreateBucketRequest
+			.builder()
+			.bucket(name)
+			.createBucketConfiguration(CreateBucketConfiguration.builder()
+				.build())
+			.build();
+		s3.createBucket(createBucketRequest);
+	}
+
+}

--- a/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/MinioContainer.java
+++ b/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/MinioContainer.java
@@ -1,0 +1,43 @@
+package com.gentics.mesh.storage.s3;
+
+import java.net.URI;
+import java.time.Duration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+public class MinioContainer extends GenericContainer<MinioContainer> {
+
+	public static final String VERSION = "7268-b336f52";
+
+	public static final String MINIO_ACCESS_KEY = "minio";
+
+	public static final String MINIO_SECRET_KEY = "miniosecret";
+
+	public MinioContainer() {
+		super("minio/minio:" + VERSION);
+	}
+
+	@Override
+	protected void configure() {
+		withCommand("server /data");
+		withEnv("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY);
+		withEnv("MINIO_SECRET_KEY", MINIO_SECRET_KEY);
+		withExposedPorts(9000);
+		withLogConsumer(o -> System.out.print(o.getUtf8String()));
+		withStartupTimeout(Duration.ofSeconds(10L));
+		waitingFor(new HttpWaitStrategy().forPath("/minio/health/ready"));
+	}
+
+	/**
+	 * Return the server address.
+	 * 
+	 * @return
+	 */
+	public URI getURI() {
+		return URI.create("http://"
+			+ getContainerIpAddress()
+			+ ":" + getFirstMappedPort());
+	}
+
+}

--- a/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
+++ b/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
@@ -41,9 +41,9 @@ public class S3BinaryStorageTest extends AbstractMinioTest {
 	@Test
 	public void testStore() throws IOException {
 		Buffer data = Buffer.buffer("test1234");
-		final Flowable<Buffer> flow = Flowable.just(data);
-		final String uuid = UUIDUtil.randomUUID();
-		final String temporaryId = UUIDUtil.randomUUID();
+		Flowable<Buffer> flow = Flowable.just(data);
+		String uuid = UUIDUtil.randomUUID();
+		String temporaryId = UUIDUtil.randomUUID();
 
 		Binary binary = Mockito.mock(Binary.class);
 		Mockito.when(binary.getSHA512Sum()).thenReturn(uuid);
@@ -71,6 +71,10 @@ public class S3BinaryStorageTest extends AbstractMinioTest {
 		// Delete file & check
 		storage.delete(uuid).blockingAwait();
 		assertFalse(storage.exists(mockField).blockingGet());
+
+		flow = Flowable.just(data);
+		storage.storeInTemp(flow, data.length(), temporaryId).blockingAwait();
+		storage.purgeTemporaryUpload(temporaryId);
 	}
 
 }

--- a/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
+++ b/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
@@ -38,16 +38,19 @@ public class S3BinaryStorageTest extends AbstractMinioTest {
 
 	@Test
 	public void testStore() throws IOException {
-		BinaryGraphField mockField = Mockito.mock(BinaryGraphField.class);
+		final Flowable<Buffer> data = Flowable.just(Buffer.buffer("test"));
+		final String uuid = "test123";
+
 		Binary binary = Mockito.mock(Binary.class);
+		Mockito.when(binary.getSHA512Sum()).thenReturn(uuid);
+
+		BinaryGraphField mockField = Mockito.mock(BinaryGraphField.class);
 		Mockito.when(mockField.getBinary()).thenReturn(binary);
-		Mockito.when(binary.getSHA512Sum()).thenReturn("test");
 
 		// assertFalse(storage.exists(mockField));
-		Flowable<Buffer> data = Flowable.just(Buffer.buffer("test"));
-		storage.storeInTemp(data, "test").blockingAwait();
+		storage.storeInTemp(data, uuid).blockingAwait();
 		assertTrue(storage.exists(mockField));
-		Single<Buffer> buf = RxUtil.readEntireData(storage.read("test"));
+		Single<Buffer> buf = RxUtil.readEntireData(storage.read(uuid));
 		System.out.println("Data: " + buf.blockingGet().toString());
 	}
 

--- a/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
+++ b/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
@@ -1,63 +1,54 @@
 package com.gentics.mesh.storage.s3;
 
+import static com.gentics.mesh.storage.s3.MinioContainer.MINIO_ACCESS_KEY;
+import static com.gentics.mesh.storage.s3.MinioContainer.MINIO_SECRET_KEY;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.Wait;
 
 import com.gentics.mesh.core.data.binary.Binary;
 import com.gentics.mesh.core.data.node.field.BinaryGraphField;
+import com.gentics.mesh.util.RxUtil;
 
 import io.reactivex.Flowable;
+import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.reactivex.core.Vertx;
 
-@Ignore
-public class S3BinaryStorageTest {
-
-	public static final String VERSION = "RELEASE.2018-01-18T20-33-21Z";
-	public static final String ACCESS_KEY = "myKey";
-	public static final String SECRET_KEY = "mySecret";
-	public static final String BUCKET_NAME = "mesh-test";
+public class S3BinaryStorageTest extends AbstractMinioTest {
 
 	private static Vertx vertx = Vertx.vertx();
-
-	@ClassRule
-	public static GenericContainer<?> minio = new GenericContainer<>("minio/minio:" + VERSION)
-		.withCommand("server /data")
-		.withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
-		.withEnv("MINIO_SECRET_KEY", SECRET_KEY)
-		.withExposedPorts(9000)
-		.waitingFor(Wait.forHttp("/").forStatusCode(403));
 
 	private S3BinaryStorage storage;
 
 	@Before
 	public void setup() {
 		S3StorageOptions options = new S3StorageOptions();
-		options.setAccessId(ACCESS_KEY);
-		options.setAccessKey(SECRET_KEY);
+		options.setAccessId(MINIO_ACCESS_KEY);
+		options.setAccessKey(MINIO_SECRET_KEY);
 		options.setRegion("US_EAST_1");
 		options.setBucketName(BUCKET_NAME);
-		options.setUrl("http://localhost:" + minio.getMappedPort(9000));
+		options.setUrl(minio.getURI().toString());
 		storage = new S3BinaryStorage(options, vertx);
 	}
 
 	@Test
-	public void testStore() {
+	public void testStore() throws IOException {
 		BinaryGraphField mockField = Mockito.mock(BinaryGraphField.class);
 		Binary binary = Mockito.mock(Binary.class);
 		Mockito.when(mockField.getBinary()).thenReturn(binary);
 		Mockito.when(binary.getSHA512Sum()).thenReturn("test");
-//		assertFalse(storage.exists(mockField));
-		storage.store(Flowable.just(Buffer.buffer("test")), "test").blockingAwait();
+
+		// assertFalse(storage.exists(mockField));
+		Flowable<Buffer> data = Flowable.just(Buffer.buffer("test"));
+		storage.storeInTemp(data, "test").blockingAwait();
 		assertTrue(storage.exists(mockField));
-		storage.read("test").ignoreElements().blockingAwait();
+		Single<Buffer> buf = RxUtil.readEntireData(storage.read("test"));
+		System.out.println("Data: " + buf.blockingGet().toString());
 	}
 
 }

--- a/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
+++ b/services/aws-s3-storage/src/test/java/com/gentics/mesh/storage/s3/S3BinaryStorageTest.java
@@ -2,6 +2,7 @@ package com.gentics.mesh.storage.s3;
 
 import static com.gentics.mesh.storage.s3.MinioContainer.MINIO_ACCESS_KEY;
 import static com.gentics.mesh.storage.s3.MinioContainer.MINIO_SECRET_KEY;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -38,7 +39,8 @@ public class S3BinaryStorageTest extends AbstractMinioTest {
 
 	@Test
 	public void testStore() throws IOException {
-		final Flowable<Buffer> data = Flowable.just(Buffer.buffer("test"));
+		Buffer data = Buffer.buffer("test1234");
+		final Flowable<Buffer> flow = Flowable.just(data);
 		final String uuid = "test123";
 
 		Binary binary = Mockito.mock(Binary.class);
@@ -47,8 +49,8 @@ public class S3BinaryStorageTest extends AbstractMinioTest {
 		BinaryGraphField mockField = Mockito.mock(BinaryGraphField.class);
 		Mockito.when(mockField.getBinary()).thenReturn(binary);
 
-		// assertFalse(storage.exists(mockField));
-		storage.storeInTemp(data, uuid).blockingAwait();
+		assertFalse(storage.exists(mockField));
+		storage.storeInTemp(flow, data.length(), uuid).blockingAwait();
 		assertTrue(storage.exists(mockField));
 		Single<Buffer> buf = RxUtil.readEntireData(storage.read(uuid));
 		System.out.println("Data: " + buf.blockingGet().toString());

--- a/services/aws-s3-storage/src/test/resources/logback-test.xml
+++ b/services/aws-s3-storage/src/test/resources/logback-test.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-	<conversionRule conversionWord="meshName"
-		converterClass="com.gentics.mesh.log.MeshLogNameConverter" />
+	<conversionRule conversionWord="meshName" converterClass="com.gentics.mesh.log.MeshLogNameConverter"/>
 
 	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
 		<target>System.err</target>
@@ -23,8 +22,7 @@
 			</pattern>
 		</encoder>
 	</appender>
-
-	<root level="ERROR">
-		<appender-ref ref="STDOUT" />
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
 	</root>
 </configuration>

--- a/services/local-storage/src/main/java/com/gentics/mesh/storage/LocalBinaryStorage.java
+++ b/services/local-storage/src/main/java/com/gentics/mesh/storage/LocalBinaryStorage.java
@@ -21,6 +21,7 @@ import com.gentics.mesh.util.RxUtil;
 
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
+import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.logging.Logger;
@@ -163,9 +164,9 @@ public class LocalBinaryStorage extends AbstractBinaryStorage {
 	}
 
 	@Override
-	public boolean exists(BinaryGraphField field) {
+	public Single<Boolean> exists(BinaryGraphField field) {
 		String uuid = field.getBinary().getUuid();
-		return new File(getFilePath(uuid)).exists();
+		return fileSystem.rxExists(getFilePath(uuid));
 	}
 
 	@Override

--- a/services/local-storage/src/main/java/com/gentics/mesh/storage/LocalBinaryStorage.java
+++ b/services/local-storage/src/main/java/com/gentics/mesh/storage/LocalBinaryStorage.java
@@ -100,7 +100,7 @@ public class LocalBinaryStorage extends AbstractBinaryStorage {
 	}
 
 	@Override
-	public Completable storeInTemp(Flowable<Buffer> stream, String temporaryId) {
+	public Completable storeInTemp(Flowable<Buffer> stream, long size, String temporaryId) {
 		Objects.requireNonNull(temporaryId, "The temporary id was not specified.");
 		return Completable.defer(() -> {
 			String path = getTemporaryFilePath(temporaryId);


### PR DESCRIPTION
This PR aims to provide S3 and additional binary plugin support

* BinaryAuxSourcePlugin - gentics/mesh-incubator#205
* BinaryProcessorPlugin - gentics/mesh-incubator#27
* BinaryStoragePlugin - gentics/mesh-incubator#111

## TODO

* [ ] Provide default (build-in) local storage support
      Move RangeRequestHandler code and refactor BinaryFieldResponseHandler
* [ ] Refactor Range Request Handling (to use binary storage)
      Code should be part of the local storage provider implementation
* [ ] Merge https://github.com/gentics/mesh/pull/868 with PR
* [ ] Merge parts of https://github.com/gentics/mesh/compare/dev-new-es-handling-upload-s3...jdbranham:dev-new-es-handling-upload-s3
* [ ] Add BinaryProcessorPlugin support / tests
* [ ] Add BinaryStoragePlugin support / tests
* [ ] Add BinaryAuxSourcePlugin support / tests
* [ ] Create S3 storage plugin
      Move S3 provider code into plugin
* [ ] Documentation
      Document new plugin types
* [ ] Plugin Examples
      Virus Scanner plugin
      External binary source plugin

## Limitations

* Migration between binary storage systems will not be supported out of the box

## Questions

* Should webroot requests be answered via proxying the request between client and S3 (Additional traffic) or redirect via `302` to S3 URL.
* Should the webroot link resolver also render S3 urls whenever possible? This way a client request would directly hit S3 without involving the Mesh server.