### PR TITLE
Vert.x instance sharing concept

### DIFF
--- a/api/src/main/java/com/gentics/mesh/Mesh.java
+++ b/api/src/main/java/com/gentics/mesh/Mesh.java
@@ -21,12 +21,25 @@ public interface Mesh {
 	 * Returns the initialized instance.
 	 * 
 	 * @param options
+	 *            Mesh Optionss
+	 * @param vertx
+	 *            Vert.x instance to be used for the Mesh instance
+	 * @return Fluent API
+	 */
+	static Mesh create(MeshOptions options, Vertx vertx) {
+		options.validate();
+		return factory.create(options, vertx);
+	}
+
+	/**
+	 * Returns the initialized instance.
+	 * 
+	 * @param options
 	 * 
 	 * @return Fluent API
 	 */
 	static Mesh create(MeshOptions options) {
-		options.validate();
-		return factory.create(options);
+		return create(options, null);
 	}
 
 	/**
@@ -62,8 +75,8 @@ public interface Mesh {
 	MeshOptions getOptions();
 
 	/**
-	 * Start Gentics Mesh. This will effectively block until {@link #shutdown()} is called from another thread. This method will initialise the dagger context and
-	 * deploy mandatory verticles and extensions.
+	 * Start Gentics Mesh. This will effectively block until {@link #shutdown()} is called from another thread. This method will initialise the dagger context
+	 * and deploy mandatory verticles and extensions.
 	 * 
 	 * @throws Exception
 	 * @return Fluent API

--- a/api/src/main/java/com/gentics/mesh/MeshFactory.java
+++ b/api/src/main/java/com/gentics/mesh/MeshFactory.java
@@ -2,6 +2,8 @@ package com.gentics.mesh;
 
 import com.gentics.mesh.etc.config.MeshOptions;
 
+import io.vertx.core.Vertx;
+
 /**
  * Mesh factory which provides new instances of mesh.
  */
@@ -19,8 +21,21 @@ public interface MeshFactory {
 	 * 
 	 * @param options
 	 *            Mesh options
+	 * @param vertx
+	 *            Vert.x instance to be used
 	 * @return Mesh instance
 	 */
-	Mesh create(MeshOptions options);
+	Mesh create(MeshOptions options, Vertx vertx);
+
+	/**
+	 * Return a new instance of mesh.
+	 * 
+	 * @param options
+	 *            Mesh options
+	 * @return Mesh instance
+	 */
+	default Mesh create(MeshOptions options) {
+		return create(options, null);
+	}
 
 }

--- a/core/src/main/java/com/gentics/mesh/dagger/MeshComponent.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/MeshComponent.java
@@ -1,5 +1,7 @@
 package com.gentics.mesh.dagger;
 
+import java.util.function.Supplier;
+
 import javax.annotation.Nullable;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -168,6 +170,9 @@ public interface MeshComponent {
 	interface Builder {
 		@BindsInstance
 		Builder configuration(MeshOptions options);
+
+		@BindsInstance
+		Builder vertx(@Nullable Supplier<Vertx> vertxSupplier);
 
 		@BindsInstance
 		Builder searchProviderType(@Nullable SearchProviderType type);

--- a/core/src/main/java/com/gentics/mesh/impl/MeshFactoryImpl.java
+++ b/core/src/main/java/com/gentics/mesh/impl/MeshFactoryImpl.java
@@ -6,6 +6,8 @@ import com.gentics.mesh.OptionsLoader;
 import com.gentics.mesh.cli.MeshImpl;
 import com.gentics.mesh.etc.config.MeshOptions;
 
+import io.vertx.core.Vertx;
+
 /**
  * Factory which will create and maintain the state of a single mesh instance.
  */
@@ -17,8 +19,8 @@ public class MeshFactoryImpl implements MeshFactory {
 	}
 
 	@Override
-	public Mesh create(MeshOptions options) {
-		return new MeshImpl(options);
+	public Mesh create(MeshOptions options, Vertx vertx) {
+		return new MeshImpl(options, vertx);
 	}
 
 }


### PR DESCRIPTION
## Abstract

When using mesh in multi tenant mode a dedicated Vert.x instance will be created for each tenant. This creates additional overhead on Vert.x object (thread pools, netty buffers, context objects..)

I suggest two changes to avoid duplicating Vert.x:

1. Add an option to inject a Vert.x instance when creating a new Mesh instance
   See `MeshImpl#138`, `MeshImpl#69`

2. Utilize a wrapped Vert.x instance in the mesh-multitenancy-server to each created mesh instance.
  The wrapped Vert.x instance would utilize a prefix string to automatically prefix the eventbus and shared data maps. This way no custom prefix logic needs to be added in Mesh.

The included example wrapper classes would be moved to `mesh-multitenancy-server`.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
