### PR TITLE
Add resolving for nodeName setting

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,10 @@ include::content/docs/variables.adoc-include[]
 
 * The Mesh Server will require Java 11 with the release of 2.0.0. The runtime support for Java 8 will be dropped. The Mesh Java REST client will still be usable with Java 8.
 
+[[pending]]
+
+icon:plus[] Settings: The `nodeName` setting can now be set to `$HOSTNAME` to automatically assign the server or container hostname as `nodeName`.
+
 [[v1.3.3]]
 == 1.3.3 (17.01.2020)
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -105,6 +105,11 @@
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-auth-jwt</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.kstruct</groupId>
+			<artifactId>gethostname4j</artifactId>
+			<version>0.0.3</version>
+		</dependency>
 
 		<!-- Bcrypt -->
 		<dependency>

--- a/common/src/main/java/com/gentics/mesh/OptionsLoader.java
+++ b/common/src/main/java/com/gentics/mesh/OptionsLoader.java
@@ -23,6 +23,7 @@ import com.gentics.mesh.cli.MeshCLI;
 import com.gentics.mesh.cli.MeshNameProvider;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.util.UUIDUtil;
+import com.kstruct.gethostname4j.Hostname;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -53,9 +54,17 @@ public final class OptionsLoader {
 		MeshOptions options = loadMeshOptions(defaultOption);
 		applyNonYamlProperties(defaultOption, options);
 		applyEnvironmentVariables(options);
+		applyReplacements(options);
 		applyCommandLineArgs(options, args);
 		options.validate();
 		return options;
+	}
+
+	private static void applyReplacements(MeshOptions options) {
+		String nodeName = options.getNodeName();
+		if ("$HOSTNAME".equals(nodeName)) {
+			options.setNodeName(Hostname.getHostname());
+		}
 	}
 
 	private static void applyNonYamlProperties(MeshOptions defaultOption, MeshOptions options) {

--- a/common/src/test/java/com/gentics/mesh/OptionsLoaderTest.java
+++ b/common/src/test/java/com/gentics/mesh/OptionsLoaderTest.java
@@ -81,7 +81,6 @@ public class OptionsLoaderTest {
 		environmentVariables.set(MeshOptions.MESH_NODE_NAME_ENV, "$HOSTNAME");
 		MeshOptions options = OptionsLoader.createOrloadOptions();
 		String nodeName = options.getNodeName();
-		System.out.println(nodeName);
 		assertNotNull(nodeName);
 		assertEquals(Hostname.getHostname(), nodeName);
 	}

--- a/common/src/test/java/com/gentics/mesh/OptionsLoaderTest.java
+++ b/common/src/test/java/com/gentics/mesh/OptionsLoaderTest.java
@@ -22,12 +22,13 @@ import com.gentics.mesh.etc.config.MonitoringConfig;
 import com.gentics.mesh.etc.config.VertxOptions;
 import com.gentics.mesh.etc.config.search.ElasticSearchOptions;
 import com.gentics.mesh.etc.config.search.MappingMode;
+import com.kstruct.gethostname4j.Hostname;
 
 public class OptionsLoaderTest {
-	
+
 	@Rule
 	public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-	
+
 	@Test
 	public void testOptionsLoader() {
 		File confFile = new File(CONFIG_FOLDERNAME + "/" + MESH_CONF_FILENAME);
@@ -73,6 +74,16 @@ public class OptionsLoaderTest {
 		assertEquals("0.0.0.0", options.getMonitoringOptions().getHost());
 		assertTrue(options.getContentOptions().isAutoPurge());
 		assertEquals(MappingMode.STRICT, options.getSearchOptions().getMappingMode());
+	}
+
+	@Test
+	public void testNodeNameWithHostnameVar() {
+		environmentVariables.set(MeshOptions.MESH_NODE_NAME_ENV, "$HOSTNAME");
+		MeshOptions options = OptionsLoader.createOrloadOptions();
+		String nodeName = options.getNodeName();
+		System.out.println(nodeName);
+		assertNotNull(nodeName);
+		assertEquals(Hostname.getHostname(), nodeName);
 	}
 
 	@Test


### PR DESCRIPTION
When deploying Mesh in K8S it may be desired to use the Pod Name as the node-name. This is especially handy when using stateful sets. Otherwise you would end up with a lot of node entries in OrientDB cluster configuration. Clustering would break when using writeQuorum majority and restarting Pods because new cluster nodes would be listed in the distributed configuration.