### PR TITLE
Send GraphQL errors to client

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,8 @@ icon:plus[] Core: The core Vert.x library was updated to version `3.8.5`.
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.0.27`
 
+icon:check[] GraphQL: Errors during GraphQL queries are now correctly propagated to the client.
+
 [[v1.4.0]]
 == 1.4.0 (24.01.2020)
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/GraphQLHandler.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/GraphQLHandler.java
@@ -1,33 +1,34 @@
 package com.gentics.mesh.graphql;
 
-import com.gentics.madl.tx.Tx;
-import com.gentics.mesh.core.rest.MeshEvent;
-import com.gentics.mesh.core.rest.error.AbstractUnavailableException;
-import com.gentics.mesh.etc.config.MeshOptions;
-import com.gentics.mesh.event.MeshEventSender;
-import com.gentics.mesh.graphdb.spi.Database;
-import com.gentics.mesh.graphql.context.GraphQLContext;
-import com.gentics.mesh.graphql.type.QueryTypeProvider;
-import com.gentics.mesh.parameter.SearchParameters;
-import com.gentics.mesh.util.SearchWaitUtil;
-import graphql.*;
-import graphql.language.SourceLocation;
-import io.reactivex.Completable;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.reactivex.core.Vertx;
+import static graphql.GraphQL.newGraphQL;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static graphql.GraphQL.newGraphQL;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.gentics.madl.tx.Tx;
+import com.gentics.mesh.core.rest.error.AbstractUnavailableException;
+import com.gentics.mesh.graphdb.spi.Database;
+import com.gentics.mesh.graphql.context.GraphQLContext;
+import com.gentics.mesh.graphql.type.QueryTypeProvider;
+import com.gentics.mesh.util.SearchWaitUtil;
+
+import graphql.ExceptionWhileDataFetching;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.reactivex.core.Vertx;
 
 @Singleton
 public class GraphQLHandler {
@@ -95,7 +96,9 @@ public class GraphQLHandler {
 			} catch (Exception e) {
 				promise.fail(e);
 			}
-		})).subscribe();
+		}))
+		.doOnError(gc::fail)
+		.subscribe();
 	}
 
 	/**


### PR DESCRIPTION
## Abstract
GraphQL errors have not been handled, causing `io.reactivex.exceptions.OnErrorNotImplementedException`. 

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
