### PR TITLE
Microschema migration fix

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,8 @@ include::content/docs/variables.adoc-include[]
 [[v1.4.4]]
 == 1.4.4 (TBD)
 
+CAUTION: Microschema migrations since version 1.2.0 are very likely to cause a loss of data in nodes that contain micronodes of the migrated schema. This bug has been fixed in this version. At the first start with this version or higher, Gentics Mesh will try to restore affected nodes. However, because some data cannot be restored, we advise to restore a backup of a moment before the microschema migration, if possible. We apologize for the inconvenience.
+
 icon:plus[] Monitoring: Metrics have been added for the synchronized write lock, the topology lock, commit times and interrupts. Take a look at our link:{{< relref "monitoring.asciidoc" >}}#_metrics[documentation] for more information.
 
 [[v1.4.3]]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,7 +28,7 @@ include::content/docs/variables.adoc-include[]
 [[v1.4.4]]
 == 1.4.4 (TBD)
 
-CAUTION: Microschema migrations since version 1.2.0 are very likely to cause a loss of data in nodes that contain micronodes of the migrated schema. This bug has been fixed in this version. At the first start with this version or higher, Gentics Mesh will try to restore affected nodes. However, because some data cannot be restored, we advise to restore a backup of a moment before the microschema migration, if possible. We apologize for the inconvenience.
+CAUTION: Microschema migrations since version 1.2.0 are very likely to cause a loss of data in nodes that contain micronodes of the migrated schema. This bug has been fixed in this version. At the first start with this version or higher, Gentics Mesh will try to restore affected nodes in projects with a single branch. However, because some data cannot be restored, we advise to restore a backup of a moment before the microschema migration, if possible. We apologize for the inconvenience.
 
 icon:plus[] Monitoring: Metrics have been added for the synchronized write lock, the topology lock, commit times and interrupts. Take a look at our link:{{< relref "monitoring.asciidoc" >}}#_metrics[documentation] for more information.
 

--- a/api/src/main/java/com/gentics/mesh/util/VersionNumber.java
+++ b/api/src/main/java/com/gentics/mesh/util/VersionNumber.java
@@ -182,6 +182,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
 	/**
 	 * Get the minor version part
+	 * @return
 	 */
 	public int getMinor() {
 		return minor;

--- a/api/src/main/java/com/gentics/mesh/util/VersionNumber.java
+++ b/api/src/main/java/com/gentics/mesh/util/VersionNumber.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.util;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -10,11 +11,11 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
 	private final static Pattern pattern = Pattern.compile("([0-9]+)\\.([0-9]+)");
 
-	private int major;
+	private final int major;
 
-	private int minor;
+	private final int minor;
 
-	private String fullVersion;
+	private final String fullVersion;
 
 	/**
 	 * Create an instance for Version 0.1
@@ -134,6 +135,11 @@ public class VersionNumber implements Comparable<VersionNumber> {
 		return false;
 	}
 
+	@Override
+	public int hashCode() {
+		return Objects.hash(major, minor);
+	}
+
 	/**
 	 * Compares two version strings.
 	 * 
@@ -166,4 +172,18 @@ public class VersionNumber implements Comparable<VersionNumber> {
 		return Integer.signum(vals1.length - vals2.length);
 	}
 
+	/**
+	 * Get the major version part
+	 * @return
+	 */
+	public int getMajor() {
+		return major;
+	}
+
+	/**
+	 * Get the minor version part
+	 */
+	public int getMinor() {
+		return minor;
+	}
 }

--- a/common/src/main/java/com/gentics/mesh/context/impl/DummyEventQueueBatch.java
+++ b/common/src/main/java/com/gentics/mesh/context/impl/DummyEventQueueBatch.java
@@ -45,4 +45,23 @@ public class DummyEventQueueBatch implements EventQueueBatch {
 
 	}
 
+	@Override
+	public EventQueueBatch add(MeshEventModel event) {
+		return this;
+	}
+
+	@Override
+	public void addAll(EventQueueBatch containerBatch) {
+
+	}
+
+	@Override
+	public void clear() {
+
+	}
+
+	@Override
+	public int size() {
+		return 0;
+	}
 }

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/HighLevelChangesList.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/HighLevelChangesList.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.gentics.mesh.changelog.highlevel.change.ExtractPlainText;
+import com.gentics.mesh.changelog.highlevel.change.FixNodeVersionOrder;
 import com.gentics.mesh.changelog.highlevel.change.RestructureWebrootIndex;
 import com.gentics.mesh.core.data.changelog.HighLevelChange;
 
