### PR TITLE
Add support for non-i18n fields

### DIFF
--- a/core/src/test/java/com/gentics/mesh/core/field/NonI18nFieldTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/NonI18nFieldTest.java
@@ -1,0 +1,66 @@
+package com.gentics.mesh.core.field;
+
+import static com.gentics.mesh.test.ClientHelper.call;
+
+import org.junit.Test;
+
+import com.gentics.mesh.FieldUtil;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.NodeUpdateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.parameter.impl.NodeParametersImpl;
+import com.gentics.mesh.test.TestSize;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+@MeshTestSetting(testSize = TestSize.PROJECT_AND_NODE, startServer = true)
+public class NonI18nFieldTest extends AbstractMeshTest {
+
+	@Test
+	public void testNonI18n() {
+
+		String parentFolderUuid = tx(() -> project().getBaseNode().getUuid());
+
+		SchemaCreateRequest schemaRequest = new SchemaCreateRequest();
+		schemaRequest.setName("testing");
+		schemaRequest.addField(FieldUtil.createStringFieldSchema("i18n-name").setTranslatable(true));
+		schemaRequest.addField(FieldUtil.createStringFieldSchema("non-i18n-name").setTranslatable(false));
+		SchemaResponse schemaResponse = call(() -> client().createSchema(schemaRequest));
+		call(() -> client().assignSchemaToProject(projectName(), schemaResponse.getUuid()));
+
+		NodeCreateRequest nodeRequest = new NodeCreateRequest();
+		nodeRequest.setSchemaName("testing");
+		nodeRequest.setLanguage("en");
+		nodeRequest.getFields().put("i18n-name", FieldUtil.createStringField("i18n en name"));
+		nodeRequest.getFields().put("non-i18n-name", FieldUtil.createStringField("non-i18n en name"));
+		nodeRequest.setParentNodeUuid(parentFolderUuid);
+		NodeResponse nodeResponse = call(() -> client().createNode(projectName(), nodeRequest));
+		String uuid = nodeResponse.getUuid();
+
+		NodeUpdateRequest nodeUpdateRequest = new NodeUpdateRequest();
+		nodeUpdateRequest.setLanguage("de");
+		nodeUpdateRequest.getFields().put("i18n-name", FieldUtil.createStringField("i18n de name"));
+		call(() -> client().updateNode(projectName(), uuid, nodeUpdateRequest));
+
+		printFields(uuid);
+
+		// Now update one language
+		nodeUpdateRequest.getFields().put("non-i18n-name", FieldUtil.createStringField("non-i18n de name new!"));
+		call(() -> client().updateNode(projectName(), uuid, nodeUpdateRequest));
+
+		printFields(uuid);
+
+	}
+
+	private void printFields(String uuid) {
+		NodeResponse deNode = call(() -> client().findNodeByUuid(projectName(), uuid, new NodeParametersImpl().setLanguages("de")));
+		System.out.println(deNode.getFields().toJson());
+
+		NodeResponse enNode = call(() -> client().findNodeByUuid(projectName(), uuid, new NodeParametersImpl().setLanguages("en")));
+		System.out.println(enNode.getFields().toJson());
+
+	}
+
+}

--- a/core/src/test/java/com/gentics/mesh/core/field/NonI18nFieldTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/NonI18nFieldTest.java
@@ -2,6 +2,9 @@ package com.gentics.mesh.core.field;
 
 import static com.gentics.mesh.test.ClientHelper.call;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
 import org.junit.Test;
 
 import com.gentics.mesh.FieldUtil;
@@ -14,6 +17,8 @@ import com.gentics.mesh.parameter.impl.NodeParametersImpl;
 import com.gentics.mesh.test.TestSize;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
