### PR TITLE
Fix internal server error when creating project after certain conditions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,10 @@ include::content/docs/variables.adoc-include[]
 
 * The Mesh Server will require Java 11 with the release of 2.0.0. The runtime support for Java 8 will be dropped. The Mesh Java REST client will still be usable with Java 8.
 
+[[Unreleased]]
+
+icon:check[] Core: Fixed a bug that caused an internal server error if a project was attempted to be created after any role with permissions to create projects was deleted.
+
 [[v1.4.0]]
 == 1.4.0 (24.01.2020)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/generic/PermissionProperties.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/generic/PermissionProperties.java
@@ -3,6 +3,7 @@ package com.gentics.mesh.core.data.generic;
 import static com.gentics.mesh.core.data.relationship.GraphPermission.READ_PERM;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -34,7 +35,10 @@ public class PermissionProperties {
 			? Stream.empty()
 			: roleUuids.stream();
 		RoleRoot roleRoot = boot.roleRoot();
-		return new TraversalResult<>(stream.map(roleRoot::findByUuid));
+		return new TraversalResult<>(stream
+			.map(roleRoot::findByUuid)
+			.filter(Objects::nonNull)
+		);
 	}
 
 	public PermissionInfo getRolePermissions(MeshVertex vertex, InternalActionContext ac, String roleUuid) {

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
@@ -70,6 +70,8 @@ import com.gentics.mesh.core.rest.project.ProjectCreateRequest;
 import com.gentics.mesh.core.rest.project.ProjectListResponse;
 import com.gentics.mesh.core.rest.project.ProjectResponse;
 import com.gentics.mesh.core.rest.project.ProjectUpdateRequest;
+import com.gentics.mesh.core.rest.role.RolePermissionRequest;
+import com.gentics.mesh.core.rest.role.RoleResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaReferenceImpl;
 import com.gentics.mesh.parameter.LinkType;
 import com.gentics.mesh.parameter.impl.NodeParametersImpl;
@@ -800,5 +802,13 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 		checkConsistency();
 
 		call(() -> client().deleteProject(uuid));
+	}
+
+	@Test
+	public void createProjectAfterDeletedRole() {
+		RoleResponse role = createRole("test");
+		client().updateRolePermissions(role.getUuid(), "/projects", RolePermissionRequest.withPermissions(CREATE)).blockingAwait();
+		deleteRole(role.getUuid());
+		createProject("testProject");
 	}
 }

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -300,6 +300,13 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		call(() -> client().deleteGroup(uuid));
 	}
 
+	default public RoleResponse createRole(String roleName) {
+		RoleCreateRequest roleCreateRequest = new RoleCreateRequest();
+		roleCreateRequest.setName(roleName);
+		RoleResponse roleResponse = call(() -> client().createRole(roleCreateRequest));
+		return roleResponse;
+	}
+
 	default public RoleResponse createRole(String roleName, String groupUuid) {
 		RoleCreateRequest roleCreateRequest = new RoleCreateRequest();
 		roleCreateRequest.setName(roleName);


### PR DESCRIPTION
## Abstract
This NPE was thrown if a project was attempted to be created after any role with permissions to create projects was deleted:
```
16:37:02.181 [] ERROR [vert.x-eventloop-thread-9] [c.g.m.r.r.FailureHandler] - Error for request in path: /api/v1/projects
16:37:02.181 [] ERROR [vert.x-eventloop-thread-9] [c.g.m.r.r.FailureHandler] - Error:
java.lang.NullPointerException: null
	at com.gentics.mesh.core.data.impl.UserImpl.addPermissionsOnRole(UserImpl.java:504)
	at com.gentics.mesh.core.data.impl.UserImpl.addCRUDPermissionOnRole(UserImpl.java:496)
	at com.gentics.mesh.core.data.root.impl.ProjectRootImpl.create(ProjectRootImpl.java:210)
	at com.gentics.mesh.core.data.root.impl.ProjectRootImpl.create(ProjectRootImpl.java:44)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.lambda$null$4(HandlerUtilities.java:168)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.lambda$eventAction$14(HandlerUtilities.java:327)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.lambda$eventAction$15(HandlerUtilities.java:339)
	at com.gentics.mesh.graphdb.OrientDBDatabase.tx(OrientDBDatabase.java:343)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.eventAction(HandlerUtilities.java:337)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.eventAction(HandlerUtilities.java:327)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.lambda$createOrUpdateElement$5(HandlerUtilities.java:166)
	at com.gentics.mesh.graphdb.OrientDBDatabase.tx(OrientDBDatabase.java:343)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.syncTx(HandlerUtilities.java:244)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.createOrUpdateElement(HandlerUtilities.java:145)
	at com.gentics.mesh.core.verticle.handler.HandlerUtilities.createElement(HandlerUtilities.java:83)
	at com.gentics.mesh.core.endpoint.handler.AbstractCrudHandler.handleCreate(AbstractCrudHandler.java:48)
	at com.gentics.mesh.core.endpoint.project.ProjectEndpoint.lambda$addCreateHandler$1(ProjectEndpoint.java:94)
	at io.vertx.ext.web.impl.BlockingHandlerDecorator.lambda$handle$0(BlockingHandlerDecorator.java:48)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
16:37:02.183 [] ERROR [vert.x-eventloop-thread-9] [i.v.e.w.h.i.LoggerHandlerImpl] - 127.0.0.1 - POST /api/v1/projects HTTP/1.1 500 44 - 22 ms
```
## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
