### PR TITLE
fix: update field operation is now correctly migrating the value of t…

### DIFF
--- a/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateFieldChangeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateFieldChangeImpl.java
@@ -77,7 +77,11 @@ public class UpdateFieldChangeImpl extends AbstractSchemaFieldChange implements 
 
 	@Override
 	public Map<String, Field> createFields(FieldSchemaContainer oldSchema, FieldContainer oldContent) {
-		return Collections.emptyMap();
+        String oldFieldName = getFieldName();
+        String newFieldName = getRestProperty(SchemaChangeModel.NAME_KEY);
+        FieldSchema fieldSchema = oldSchema.getField(oldFieldName);
+        Field field = oldContent.getFields().getField(oldFieldName, fieldSchema);
+        return Collections.singletonMap(newFieldName, field);
 	}
 
 	@Override


### PR DESCRIPTION
…he field data


when updating a schema field data is loss:

step to reproduce

create a schema with a field named 'bad_name'
create a node with this schema add a value to the field bad_name

migrate the field with this operation:
```
	{
	  "changes": [
	    {
	      "operation": "UPDATEFIELD",
	      "properties": {
	        "field": "bad_name",
	        "name": "realname"
	      }
	    }
	  ]
	}
```

then migrate the branch schema to latest

the node is migrated to the last schema (update) BUT the field data of 'realname' is not populated by the old value of field "bad_name"