@@ -23,13 +24,17 @@ public class HighLevelChangesList {
 	public ExtractPlainText plainText;
 
 	@Inject
+	public FixNodeVersionOrder fixNodeVersionOrder;
+
+	@Inject
 	public HighLevelChangesList() {
 	}
 
 	public List<HighLevelChange> getList() {
 		return Arrays.asList(
 			restructureWebroot,
-			plainText
+			plainText,
+			fixNodeVersionOrder
 		// ADD NEW CHANGES HERE!
 		);
 	}

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/FixNodeVersionOrder.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/FixNodeVersionOrder.java
@@ -1,0 +1,191 @@
+package com.gentics.mesh.changelog.highlevel.change;
+
+import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_FIELD_CONTAINER;
+import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_VERSION;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.gentics.madl.tx.Tx;
+import com.gentics.mesh.changelog.highlevel.AbstractHighLevelChange;
+import com.gentics.mesh.cli.BootstrapInitializer;
+import com.gentics.mesh.core.data.GraphFieldContainerEdge;
+import com.gentics.mesh.core.data.NodeGraphFieldContainer;
+import com.gentics.mesh.core.data.Project;
+import com.gentics.mesh.core.data.impl.GraphFieldContainerEdgeImpl;
+import com.gentics.mesh.core.data.node.Node;
+import com.gentics.mesh.core.rest.common.ContainerType;
+import com.gentics.mesh.util.VersionNumber;
+import com.google.common.collect.Iterables;
+import com.syncleus.ferma.EdgeFrame;
+
+import dagger.Lazy;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * Fixes the order of node versions and removes duplicate versions. This was caused by a bug described in these issues:
+ * <ul>
+ *     <li><a href="https://github.com/gentics/mesh/issues/979">https://github.com/gentics/mesh/issues/979</a></li>
+ *     <li><a href="https://github.com/gentics/mesh/issues/1014">https://github.com/gentics/mesh/issues/1014</a></li>
+ *     <li><a href="https://github.com/gentics/mesh/issues/1025">https://github.com/gentics/mesh/issues/1025</a></li>
+ * </ul>
+ *
+ * This only fixes nodes in projects with single branches, because this is the simplest case to implement.
+ */
+@Singleton
+public class FixNodeVersionOrder extends AbstractHighLevelChange {
+	public static final Logger log = LoggerFactory.getLogger(FixNodeVersionOrder.class);
+
+	private final Lazy<BootstrapInitializer> boot;
+
+	@Inject
+	public FixNodeVersionOrder(Lazy<BootstrapInitializer> boot) {
+		this.boot = boot;
+	}
+
+	@Override
+	public String getUuid() {
+		return "38F37731BDBB4FAFBEA5A5D19C435E11";
+	}
+
+	@Override
+	public String getName() {
+		return "FixNodeVersionOrder";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Fixes the order of node versions and removes duplicate versions (single branch only)";
+	}
+
+	@Override
+	public void apply() {
+		AtomicLong nodeCount = new AtomicLong();
+		AtomicLong fixedNodes = new AtomicLong();
+		singleBranchProjects()
+			.flatMap(project -> project.getNodeRoot().findAll().stream())
+			.forEach(node -> {
+				long count = nodeCount.get();
+				if (count != 0 && count % 1000 == 0) {
+					log.info("Checked {} nodes. Found and fixed {} broken nodes", count, fixedNodes.get());
+				}
+				node.getGraphFieldContainers(ContainerType.INITIAL).stream()
+					.forEach(content -> {
+						boolean mutated = fixNodeVersionOrder(node, content);
+						if (mutated) {
+							fixedNodes.incrementAndGet();
+						}
+					});
+				nodeCount.incrementAndGet();
+			});
+		log.info("Checked {} nodes. Found and fixed {} broken nodes", nodeCount.get(), fixedNodes.get());
+	}
+
+	private boolean fixNodeVersionOrder(Node node, NodeGraphFieldContainer initialContent) {
+		Set<VersionNumber> seenVersions = new HashSet<>();
+		TreeSet<NodeGraphFieldContainer> versions = new TreeSet<>(Comparator.comparing(NodeGraphFieldContainer::getVersion));
+		NodeGraphFieldContainer highestVersion = null;
+		NodeGraphFieldContainer currentContainer = initialContent;
+		NodeGraphFieldContainer latestPublished = null;
+		boolean mutated = false;
+
+		while (currentContainer != null) {
+			// Since we only look at single branch projects, there can at most only be one next version.
+			NodeGraphFieldContainer nextContainer = Iterables.getFirst(currentContainer.getNextVersions(), null);
+			VersionNumber currentVersion = currentContainer.getVersion();
+			boolean isDuplicate = !seenVersions.add(currentVersion);
+			if (isDuplicate) {
+				currentContainer.remove();
+				if (nextContainer != null) {
+					// previousContainer can't be null because this branch is only visited if there is a duplicate
+					highestVersion.setSingleLinkOutTo(nextContainer, HAS_VERSION);
+				}
+				mutated = true;
+				currentContainer = nextContainer;
+			} else {
+				if (highestVersion != null && currentVersion.compareTo(highestVersion.getVersion()) < 0) {
+					// Wrong order
+
+					NodeGraphFieldContainer lower = versions.lower(currentContainer);
+					// There must always be a higher version
+					NodeGraphFieldContainer higher = versions.higher(currentContainer);
+					higher.unlinkIn(null, HAS_VERSION);
+					currentContainer.unlinkIn(null, HAS_VERSION);
+					currentContainer.unlinkOut(null, HAS_VERSION);
+					currentContainer.setNextVersion(higher);
+					if (lower != null) {
+						lower.unlinkOut(null, HAS_VERSION);
+						lower.setNextVersion(currentContainer);
+					}
+					mutated = true;
+				}
+				versions.add(currentContainer);
+				if (currentVersion.getMinor() == 0 && (latestPublished == null || latestPublished.getVersion().getMajor() < currentVersion.getMajor())) {
+					latestPublished = currentContainer;
+				}
+
+				highestVersion = versions.last();
+				currentContainer = nextContainer;
+			}
+		}
+
+		// Reset draft and published edge
+		String branchUuid = initialContent.getBranches(ContainerType.INITIAL).iterator().next();
+		String languageTag = initialContent.getLanguageTag();
+
+		EdgeFrame rawDraftEdge = node.getGraphFieldContainerEdgeFrame(languageTag, branchUuid, ContainerType.DRAFT);
+		if (rawDraftEdge != null) {
+			GraphFieldContainerEdgeImpl draftEdge = rawDraftEdge
+				.reframeExplicit(GraphFieldContainerEdgeImpl.class);
+			if (!draftEdge.getNodeContainer().equals(highestVersion)) {
+				setNewOutV(draftEdge, node, highestVersion);
+				mutated = true;
+			}
+		}
+
+		EdgeFrame publishedRawEdge = node.getGraphFieldContainerEdgeFrame(languageTag, branchUuid, ContainerType.PUBLISHED);
+		if (publishedRawEdge != null) {
+			GraphFieldContainerEdgeImpl publishedEdge = publishedRawEdge.reframeExplicit(GraphFieldContainerEdgeImpl.class);
+			if (!publishedEdge.getNodeContainer().equals(latestPublished)) {
+				setNewOutV(publishedEdge, node, latestPublished);
+				mutated = true;
+			}
+		}
+		Tx.get().commit();
+		return mutated;
+	}
+
+	private GraphFieldContainerEdge setNewOutV(GraphFieldContainerEdgeImpl edge, Node from, NodeGraphFieldContainer to) {
+		GraphFieldContainerEdge newEdge = from.addFramedEdge(HAS_FIELD_CONTAINER, to, GraphFieldContainerEdgeImpl.class);
+		newEdge.setBranchUuid(edge.getBranchUuid());
+		newEdge.setLanguageTag(edge.getLanguageTag());
+		newEdge.setSegmentInfo(edge.getSegmentInfo());
+		newEdge.setType(edge.getType());
+		newEdge.setUrlFieldInfo(edge.getUrlFieldInfo());
+		edge.remove();
+		return newEdge;
+	}
+
+	private Stream<? extends Project> singleBranchProjects() {
+		return boot.get().projectRoot().findAll().stream()
+			.filter(this::hasSingleBranch);
+	}
+
+	private boolean hasSingleBranch(Project project) {
+		long count = project.getBranchRoot().computeCount();
+		if (count == 1) {
+			return true;
+		} else {
+			log.info("Skipping project {{}} because it has {} branches", project.getName(), count);
+			return false;
+		}
+	}
+}

--- a/core/src/main/java/com/gentics/mesh/core/data/container/impl/MicroschemaContainerVersionImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/container/impl/MicroschemaContainerVersionImpl.java
@@ -60,7 +60,8 @@ public class MicroschemaContainerVersionImpl extends
 	public TraversalResult<? extends NodeGraphFieldContainer> getDraftFieldContainers(String branchUuid) {
 		return new TraversalResult<>(getMicronodeStream()
 			.flatMap(micronode -> micronode.getContainers().stream())
-			.filter(uniqueBy(ElementFrame::getId)));
+			.filter(uniqueBy(ElementFrame::getId))
+			.filter(container -> container.isDraft(branchUuid)));
 	}
 
 	@Override

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointBranchTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointBranchTest.java
@@ -55,10 +55,6 @@ public class GraphQLEndpointBranchTest extends AbstractMeshTest {
 		return call(() -> client().createNode(PROJECT_NAME, request, new VersioningParametersImpl().setBranch(BRANCH_NAME)));
 	}
 
