### PR TITLE
Add bcrypt password hash environment handling

### DIFF
--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
@@ -34,6 +34,7 @@ public class MeshOptions implements Option {
 	public static final String MESH_LOCK_PATH_ENV = "MESH_LOCK_PATH";
 	public static final String MESH_START_IN_READ_ONLY_ENV = "MESH_START_IN_READ_ONLY";
 	public static final String MESH_INITIAL_ADMIN_PASSWORD_ENV = "MESH_INITIAL_ADMIN_PASSWORD";
+	public static final String MESH_INITIAL_ADMIN_PASSWORD_HASH_ENV = "MESH_INITIAL_ADMIN_PASSWORD_HASH";
 	public static final String MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET_ENV = "MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET";
     public static final String MESH_MAX_PURGE_BATCH_SIZE = "MESH_MAX_PURGE_BATCH_SIZE";
 
@@ -145,6 +146,10 @@ public class MeshOptions implements Option {
 	@JsonIgnore
 	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_ENV, description = "Password which will be used during initial admin user creation.")
 	private String initialAdminPassword = PasswordUtil.humanPassword();
+
+	@JsonIgnore
+	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_HASH_ENV, description = "BCrypt password hash which can be used during initial admin user creation. A present env value will take precedence over the plain text password.")
+	private String initialAdminPasswordHash = null;
 
 	@JsonIgnore
 	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET_ENV, description = "Control whether a forced password reset should be triggered when creating the initial admin user. Default: true")
@@ -392,6 +397,17 @@ public class MeshOptions implements Option {
 	}
 
 	@JsonIgnore
+	public String getInitialAdminPasswordHash() {
+		return initialAdminPasswordHash;
+	}
+
+	@JsonIgnore
+	public MeshOptions setInitialAdminPasswordHash(String initialAdminPasswordHash) {
+		this.initialAdminPasswordHash = initialAdminPasswordHash;
+		return this;
+	}
+
+	@JsonIgnore
 	public boolean isForceInitialAdminPasswordReset() {
 		return forceInitialAdminPasswordReset;
 	}
@@ -420,14 +436,14 @@ public class MeshOptions implements Option {
 		return this;
 	}
 
-    public int getVersionPurgeMaxBatchSize() {
-        return versionPurgeMaxBatchSize;
-    }
+	public int getVersionPurgeMaxBatchSize() {
+		return versionPurgeMaxBatchSize;
+	}
 
-    public MeshOptions setVersionPurgeMaxBatchSize(int versionPurgeMaxBatchSize) {
-        this.versionPurgeMaxBatchSize = versionPurgeMaxBatchSize;
-        return this;
-    }
+	public MeshOptions setVersionPurgeMaxBatchSize(int versionPurgeMaxBatchSize) {
+		this.versionPurgeMaxBatchSize = versionPurgeMaxBatchSize;
+		return this;
+	}
 
 	public void validate() {
 		if (getClusterOptions() != null) {

--- a/common/src/main/java/com/gentics/mesh/OptionsLoader.java
+++ b/common/src/main/java/com/gentics/mesh/OptionsLoader.java
@@ -61,6 +61,7 @@ public final class OptionsLoader {
 	private static void applyNonYamlProperties(MeshOptions defaultOption, MeshOptions options) {
 		if (defaultOption != null) {
 			options.setInitialAdminPassword(defaultOption.getInitialAdminPassword());
+			options.setInitialAdminPasswordHash(defaultOption.getInitialAdminPasswordHash());
 			options.setForceInitialAdminPasswordReset(defaultOption.isForceInitialAdminPasswordReset());
 		}
 	}


### PR DESCRIPTION
# BCrypt Password Hash Handling

## Abstract

This change adds the option to specify a bcrypt hashed password via env. This way the initial password can be securely set for a new Gentics Mesh instance. In K8S the initial password could be stored in a secret. 

## Checklist

### General

* [x] Added abstract that describes the change. 
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