+
+import io.vertx.core.buffer.Buffer;
 
 @MeshTestSetting(testSize = TestSize.PROJECT_AND_NODE, startServer = true)
 public class NonI18nFieldTest extends AbstractMeshTest {
@@ -54,13 +59,46 @@ public class NonI18nFieldTest extends AbstractMeshTest {
 
 	}
 
+	@Test
+	public void testNonI18nBinary() {
+		String parentFolderUuid = tx(() -> project().getBaseNode().getUuid());
+
+		SchemaCreateRequest schemaRequest = new SchemaCreateRequest();
+		schemaRequest.setName("testing");
+		schemaRequest.addField(FieldUtil.createStringFieldSchema("i18n-name").setTranslatable(true));
+		schemaRequest.addField(FieldUtil.createStringFieldSchema("non-i18n-name").setTranslatable(false));
+		schemaRequest.addField(FieldUtil.createBinaryFieldSchema("image").setTranslatable(false));
+
+		SchemaResponse schemaResponse = call(() -> client().createSchema(schemaRequest));
+		call(() -> client().assignSchemaToProject(projectName(), schemaResponse.getUuid()));
+
+		NodeCreateRequest nodeRequest = new NodeCreateRequest();
+		nodeRequest.setSchemaName("testing");
+		nodeRequest.setLanguage("en");
+		nodeRequest.getFields().put("i18n-name", FieldUtil.createStringField("i18n en name"));
+		nodeRequest.setParentNodeUuid(parentFolderUuid);
+		NodeResponse nodeResponse = call(() -> client().createNode(projectName(), nodeRequest));
+		String uuid = nodeResponse.getUuid();
+
+		NodeUpdateRequest nodeUpdateRequest = new NodeUpdateRequest();
+		nodeUpdateRequest.setLanguage("de");
+		nodeUpdateRequest.getFields().put("i18n-name", FieldUtil.createStringField("i18n de name"));
+		call(() -> client().updateNode(projectName(), uuid, nodeUpdateRequest));
+
+		Buffer buffer = Buffer.buffer("text");
+		InputStream ins = new ByteArrayInputStream(buffer.getBytes());
+		call(() -> client().updateNodeBinaryField(projectName(), uuid, "de", "draft", "image", ins, buffer.length(), "dummy.txt", "text/plain"));
+
+		printFields(uuid);
+
+	}
+
 	private void printFields(String uuid) {
 		NodeResponse deNode = call(() -> client().findNodeByUuid(projectName(), uuid, new NodeParametersImpl().setLanguages("de")));
 		System.out.println(deNode.getFields().toJson());
 
 		NodeResponse enNode = call(() -> client().findNodeByUuid(projectName(), uuid, new NodeParametersImpl().setLanguages("en")));
 		System.out.println(enNode.getFields().toJson());
-
 	}
 
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/micronode/MicronodeResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/micronode/MicronodeResponse.java
@@ -47,6 +47,19 @@ public class MicronodeResponse extends AbstractResponse implements MicronodeFiel
 		return this;
 	}
 
+	/**
+	 * Shortcut to set the schema reference by microschemaName.
+	 * 
+	 * @param microschemaName
+	 * @return
+	 */
+	public MicronodeResponse setMicroschemaName(String microschemaName) {
+		MicroschemaReference microschemaReference = new MicroschemaReferenceImpl();
+		microschemaReference.setName(microschemaName);
+		setMicroschema(microschemaReference);
+		return this;
+	}
+
 	@Override
 	public FieldMap getFields() {
 		return fields;

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchema.java
@@ -72,10 +72,25 @@ public interface FieldSchema {
 	/**
 	 * Set the required flag.
 	 * 
-	 * @param isRequired
+	 * @param flag
 	 * @return Fluent API
 	 */
-	FieldSchema setRequired(boolean isRequired);
+	FieldSchema setRequired(boolean flag);
+
+	/**
+	 * Return the translatable flag of the field.
+	 * @return
+	 */
+	boolean isTranslatable();
+
+	/**
+	 * Set the translatable flag.
+	 * 
+	 * @param flag
+	 * @return
+	 */
+	FieldSchema setTranslatable(boolean flag);
+
 
 	/**
 	 * Compare the field schema with the given field schema.

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
@@ -49,6 +49,10 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 	private boolean required = false;
 
 	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag which indicates whether the field is translatable or not. Non-i18n fields will automatically be kept in sync with other languages.")
+	private boolean translatable = true;
+
+	@JsonProperty(required = false)
 	@JsonPropertyDescription("Additional elasticsearch index field configuration. This can be used to add custom fields with custom analyzers to the search index.")
 	private JsonObject elasticsearch;
 
@@ -82,6 +86,17 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 	@Override
 	public AbstractFieldSchema setRequired(boolean flag) {
 		this.required = flag;
+		return this;
+	}
+
+	@Override
+	public boolean isTranslatable() {
+		return translatable;
+	}
+
+	@Override
+	public AbstractFieldSchema setTranslatable(boolean flag) {
+		this.translatable = flag;
 		return this;
 	}
 


### PR DESCRIPTION
The proposed mechanism works by synchronizing field values for non-i18n fields to other language contents. Updating a german content will propagate the included non-i18n fields to other language contents. This way no complex domain model changes need to be made. The non-i18n fields are automatically versioned.

TODO:

* [ ] Invoke synchronization of fields when nodes get published
> In this case we need to push all non-i18n fields to other published containers of the node and update their version. Would this be the expected behaviour?
* [ ] Invoke synchronization of fields when nodes get taken offline (in this case the draft non-i18n fields need to be used for the new draft container)
* [ ] Check how we could support non-18n fields for micronodes. Is that even needed?
* [x] Push new non-18n fields to other containers
* [x] Pull non-18n fields from other containers to new versions. Do we only need to do this for newly create language containers? 
> It is only needed for new languages
* [x] Ensure sync during file upload
* [ ] Ensure sync during node migration (is this needed?)
* [x] What happens for fields for which the i18n flag gets updated. Is it enough to just stop the sync in this case? 
> Yes, as soon as the flag is updated for the NGFC's SCV the mechanism stops.
* [ ] Check what can happen if a node gets published and the other language already contains another draft. (e.g.:  Draft[de:0.1]  (will be published) -> Published[de: 1.0] => SYNC => Published[en: 1.0] has already a Draft[en:1.1]  )
* [ ] Add changelog
* [ ] Add tests
* [ ] Add documentation