### PR TITLE
Fix ignored language parameter in link rendering

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,10 @@ include::content/docs/variables.adoc-include[]
 
 * The Mesh Server will require Java 11 with the release of 2.0.0. The runtime support for Java 8 will be dropped. The Mesh Java REST client will still be usable with Java 8.
 
+[[Unreleased]]
+
+icon:check[] Core: Fixed a bug in the link renderer that caused the language parameter to be ignored if the branch parameter was passed.
+
 [[v1.3.2]]
 == 1.3.2 (12.12.2019)
 

--- a/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacer.java
+++ b/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacer.java
@@ -114,7 +114,7 @@ public class WebRootLinkReplacer {
 				// Branch in link argument always comes first
 				branch = linkArguments[2].trim();
 			}
-			if (linkArguments.length == 2) {
+			if (linkArguments.length >= 2) {
 				segments.add(resolve(ac, branch, edgeType, linkArguments[0], type, projectName, linkArguments[1].trim()));
 			} else if (languageTags != null) {
 				segments.add(resolve(ac, branch, edgeType, linkArguments[0], type, projectName,

--- a/core/src/test/java/com/gentics/mesh/linkrenderer/LinkRendererEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/linkrenderer/LinkRendererEndpointTest.java
@@ -1,5 +1,14 @@
 package com.gentics.mesh.linkrenderer;
 
+import static com.gentics.mesh.handler.VersionHandler.CURRENT_API_BASE_PATH;
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
 import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.core.data.node.Node;
 import com.gentics.mesh.parameter.LinkType;
@@ -9,14 +18,6 @@ import com.gentics.mesh.test.context.MeshTestSetting;
 import com.gentics.mesh.util.UUIDUtil;
 
 import io.vertx.core.json.JsonObject;
-import org.junit.Test;
-
-import java.util.Arrays;
-
-import static com.gentics.mesh.handler.VersionHandler.CURRENT_API_BASE_PATH;
-import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.TestSize.FULL;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test cases for link rendering using the Utility Verticle
@@ -100,6 +101,13 @@ public class LinkRendererEndpointTest extends AbstractMeshTest {
 		try (Tx tx = tx()) {
 			testRenderContent("{{mesh.link('" + UUIDUtil.randomUUID() + "')}}", LinkType.FULL, CURRENT_API_BASE_PATH + "/project/webroot/error/404");
 		}
+	}
+
+	@Test
+	public void testRenderLanguagesWithBranch() {
+		String uuid = tx(() -> folder("news").getUuid());
+		testRenderContent(String.format("{{mesh.link(%s, %s, %s)}}", uuid, "en", "demo"), LinkType.SHORT, "/News");
+		testRenderContent(String.format("{{mesh.link(%s, %s, %s)}}", uuid, "de", "demo"), LinkType.SHORT, "/Neuigkeiten");
 	}
 
 	/**


### PR DESCRIPTION
Happened if the branch parameter is passed.