-	private ProjectResponse getProject() {
-		return call(() -> client().findProjectByName(PROJECT_NAME));
-	}
-
 	private void createBranchRestAndWait(String name, boolean latest) {
 		waitForJobs(() -> {
 			createBranchRest(name, latest);

--- a/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaMigrationTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaMigrationTest.java
@@ -1,0 +1,121 @@
+package com.gentics.mesh.core.schema;
+
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static com.gentics.mesh.test.context.ElasticsearchTestMode.TRACKING;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gentics.mesh.core.rest.micronode.MicronodeResponse;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaCreateRequest;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaResponse;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaUpdateRequest;
+import com.gentics.mesh.core.rest.node.FieldMap;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.field.StringField;
+import com.gentics.mesh.core.rest.node.field.list.impl.MicronodeFieldListImpl;
+import com.gentics.mesh.core.rest.schema.impl.ListFieldSchemaImpl;
+import com.gentics.mesh.core.rest.schema.impl.MicronodeFieldSchemaImpl;
+import com.gentics.mesh.core.rest.schema.impl.MicroschemaReferenceImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+@MeshTestSetting(elasticsearch = TRACKING, testSize = FULL, startServer = true)
+public class MicroschemaMigrationTest extends AbstractMeshTest {
+
+	private MicroschemaResponse phoneMicroschema;
+
+	@Before
+	public void setUp() throws Exception {
+		grantAdminRole();
+		createTestSchema();
+		createMicroschemas();
+	}
+
+	@Test
+	public void test() {
+		NodeResponse testNode = createTestNode();
+		publishNode(testNode);
+		assertVersions(testNode, "PD(1.0)=>I(0.1)");
+		MicroschemaUpdateRequest updateSchemaRequest = addRandomField(phoneMicroschema);
+		waitForLatestJob(() -> client().updateMicroschema(phoneMicroschema.getUuid(), updateSchemaRequest).blockingAwait());
+		assertVersions(testNode, "PD(2.0)=>I(0.1)");
+	}
+
+	private NodeResponse createTestNode() {
+		return client().createNode(PROJECT_NAME, new NodeCreateRequest()
+			.setSchemaName("testSchema")
+			.setParentNodeUuid(getProject().getRootNode().getUuid())
+			.setLanguage("en")
+			.setFields(FieldMap.of(
+				"name", StringField.of("testNode"),
+				"phone", phoneNumber("+43", "1234567"),
+				"locations", new MicronodeFieldListImpl().setItems(Arrays.asList(
+					location("aut", "vienna"),
+					location("aut", "graz"),
+					location("aut", "linz")
+			))
+		))).blockingGet();
+	}
+
+	private MicronodeResponse phoneNumber(String countryCode, String number) {
+		MicronodeResponse micronodeResponse = new MicronodeResponse();
+		micronodeResponse.setMicroschema(new MicroschemaReferenceImpl().setName("phonenumber"));
+		FieldMap fields = micronodeResponse.getFields();
+		fields.put("countrycode", StringField.of(countryCode));
+		fields.put("number", StringField.of(number));
+		return micronodeResponse;
+	}
+
+	private MicronodeResponse location(String country, String city) {
+		MicronodeResponse micronodeResponse = new MicronodeResponse();
+		micronodeResponse.setMicroschema(new MicroschemaReferenceImpl().setName("location"));
+		FieldMap fields = micronodeResponse.getFields();
+		fields.put("country", StringField.of(country));
+		fields.put("city", StringField.of(city));
+		return micronodeResponse;
+	}
+
+	private void createTestSchema() {
+		SchemaCreateRequest createRequest = new SchemaCreateRequest();
+		createRequest.setName("testSchema");
+		createRequest.setFields(Arrays.asList(
+			new StringFieldSchemaImpl().setName("name"),
+			new MicronodeFieldSchemaImpl().setName("phone"),
+			new ListFieldSchemaImpl().setListType("micronode").setName("locations")
+		));
+		SchemaResponse schemaResponse = client().createSchema(createRequest).blockingGet();
+		client().assignSchemaToProject(PROJECT_NAME, schemaResponse.getUuid()).blockingAwait();
+	}
+
+	private void createMicroschemas() {
+		phoneMicroschema = createAndAssign(new MicroschemaCreateRequest()
+			.setName("phonenumber")
+			.setFields(Arrays.asList(
+				new StringFieldSchemaImpl().setName("countrycode"),
+				new StringFieldSchemaImpl().setName("number")
+			))
+		);
+
+		createAndAssign(new MicroschemaCreateRequest()
+			.setName("location")
+			.setFields(Arrays.asList(
+				new StringFieldSchemaImpl().setName("country"),
+				new StringFieldSchemaImpl().setName("city")
+			))
+		);
+	}
+
+	private MicroschemaResponse createAndAssign(MicroschemaCreateRequest microschemaCreateRequest) {
+		MicroschemaResponse microschemaResponse = client().createMicroschema(microschemaCreateRequest).blockingGet();
+		client().assignMicroschemaToProject(PROJECT_NAME, microschemaResponse.getUuid()).blockingAwait();
+		return microschemaResponse;
+	}
+}

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -476,6 +476,10 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		return call(() -> client().createProject(projectCreateRequest));
 	}
 
+	default public ProjectResponse getProject() {
+		return client().findProjectByName(PROJECT_NAME).blockingGet();
+	}
+
 	default public ProjectResponse readProject(String uuid) {
 		return call(() -> client().findProjectByUuid(uuid));
 	}
@@ -670,6 +674,10 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		}
 		NodeVersionsResponse response = call(() -> client().listNodeVersions(projectName(), nodeUuid, param));
 		assertEquals("The versions did not match", versions, response.listVersions(lang));
+	}
+
+	default void assertVersions(NodeResponse node, String versions) {
+		assertVersions(node.getUuid(), node.getLanguage(), versions);
 	}
 
 	default void assertVersions(String nodeUuid, String lang, String versions) {

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/ClientHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/ClientHelper.java
@@ -12,6 +12,8 @@ import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.branch.BranchCreateRequest;
 import com.gentics.mesh.core.rest.branch.BranchResponse;
 import com.gentics.mesh.core.rest.common.ListResponse;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaResponse;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaUpdateRequest;
 import com.gentics.mesh.core.rest.node.NodeCreateRequest;
 import com.gentics.mesh.core.rest.node.NodeResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
@@ -45,6 +47,12 @@ public interface ClientHelper extends EventHelper {
 
 	default SchemaUpdateRequest addRandomField(SchemaResponse schemaResponse) {
 		SchemaUpdateRequest request = schemaResponse.toUpdateRequest();
+		request.getFields().add(new StringFieldSchemaImpl().setName(RandomStringUtils.randomAlphabetic(10)));
+		return request;
+	}
+
+	default MicroschemaUpdateRequest addRandomField(MicroschemaResponse schemaResponse) {
+		MicroschemaUpdateRequest request = schemaResponse.toRequest();
 		request.getFields().add(new StringFieldSchemaImpl().setName(RandomStringUtils.randomAlphabetic(10)));
 		return request;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/FieldMap.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/FieldMap.java
@@ -290,4 +290,32 @@ public interface FieldMap extends RestModel {
 		map.put(key, field);
 		return map;
 	}
+
+	/**
+	 * Convenience method for creating a field map with two entries.
+	 * @param key
+	 * @param field
+	 * @return
+	 */
+	static FieldMap of(String key, Field field, String key2, Field field2) {
+		FieldMap map = new FieldMapImpl();
+		map.put(key, field);
+		map.put(key2, field2);
+		return map;
+	}
+
+	/**
+	 * Convenience method for creating a field map with three entries.
+	 * @param key
+	 * @param field
+	 * @return
+	 */
+	static FieldMap of(String key, Field field, String key2, Field field2, String key3, Field field3) {
+		FieldMap map = new FieldMapImpl();
+		map.put(key, field);
+		map.put(key2, field2);
+		map.put(key3, field3);
+		return map;
+	}
+
 }


### PR DESCRIPTION
## Abstract
Fixes microschema migration by fixing the MicroschemaContainerVersionImpl#getDraftFieldContainers method.

Fixes #979 Fixes #1014 Fixes #1025 

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
