### PR TITLE
Auto feature image manipulation hotfix 1.4.x

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,7 +35,7 @@ icon:check[] Changelog: The automated recovery from v1.4.4 now renames duplicate
 [[v1.4.5]]
 == 1.4.5 (15.04.2020)
 
-icon:plus[] Image Manipulation: Mesh supports now the ´auto´ parameter when manipulating the images. The width and height fields in the binaries are now strings.
+icon:plus[] Image Manipulation: Gentics Mesh now supports the ´auto´ parameter when manipulating images.For more info check the {{< relref "image-manipulation.asciidoc" >}}[Image Manipulation documentation].
 
 [[v1.4.4]]
 == 1.4.4 (14.04.2020)

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,9 +32,6 @@ icon:plus[] Server: The `serverTokens` flag and `MESH_HTTP_SERVER_TOKENS` env ha
 
 icon:check[] Changelog: The automated recovery from v1.4.4 now renames duplicate versions instead of deleting them.
 
-[[v1.4.5]]
-== 1.4.5 (15.04.2020)
-
 icon:plus[] Image Manipulation: Gentics Mesh now supports the ´auto´ parameter when manipulating images.For more info check the {{< relref "image-manipulation.asciidoc" >}}[Image Manipulation documentation].
 
 [[v1.4.4]]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,11 @@ icon:plus[] Server: The `serverTokens` flag and `MESH_HTTP_SERVER_TOKENS` env ha
 
 icon:check[] Changelog: The automated recovery from v1.4.4 now renames duplicate versions instead of deleting them.
 
+[[v1.4.5]]
+== 1.4.5 (15.04.2020)
+
+icon:plus[] Image Manipulation: Mesh supports now the ´auto´ parameter when manipulating the images. The width and height fields in the binaries are now strings.
+
 [[v1.4.4]]
 == 1.4.4 (14.04.2020)
 

--- a/common/src/main/java/com/gentics/mesh/parameter/impl/ImageManipulationParametersImpl.java
+++ b/common/src/main/java/com/gentics/mesh/parameter/impl/ImageManipulationParametersImpl.java
@@ -40,11 +40,11 @@ public class ImageManipulationParametersImpl extends AbstractParameters implemen
 	@Override
 	public void validate() {
 		Integer width = toInteger(getWidth(), null);
-		if (getWidth() != null && width != null && width < 1) {
+		if (width != null && width < 1) {
 			throw error(BAD_REQUEST, "image_error_parameter_positive", WIDTH_QUERY_PARAM_KEY, String.valueOf(width));
 		}
 		Integer height = toInteger(getHeight(), null);
-		if (getHeight() != null && height != null && height < 1) {
+		if (height != null && height < 1) {
 			throw error(BAD_REQUEST, "image_error_parameter_positive", HEIGHT_QUERY_PARAM_KEY, String.valueOf(height));
 		}
 		ImageRect rect = getRect();

--- a/common/src/main/java/com/gentics/mesh/parameter/impl/ImageManipulationParametersImpl.java
+++ b/common/src/main/java/com/gentics/mesh/parameter/impl/ImageManipulationParametersImpl.java
@@ -1,20 +1,20 @@
 package com.gentics.mesh.parameter.impl;
 
-import static com.gentics.mesh.core.rest.error.Errors.error;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.raml.model.ParamType;
-import org.raml.model.parameter.QueryParameter;
-
 import com.gentics.mesh.handler.ActionContext;
 import com.gentics.mesh.parameter.AbstractParameters;
 import com.gentics.mesh.parameter.ImageManipulationParameters;
 import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ImageRect;
 import com.gentics.mesh.parameter.image.ResizeMode;
+import org.raml.model.ParamType;
+import org.raml.model.parameter.QueryParameter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static com.gentics.mesh.util.NumberUtils.toInteger;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 /**
  * Crop and resize parameters for image manipulation.
@@ -38,16 +38,14 @@ public class ImageManipulationParametersImpl extends AbstractParameters implemen
 	 */
 	@Override
 	public void validate() {
-		Integer width = getWidth();
-		if (width != null && width < 1) {
+		Integer width = toInteger(getWidth(), null);
+		if (getWidth() != null && width != null && width < 1) {
 			throw error(BAD_REQUEST, "image_error_parameter_positive", WIDTH_QUERY_PARAM_KEY, String.valueOf(width));
 		}
-
-		Integer height = getHeight();
-		if (height != null && height < 1) {
+		Integer height = toInteger(getHeight(), null);
+		if (getHeight() != null && height != null && height < 1) {
 			throw error(BAD_REQUEST, "image_error_parameter_positive", HEIGHT_QUERY_PARAM_KEY, String.valueOf(height));
 		}
-
 		ImageRect rect = getRect();
 		if (rect != null) {
 			rect.validate();
@@ -85,9 +83,9 @@ public class ImageManipulationParametersImpl extends AbstractParameters implemen
 		// fpx
 		QueryParameter fpxParameter = new QueryParameter();
 		fpxParameter.setDescription(
-				"Set the focal point x factor between 0  and 1 where 0.5 is the middle of the image.  You can use this parameter in combination with the "
-						+ CROP_MODE_QUERY_PARAM_KEY + "=" + CropMode.FOCALPOINT.getKey()
-						+ " parameter in order to crop and resize the image in relation to the given point.");
+			"Set the focal point x factor between 0  and 1 where 0.5 is the middle of the image.  You can use this parameter in combination with the "
+				+ CROP_MODE_QUERY_PARAM_KEY + "=" + CropMode.FOCALPOINT.getKey()
+				+ " parameter in order to crop and resize the image in relation to the given point.");
 		fpxParameter.setRequired(false);
 		fpxParameter.setExample("0.1");
 		fpxParameter.setType(ParamType.NUMBER);
@@ -96,9 +94,9 @@ public class ImageManipulationParametersImpl extends AbstractParameters implemen
 		// fpy
 		QueryParameter fpyParameter = new QueryParameter();
 		fpyParameter.setDescription(
-				"Set the focal point y factor between 0  and 1 where 0.5 is the middle of the image. You can use this parameter in combination with the "
-						+ CROP_MODE_QUERY_PARAM_KEY + "=" + CropMode.FOCALPOINT.getKey()
-						+ " parameter in order to crop and resize the image in relation to the given point.");
+			"Set the focal point y factor between 0  and 1 where 0.5 is the middle of the image. You can use this parameter in combination with the "
+				+ CROP_MODE_QUERY_PARAM_KEY + "=" + CropMode.FOCALPOINT.getKey()
+				+ " parameter in order to crop and resize the image in relation to the given point.");
 		fpyParameter.setRequired(false);
 		fpyParameter.setExample("0.2");
 		fpyParameter.setType(ParamType.NUMBER);
@@ -130,7 +128,7 @@ public class ImageManipulationParametersImpl extends AbstractParameters implemen
 
 		// resize
 		QueryParameter resizeParameter = new QueryParameter();
-		resizeParameter.setDescription("Set the resize mode. Possible modes: " + ResizeMode.description());		
+		resizeParameter.setDescription("Set the resize mode. Possible modes: " + ResizeMode.description());
 		resizeParameter.setExample(ResizeMode.SMART.getKey());
 		resizeParameter.setRequired(false);
 		resizeParameter.setType(ParamType.STRING);

--- a/common/src/main/java/com/gentics/mesh/parameter/impl/ImageManipulationParametersImpl.java
+++ b/common/src/main/java/com/gentics/mesh/parameter/impl/ImageManipulationParametersImpl.java
@@ -1,20 +1,21 @@
 package com.gentics.mesh.parameter.impl;
 
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static com.gentics.mesh.util.NumberUtils.toInteger;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.raml.model.ParamType;
+import org.raml.model.parameter.QueryParameter;
+
 import com.gentics.mesh.handler.ActionContext;
 import com.gentics.mesh.parameter.AbstractParameters;
 import com.gentics.mesh.parameter.ImageManipulationParameters;
 import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ImageRect;
 import com.gentics.mesh.parameter.image.ResizeMode;
-import org.raml.model.ParamType;
-import org.raml.model.parameter.QueryParameter;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.gentics.mesh.core.rest.error.Errors.error;
-import static com.gentics.mesh.util.NumberUtils.toInteger;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 /**
  * Crop and resize parameters for image manipulation.

--- a/common/src/test/java/com/gentics/mesh/query/impl/ImageManipulationParametersTest.java
+++ b/common/src/test/java/com/gentics/mesh/query/impl/ImageManipulationParametersTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Map.Entry;
 
+import com.gentics.mesh.util.NumberUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -47,9 +48,9 @@ public class ImageManipulationParametersTest {
 	public void testFromAC() throws Exception {
 
 		ImageManipulationParametersImpl parameter = new ImageManipulationParametersImpl(getActionContext(HEIGHT_QUERY_PARAM_KEY + "=112&"
-				+ WIDTH_QUERY_PARAM_KEY + "=142"));
-		assertEquals(112, parameter.getHeight().intValue());
-		assertEquals(142, parameter.getWidth().intValue());
+			+ WIDTH_QUERY_PARAM_KEY + "=142"));
+		assertEquals(112, NumberUtils.toInt(parameter.getHeight(), 0));
+		assertEquals(142, NumberUtils.toInt(parameter.getWidth(), 0));
 
 		ImageManipulationParametersImpl param = new ImageManipulationParametersImpl();
 		ImageManipulationParametersImpl paramsFromQuery = new ImageManipulationParametersImpl(getActionContext(param.getQueryParameters()));
@@ -116,12 +117,12 @@ public class ImageManipulationParametersTest {
 
 		try {
 			ImageManipulationParametersImpl request = new ImageManipulationParametersImpl(getActionContext(
-					ImageManipulationParameters.FOCAL_POINT_X_QUERY_PARAM_KEY + "=0.1"));
+				ImageManipulationParameters.FOCAL_POINT_X_QUERY_PARAM_KEY + "=0.1"));
 			request.validate();
 			fail("The validation should fail but it did not.");
 		} catch (GenericRestException e) {
 			Assert.assertException(e, BAD_REQUEST, "image_error_incomplete_focalpoint_parameters",
-					ImageManipulationParameters.FOCAL_POINT_Y_QUERY_PARAM_KEY);
+				ImageManipulationParameters.FOCAL_POINT_Y_QUERY_PARAM_KEY);
 		}
 
 		ImageManipulationParametersImpl request = new ImageManipulationParametersImpl();
@@ -150,10 +151,10 @@ public class ImageManipulationParametersTest {
 	public void testCacheKey() {
 		String cacheKey = new ImageManipulationParametersImpl().getCacheKey();
 		assertEquals("resizeSMARTfp0.5-0.5", cacheKey);
-		
+
 		cacheKey = new ImageManipulationParametersImpl().setResizeMode(ResizeMode.FORCE).getCacheKey();
 		assertEquals("resizeFORCEfp0.5-0.5", cacheKey);
-		
+
 		cacheKey = new ImageManipulationParametersImpl().setResizeMode(ResizeMode.PROP).getCacheKey();
 		assertEquals("resizePROPfp0.5-0.5", cacheKey);
 

--- a/common/src/test/java/com/gentics/mesh/query/impl/ImageManipulationParametersTest.java
+++ b/common/src/test/java/com/gentics/mesh/query/impl/ImageManipulationParametersTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.fail;
 
 import java.util.Map.Entry;
 
-import com.gentics.mesh.util.NumberUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -22,7 +21,7 @@ import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ResizeMode;
 import com.gentics.mesh.parameter.impl.ImageManipulationParametersImpl;
 import com.gentics.mesh.util.HttpQueryUtils;
-
+import com.gentics.mesh.util.NumberUtils;
 import io.vertx.core.MultiMap;
 
 public class ImageManipulationParametersTest {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
@@ -1,5 +1,12 @@
 package com.gentics.mesh.core.endpoint.node;
 
+import static com.gentics.mesh.http.HttpConstants.ETAG;
+import static com.gentics.mesh.util.MimeTypeUtils.DEFAULT_BINARY_MIME_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_MODIFIED;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.context.impl.InternalRoutingActionContextImpl;
 import com.gentics.mesh.core.data.binary.Binary;
@@ -18,13 +25,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.MimeMapping;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.reactivex.core.Vertx;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import static com.gentics.mesh.http.HttpConstants.ETAG;
-import static com.gentics.mesh.util.MimeTypeUtils.DEFAULT_BINARY_MIME_TYPE;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_MODIFIED;
 
 /**
  * Handler which will accept {@link BinaryGraphField} elements and return the binary data using the given context.

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
@@ -153,8 +153,7 @@ public class BinaryFieldResponseHandler {
 
 					response.sendFile(cachedFilePath);
 				}))
-			.subscribe(ignore -> {
-			}, rc::fail);
+			.subscribe(ignore -> {}, rc::fail);
 	}
 
 	private void addContentDispositionHeader(HttpServerResponse response, String fileName, String type) {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryFieldResponseHandler.java
@@ -132,9 +132,12 @@ public class BinaryFieldResponseHandler {
 		Integer originalHeight = binaryField.getBinary().getImageHeight();
 		Integer originalWidth = binaryField.getBinary().getImageWidth();
 
-		if (imageParams.getHeight().equals("auto")) imageParams.setHeight(originalHeight);
-		if (imageParams.getWidth().equals("auto")) imageParams.setWidth(originalWidth);
-
+		if (imageParams.getHeight().equals("auto")){
+			imageParams.setHeight(originalHeight);
+		}
+		if (imageParams.getWidth().equals("auto")) {
+			imageParams.setWidth(originalWidth);
+		}
 		String fileName = binaryField.getFileName();
 		imageManipulator.handleResize(binaryField.getBinary(), imageParams)
 			.flatMap(cachedFilePath -> rxVertx.fileSystem().rxProps(cachedFilePath)

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeImageResizeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeImageResizeEndpointTest.java
@@ -214,6 +214,7 @@ public class NodeImageResizeEndpointTest extends AbstractMeshTest {
 
 		NodeResponse transformResponse = call(() -> client().transformNodeBinaryField(PROJECT_NAME, uuid, "en", version, "image", params));
 		assertEquals("The image should have been resized", 200, transformResponse.getFields().getBinaryField("image").getHeight().intValue());
+		assertEquals("The image should use the original width of 1160", 1160, transformResponse.getFields().getBinaryField("image").getWidth().intValue());
 		MeshCoreAssertion.assertThat(testContext).hasUploads(2, 2).hasTempFiles(0).hasTempUploads(0);
 
 		// 3. Validate that a new version was created
@@ -242,6 +243,7 @@ public class NodeImageResizeEndpointTest extends AbstractMeshTest {
 		params.setHeight("auto");
 
 		NodeResponse transformResponse = call(() -> client().transformNodeBinaryField(PROJECT_NAME, uuid, "en", version, "image", params));
+		assertEquals("The image should have benn in the original Height of 1376", 1376, transformResponse.getFields().getBinaryField("image").getHeight().intValue());
 		assertEquals("The image should have been resized", 200, transformResponse.getFields().getBinaryField("image").getWidth().intValue());
 		MeshCoreAssertion.assertThat(testContext).hasUploads(2, 2).hasTempFiles(0).hasTempUploads(0);
 

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeImageResizeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeImageResizeEndpointTest.java
@@ -1,29 +1,5 @@
 package com.gentics.mesh.core.node;
 
-import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
-import static com.gentics.mesh.test.TestSize.FULL;
-import static com.gentics.mesh.test.util.MeshAssert.failingLatch;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-
-import javax.imageio.ImageIO;
-
-import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-
 import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.core.data.node.Node;
 import com.gentics.mesh.core.data.node.field.BinaryGraphField;
@@ -40,8 +16,26 @@ import com.gentics.mesh.rest.client.MeshBinaryResponse;
 import com.gentics.mesh.test.assertj.MeshCoreAssertion;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
-
 import io.vertx.core.buffer.Buffer;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static com.gentics.mesh.test.util.MeshAssert.failingLatch;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 @MeshTestSetting(testSize = FULL, startServer = true)
 public class NodeImageResizeEndpointTest extends AbstractMeshTest {
@@ -203,6 +197,94 @@ public class NodeImageResizeEndpointTest extends AbstractMeshTest {
 	}
 
 	@Test
+	public void testTransformImageResizeSmartWidthAuto() throws Exception {
+		Node node = folder("news");
+		String uuid = tx(() -> node.getUuid());
+
+		// 1. Upload image
+		String version = uploadImage(node, "en", "image").getVersion();
+		MeshCoreAssertion.assertThat(testContext).hasUploads(1, 1).hasTempFiles(0).hasTempUploads(0);
+
+		// 2. Transform the image
+		ImageManipulationParameters params = new ImageManipulationParametersImpl();
+		params.setWidth("auto");
+		params.setHeight(200);
+
+		NodeResponse transformResponse = call(() -> client().transformNodeBinaryField(PROJECT_NAME, uuid, "en", version, "image", params));
+		assertEquals("The image should have been resized", 200, transformResponse.getFields().getBinaryField("image").getHeight().intValue());
+		MeshCoreAssertion.assertThat(testContext).hasUploads(2, 2).hasTempFiles(0).hasTempUploads(0);
+
+		// 3. Validate that a new version was created
+		String newNumber = transformResponse.getVersion();
+		assertNotEquals("The version number should have changed.", version, newNumber);
+
+		// 4. Download the image
+		MeshBinaryResponse result = call(() -> client().downloadBinaryField(PROJECT_NAME, uuid, "en", "image"));
+
+		// 5. Validate the resized image
+		validateResizeImage(result, null, params, 1160, 200);
+	}
+
+	@Test
+	public void testTransformImageResizeSmartHeightAuto() throws Exception {
+		Node node = folder("news");
+		String uuid = tx(() -> node.getUuid());
+
+		// 1. Upload image
+		String version = uploadImage(node, "en", "image").getVersion();
+		MeshCoreAssertion.assertThat(testContext).hasUploads(1, 1).hasTempFiles(0).hasTempUploads(0);
+
+		// 2. Transform the image
+		ImageManipulationParameters params = new ImageManipulationParametersImpl();
+		params.setWidth(200);
+		params.setHeight("auto");
+
+		NodeResponse transformResponse = call(() -> client().transformNodeBinaryField(PROJECT_NAME, uuid, "en", version, "image", params));
+		assertEquals("The image should have been resized", 200, transformResponse.getFields().getBinaryField("image").getWidth().intValue());
+		MeshCoreAssertion.assertThat(testContext).hasUploads(2, 2).hasTempFiles(0).hasTempUploads(0);
+
+		// 3. Validate that a new version was created
+		String newNumber = transformResponse.getVersion();
+		assertNotEquals("The version number should have changed.", version, newNumber);
+
+		// 4. Download the image
+		MeshBinaryResponse result = call(() -> client().downloadBinaryField(PROJECT_NAME, uuid, "en", "image"));
+
+		// 5. Validate the resized image
+		validateResizeImage(result, null, params, 200, 1376);
+	}
+
+	@Test
+	public void testTransformImageResizeSmartHeightWidthAuto() throws Exception {
+		Node node = folder("news");
+		String uuid = tx(() -> node.getUuid());
+
+		// 1. Upload image
+		String version = uploadImage(node, "en", "image").getVersion();
+		MeshCoreAssertion.assertThat(testContext).hasUploads(1, 1).hasTempFiles(0).hasTempUploads(0);
+
+		// 2. Transform the image
+		ImageManipulationParameters params = new ImageManipulationParametersImpl();
+		params.setWidth("auto");
+		params.setHeight("auto");
+
+		NodeResponse transformResponse = call(() -> client().transformNodeBinaryField(PROJECT_NAME, uuid, "en", version, "image", params));
+		assertEquals("The image should have been in the original width of 1160px", 1160, transformResponse.getFields().getBinaryField("image").getWidth().intValue());
+		assertEquals("The image should have been in the original height of  1376px", 1376, transformResponse.getFields().getBinaryField("image").getHeight().intValue());
+		MeshCoreAssertion.assertThat(testContext).hasUploads(2, 2).hasTempFiles(0).hasTempUploads(0);
+
+		// 3. Validate that a new version was created
+		String newNumber = transformResponse.getVersion();
+		assertNotEquals("The version number should have changed.", version, newNumber);
+
+		// 4. Download the image
+		MeshBinaryResponse result = call(() -> client().downloadBinaryField(PROJECT_NAME, uuid, "en", "image"));
+
+		// 5. Validate the resized image
+		validateResizeImage(result, null, params, 1160, 1376);
+	}
+
+	@Test
 	public void testTransformImageResizeForce() throws Exception {
 		Node node = folder("news");
 		String uuid = tx(() -> node.getUuid());
@@ -230,7 +312,8 @@ public class NodeImageResizeEndpointTest extends AbstractMeshTest {
 
 		// 5. Validate the resized image
 		validateResizeImage(result, null, params, 100, 500);
-	}	
+	}
+
 	@Test
 	public void testTransformImageNoParameters() throws Exception {
 		Node node = folder("news");
@@ -408,7 +491,7 @@ public class NodeImageResizeEndpointTest extends AbstractMeshTest {
 	}
 
 	private void validateResizeImage(MeshBinaryResponse download, BinaryGraphField binaryField, ImageManipulationParameters params,
-		int expectedWidth, int expectedHeight) throws Exception {
+	                                 int expectedWidth, int expectedHeight) throws Exception {
 		File targetFile = new File("target", UUID.randomUUID() + "_resized.jpg");
 		CountDownLatch latch = new CountDownLatch(1);
 		byte[] bytes = IOUtils.toByteArray(download.getStream());

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeImageResizeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeImageResizeEndpointTest.java
@@ -1,5 +1,26 @@
 package com.gentics.mesh.core.node;
 
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static com.gentics.mesh.test.util.MeshAssert.failingLatch;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import javax.imageio.ImageIO;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
 import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.core.data.node.Node;
 import com.gentics.mesh.core.data.node.field.BinaryGraphField;
@@ -17,25 +38,6 @@ import com.gentics.mesh.test.assertj.MeshCoreAssertion;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
 import io.vertx.core.buffer.Buffer;
-import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-
-import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
-import static com.gentics.mesh.test.TestSize.FULL;
-import static com.gentics.mesh.test.util.MeshAssert.failingLatch;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 
 @MeshTestSetting(testSize = FULL, startServer = true)
 public class NodeImageResizeEndpointTest extends AbstractMeshTest {
@@ -491,7 +493,7 @@ public class NodeImageResizeEndpointTest extends AbstractMeshTest {
 	}
 
 	private void validateResizeImage(MeshBinaryResponse download, BinaryGraphField binaryField, ImageManipulationParameters params,
-	                                 int expectedWidth, int expectedHeight) throws Exception {
+									 int expectedWidth, int expectedHeight) throws Exception {
 		File targetFile = new File("target", UUID.randomUUID() + "_resized.jpg");
 		CountDownLatch latch = new CountDownLatch(1);
 		byte[] bytes = IOUtils.toByteArray(download.getStream());

--- a/doc/src/main/docs/image-manipulation.asciidoc
+++ b/doc/src/main/docs/image-manipulation.asciidoc
@@ -34,7 +34,8 @@ image::https://demo.getmesh.io{apiLatest}/demo/webroot/images/ford-gt.jpg?w=500[
 When loading an image with resizing parameters you can provide either the desired width by appending `w=:width` or the desired height by appending by appending `h=:height`. 
 
 ==== Smart resizing and Cropping
-It also possible to provide both dimensions. Note that in this case Mesh potentially crops your image to fit the desired dimensions. This happens when the aspect ratio of the source image is different from the requested dimensions. In these cases Mesh will crop _either_ pixels at the top and bottom or left and right.
+It also possible to provide both dimensions. Note that in this case Mesh potentially crops your image to fit the desired dimensions. This happens when the aspect ratio of the source image is different from the requested dimensions. In these cases Mesh will crop _either_ pixels at the top and bottom or left and right. Mesh supports the `auto` dimension when manipulating an image.
+If `auto` is used in width or height then mesh will crop the use the original value when cropping the image.
 
 NOTE: Providing no resize parameter yields the same result as providing `resize=smart`
 

--- a/doc/src/main/docs/image-manipulation.asciidoc
+++ b/doc/src/main/docs/image-manipulation.asciidoc
@@ -35,7 +35,7 @@ When loading an image with resizing parameters you can provide either the desire
 
 ==== Smart resizing and Cropping
 It also possible to provide both dimensions. Note that in this case Mesh potentially crops your image to fit the desired dimensions. This happens when the aspect ratio of the source image is different from the requested dimensions. In these cases Mesh will crop _either_ pixels at the top and bottom or left and right. Mesh supports the `auto` dimension when manipulating an image.
-If `auto` is used in width or height then mesh will crop the use the original value when cropping the image.
+If `auto` is used in width or height then mesh will use the original value when cropping the image.
 
 NOTE: Providing no resize parameter yields the same result as providing `resize=smart`
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/BinaryFieldTransformRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/BinaryFieldTransformRequest.java
@@ -8,6 +8,8 @@ import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ImageRect;
 import com.gentics.mesh.parameter.image.ResizeMode;
 
+import java.text.NumberFormat;
+
 /**
  * POJO for a binary field transform request
  */
@@ -22,10 +24,10 @@ public class BinaryFieldTransformRequest implements RestModel {
 	private String language;
 
 	@JsonPropertyDescription("New width of the image.")
-	private Integer width;
+	private String width;
 
 	@JsonPropertyDescription("New height of the image.")
-	private Integer height;
+	private String height;
 
 	@JsonPropertyDescription("Crop area.")
 	private ImageRect cropRect;
@@ -37,56 +39,80 @@ public class BinaryFieldTransformRequest implements RestModel {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Resize mode.")
 	private ResizeMode resizeMode;
-	
+
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Optional new focal point for the transformed image.")
 	private FocalPoint focalPoint;
 
 	/**
 	 * Get resize width
-	 * 
+	 *
 	 * @return resize width
 	 */
-	public Integer getWidth() {
+	public String getWidth() {
 		return width;
 	}
 
 	/**
 	 * Set the resize width
-	 * 
-	 * @param width
-	 *            resize width
+	 *
+	 * @param width resize width
 	 * @return fluent API
 	 */
-	public BinaryFieldTransformRequest setWidth(Integer width) {
+	public BinaryFieldTransformRequest setWidth(String width) {
 		this.width = width;
 		return this;
 	}
 
 	/**
+	 * Set the resize width
+	 *
+	 * @param width resize width
+	 * @return fluent API
+	 * @deprecated Use the BinaryFieldTransformRequest{@link #getWidth()} instead
+	 */
+	@Deprecated
+	public BinaryFieldTransformRequest setWidth(Integer width) {
+		this.width = width.toString();
+		return this;
+	}
+
+	/**
 	 * Get the resize height
-	 * 
+	 *
 	 * @return resize height
 	 */
-	public Integer getHeight() {
+	public String getHeight() {
 		return height;
 	}
 
 	/**
 	 * Set the resize height
-	 * 
-	 * @param height
-	 *            resize height
+	 *
+	 * @param height resize height
 	 * @return fluent API
 	 */
-	public BinaryFieldTransformRequest setHeight(Integer height) {
+	public BinaryFieldTransformRequest setHeight(String height) {
 		this.height = height;
 		return this;
 	}
 
 	/**
+	 * Set the resize height
+	 *
+	 * @param height resize height
+	 * @return fluent API
+	 * @deprecated Use the BinaryFieldTransformRequest{@link #getHeight()}instead
+	 */
+	@Deprecated
+	public BinaryFieldTransformRequest setHeight(Integer height) {
+		this.height = height.toString();
+		return this;
+	}
+
+	/**
 	 * Return the crop area.
-	 * 
+	 *
 	 * @return
 	 */
 	public ImageRect getCropRect() {
@@ -103,7 +129,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Set the crop area.
-	 * 
+	 *
 	 * @param startX
 	 * @param startY
 	 * @param height
@@ -116,7 +142,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Return the crop mode.
-	 * 
+	 *
 	 * @return
 	 */
 	public CropMode getCropMode() {
@@ -133,7 +159,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Return the resize mode.
-	 * 
+	 *
 	 * @return
 	 */
 	public ResizeMode getResizeMode() {
@@ -147,9 +173,10 @@ public class BinaryFieldTransformRequest implements RestModel {
 		this.resizeMode = mode;
 		return this;
 	}
+
 	/**
 	 * Return the node language.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getLanguage() {
@@ -158,7 +185,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Set the language of the node content which contains the image.
-	 * 
+	 *
 	 * @param language
 	 * @return Fluent API
 	 */
@@ -169,7 +196,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Return the node version.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getVersion() {
@@ -178,7 +205,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Set the node version.
-	 * 
+	 *
 	 * @param version
 	 * @return Fluent API
 	 */
@@ -189,7 +216,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Return the focal point.
-	 * 
+	 *
 	 * @return
 	 */
 	public FocalPoint getFocalPoint() {
@@ -198,7 +225,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 
 	/**
 	 * Set the focal point.
-	 * 
+	 *
 	 * @param focalPoint
 	 * @return Fluent API
 	 */

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/BinaryFieldTransformRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/BinaryFieldTransformRequest.java
@@ -8,8 +8,6 @@ import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ImageRect;
 import com.gentics.mesh.parameter.image.ResizeMode;
 
-import java.text.NumberFormat;
-
 /**
  * POJO for a binary field transform request
  */

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/BinaryFieldTransformRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/BinaryFieldTransformRequest.java
@@ -67,7 +67,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 	 *
 	 * @param width resize width
 	 * @return fluent API
-	 * @deprecated Use the BinaryFieldTransformRequest{@link #getWidth()} instead
+	 * @deprecated Use {@link #setWidth(String)} instead
 	 */
 	@Deprecated
 	public BinaryFieldTransformRequest setWidth(Integer width) {
@@ -100,7 +100,7 @@ public class BinaryFieldTransformRequest implements RestModel {
 	 *
 	 * @param height resize height
 	 * @return fluent API
-	 * @deprecated Use the BinaryFieldTransformRequest{@link #getHeight()}instead
+	 * @deprecated Use {@link #setHeight(String)} instead
 	 */
 	@Deprecated
 	public BinaryFieldTransformRequest setHeight(Integer height) {

--- a/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
+++ b/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
@@ -58,9 +58,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	 *
 	 * @param width
 	 * @return Fluent API
-	 * @deprecated Use {@link #setWidth(String)} instead.
 	 */
-	@Deprecated
 	default ImageManipulationParameters setWidth(Integer width) {
 		setParameter(WIDTH_QUERY_PARAM_KEY, String.valueOf(width));
 		return this;
@@ -91,10 +89,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	 *
 	 * @param height
 	 * @return Fluent API
-	 * @deprecated Use {@link #setHeight(String)} instead.
 	 */
-
-	@Deprecated
 	default ImageManipulationParameters setHeight(Integer height) {
 		setParameter(HEIGHT_QUERY_PARAM_KEY, String.valueOf(height));
 		return this;

--- a/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
+++ b/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
@@ -1,5 +1,8 @@
 package com.gentics.mesh.parameter;
 
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+
 import com.gentics.mesh.core.rest.node.field.image.FocalPoint;
 import com.gentics.mesh.core.rest.node.field.image.Point;
 import com.gentics.mesh.etc.config.ImageManipulatorOptions;
@@ -7,9 +10,6 @@ import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ImageRect;
 import com.gentics.mesh.parameter.image.ResizeMode;
 import com.gentics.mesh.util.NumberUtils;
-
-import static com.gentics.mesh.core.rest.error.Errors.error;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 public interface ImageManipulationParameters extends ParameterProvider {
 

--- a/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
+++ b/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
@@ -129,8 +129,8 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	 * @return Image size or null when width or height are missing
 	 */
 	default Point getSize() {
-		Integer w = NumberUtils.toInt(getWidth(), null);
-		Integer h = NumberUtils.toInt(getHeight(), null);
+		Integer w = NumberUtils.toInteger(getWidth(), null);
+		Integer h = NumberUtils.toInteger(getHeight(), null);
 		if (w == null || h == null) {
 			return null;
 		}

--- a/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
+++ b/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
@@ -58,7 +58,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	 *
 	 * @param width
 	 * @return Fluent API
-	 * @deprecated Use this ImageManipulationParameters#setWidth(String) instead.
+	 * @deprecated Use {@link #setWidth(String)} instead.
 	 */
 	@Deprecated
 	default ImageManipulationParameters setWidth(Integer width) {
@@ -91,7 +91,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	 *
 	 * @param height
 	 * @return Fluent API
-	 * @deprecated Use this ImageManipulationParameters#setHeight(String) instead.
+	 * @deprecated Use {@link #setHeight(String)} instead.
 	 */
 
 	@Deprecated
@@ -129,8 +129,8 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	 * @return Image size or null when width or height are missing
 	 */
 	default Point getSize() {
-		Integer w = NumberUtils.toInt(getWidth(), 0);
-		Integer h = NumberUtils.toInt(getHeight(), 0);
+		Integer w = NumberUtils.toInt(getWidth(), null);
+		Integer h = NumberUtils.toInt(getHeight(), null);
 		if (w == null || h == null) {
 			return null;
 		}

--- a/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
+++ b/rest-model/src/main/java/com/gentics/mesh/parameter/ImageManipulationParameters.java
@@ -1,15 +1,15 @@
 package com.gentics.mesh.parameter;
 
-import static com.gentics.mesh.core.rest.error.Errors.error;
-import static com.gentics.mesh.util.NumberUtils.toInteger;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-
 import com.gentics.mesh.core.rest.node.field.image.FocalPoint;
 import com.gentics.mesh.core.rest.node.field.image.Point;
 import com.gentics.mesh.etc.config.ImageManipulatorOptions;
 import com.gentics.mesh.parameter.image.CropMode;
 import com.gentics.mesh.parameter.image.ImageRect;
 import com.gentics.mesh.parameter.image.ResizeMode;
+import com.gentics.mesh.util.NumberUtils;
+
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 public interface ImageManipulationParameters extends ParameterProvider {
 
@@ -26,26 +26,41 @@ public interface ImageManipulationParameters extends ParameterProvider {
 	public static final String RECT_QUERY_PARAM_KEY = "rect";
 
 	public static final String CROP_MODE_QUERY_PARAM_KEY = "crop";
-	
+
 	public static final String RESIZE_MODE_QUERY_PARAM_KEY = "resize";
 
 	public static final String FOCAL_POINT_DEBUG_PARAM_KEY = "fpdebug";
 
+	public static final String AUTO = "auto";
+
 	/**
 	 * Return the image width.
-	 * 
+	 *
 	 * @return
 	 */
-	default Integer getWidth() {
-		return toInteger(getParameter(WIDTH_QUERY_PARAM_KEY), null);
+	default String getWidth() {
+		return getParameter(WIDTH_QUERY_PARAM_KEY);
 	}
 
 	/**
 	 * Set the image width.
-	 * 
+	 *
 	 * @param width
 	 * @return Fluent API
 	 */
+	default ImageManipulationParameters setWidth(String width) {
+		setParameter(WIDTH_QUERY_PARAM_KEY, width);
+		return this;
+	}
+
+	/**
+	 * Set the image width.
+	 *
+	 * @param width
+	 * @return Fluent API
+	 * @deprecated Use this ImageManipulationParameters#setWidth(String) instead.
+	 */
+	@Deprecated
 	default ImageManipulationParameters setWidth(Integer width) {
 		setParameter(WIDTH_QUERY_PARAM_KEY, String.valueOf(width));
 		return this;
@@ -53,19 +68,33 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Return the image height.
-	 * 
+	 *
 	 * @return
 	 */
-	default Integer getHeight() {
-		return toInteger(getParameter(HEIGHT_QUERY_PARAM_KEY), null);
+	default String getHeight() {
+		return getParameter(HEIGHT_QUERY_PARAM_KEY);
 	}
 
 	/**
 	 * Set the image height.
-	 * 
+	 *
 	 * @param height
 	 * @return Fluent API
 	 */
+	default ImageManipulationParameters setHeight(String height) {
+		setParameter(HEIGHT_QUERY_PARAM_KEY, height);
+		return this;
+	}
+
+	/**
+	 * Set the image height.
+	 *
+	 * @param height
+	 * @return Fluent API
+	 * @deprecated Use this ImageManipulationParameters#setHeight(String) instead.
+	 */
+
+	@Deprecated
 	default ImageManipulationParameters setHeight(Integer height) {
 		setParameter(HEIGHT_QUERY_PARAM_KEY, String.valueOf(height));
 		return this;
@@ -73,20 +102,20 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the target size of the image.
-	 * 
+	 *
 	 * @param width
 	 * @param height
 	 * @return Fluent API
 	 */
 	default ImageManipulationParameters setSize(int width, int height) {
-		setWidth(width);
-		setHeight(height);
+		setWidth(String.valueOf(width));
+		setHeight(String.valueOf(height));
 		return this;
 	}
 
 	/**
 	 * Set the target size of the image.
-	 * 
+	 *
 	 * @param size
 	 * @return Fluent API
 	 */
@@ -96,12 +125,12 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Return the image size.
-	 * 
+	 *
 	 * @return Image size or null when width or height are missing
 	 */
 	default Point getSize() {
-		Integer w = getWidth();
-		Integer h = getHeight();
+		Integer w = NumberUtils.toInt(getWidth(), 0);
+		Integer h = NumberUtils.toInt(getHeight(), 0);
 		if (w == null || h == null) {
 			return null;
 		}
@@ -110,7 +139,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Returns the rect crop area parameter value.
-	 * 
+	 *
 	 * @return Configured image crop area rectangle
 	 */
 	default ImageRect getRect() {
@@ -120,7 +149,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the crop area.
-	 * 
+	 *
 	 * @param startX
 	 * @param startY
 	 * @param height
@@ -135,7 +164,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the crop area.
-	 * 
+	 *
 	 * @param rect
 	 * @return
 	 */
@@ -150,7 +179,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Return the crop mode parameter value.
-	 * 
+	 *
 	 * @return
 	 */
 	default CropMode getCropMode() {
@@ -160,7 +189,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the crop mode parameter.
-	 * 
+	 *
 	 * @param mode
 	 * @return Fluent API
 	 */
@@ -174,20 +203,20 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the crop mode parameter.
-	 * 
+	 *
 	 * @param mode
 	 * @return Fluent API
 	 */
 	default ImageManipulationParameters setCropMode(CropMode mode) {
-		if(mode != null) {
-			setParameter(CROP_MODE_QUERY_PARAM_KEY, mode.getKey());	
+		if (mode != null) {
+			setParameter(CROP_MODE_QUERY_PARAM_KEY, mode.getKey());
 		}
 		return this;
 	}
 
 	/**
 	 * Return the resize mode parameter value.
-	 * 
+	 *
 	 * @return
 	 */
 	default ResizeMode getResizeMode() {
@@ -197,7 +226,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the resize mode parameter.
-	 * 
+	 *
 	 * @param mode
 	 * @return Fluent API
 	 */
@@ -211,20 +240,20 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the resize mode parameter.
-	 * 
+	 *
 	 * @param mode
 	 * @return Fluent API
 	 */
 	default ImageManipulationParameters setResizeMode(ResizeMode mode) {
-		if(mode != null) {
+		if (mode != null) {
 			setParameter(RESIZE_MODE_QUERY_PARAM_KEY, mode.getKey());
 		}
 		return this;
 	}
-	
+
 	/**
 	 * Check whether focal point parameters have been set.
-	 * 
+	 *
 	 * @return
 	 */
 	default boolean hasFocalPoint() {
@@ -235,7 +264,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Get the focal point that has been set in the image parameter.
-	 * 
+	 *
 	 * @return
 	 */
 	default FocalPoint getFocalPoint() {
@@ -249,7 +278,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Get the focal point zoom factor.
-	 * 
+	 *
 	 * @return
 	 */
 	default Float getFocalPointZoom() {
@@ -263,7 +292,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the focal point.
-	 * 
+	 *
 	 * @param point
 	 * @return Fluent API
 	 */
@@ -280,7 +309,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the focal point.
-	 * 
+	 *
 	 * @param x
 	 * @param y
 	 * @return Fluent API
@@ -291,7 +320,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the focal point zoom factor.
-	 * 
+	 *
 	 * @param factor
 	 * @return Fluent API
 	 */
@@ -306,7 +335,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Set the focal point debug flag.
-	 * 
+	 *
 	 * @param flag
 	 * @return
 	 */
@@ -321,7 +350,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Return the focal point debug flag.
-	 * 
+	 *
 	 * @return
 	 */
 	default boolean getFocalPointDebug() {
@@ -331,7 +360,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Validates whether the focal point was fully specified.
-	 * 
+	 *
 	 * @return Fluent API
 	 */
 	default ImageManipulationParameters validateFocalPointParameter() {
@@ -347,15 +376,17 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Check whether all required crop parameters have been set.
-	 * 
+	 *
 	 * @param options
 	 * @return Fluent API
 	 */
 	default ImageManipulationParameters validateLimits(ImageManipulatorOptions options) {
-		if (getWidth() != null && options.getMaxWidth() != null && options.getMaxWidth() > 0 && getWidth() > options.getMaxWidth()) {
+		int width = NumberUtils.toInt(getWidth(), 0);
+		int height = NumberUtils.toInt(getHeight(), 0);
+		if (getWidth() != null && options.getMaxWidth() != null && options.getMaxWidth() > 0 && width > options.getMaxWidth()) {
 			throw error(BAD_REQUEST, "image_error_width_limit_exceeded", String.valueOf(options.getMaxWidth()), String.valueOf(getWidth()));
 		}
-		if (getHeight() != null && options.getMaxHeight() != null && options.getMaxHeight() > 0 && getHeight() > options.getMaxHeight()) {
+		if (getHeight() != null && options.getMaxHeight() != null && options.getMaxHeight() > 0 && height > options.getMaxHeight()) {
 			throw error(BAD_REQUEST, "image_error_height_limit_exceeded", String.valueOf(options.getMaxHeight()), String.valueOf(getHeight()));
 		}
 		return this;
@@ -363,7 +394,7 @@ public interface ImageManipulationParameters extends ParameterProvider {
 
 	/**
 	 * Generate cache key.
-	 * 
+	 *
 	 * @return
 	 */
 	default String getCacheKey() {
@@ -394,13 +425,13 @@ public interface ImageManipulationParameters extends ParameterProvider {
 		if (getFocalPointZoom() != null) {
 			builder.append("fpz" + getFocalPointZoom());
 		}
-		
+
 		return builder.toString();
 	}
 
 	/**
 	 * Check whether any resize or crop param has been set.
-	 * 
+	 *
 	 * @return
 	 */
 	default boolean hasResizeParams() {

--- a/services/image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulator.java
+++ b/services/image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulator.java
@@ -215,7 +215,6 @@ public class ImgscalrImageManipulator extends AbstractImageManipulator {
 
 	/**
 	 * Create an image writer from the same image format as the specified image reader writing to the given output stream.
-	 * <p>
 	 * When no respective writer to the given reader is available, a PNG writer will be created.
 	 *
 	 * @param reader The reader used to read the original image

--- a/services/image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulator.java
+++ b/services/image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulator.java
@@ -1,5 +1,36 @@
 package com.gentics.mesh.image;
 
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
+import javax.imageio.stream.FileImageOutputStream;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.ImageOutputStream;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.AutoDetectParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.Parser;
+import org.apache.tika.sax.BodyContentHandler;
+import org.imgscalr.Scalr;
+import org.imgscalr.Scalr.Mode;
+
 import com.gentics.mesh.core.data.binary.Binary;
 import com.gentics.mesh.core.image.spi.AbstractImageManipulator;
 import com.gentics.mesh.etc.config.ImageManipulatorOptions;
@@ -17,31 +48,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.WorkerExecutor;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.parser.AutoDetectParser;
-import org.apache.tika.parser.ParseContext;
-import org.apache.tika.parser.Parser;
-import org.apache.tika.sax.BodyContentHandler;
-import org.imgscalr.Scalr;
-import org.imgscalr.Scalr.Mode;
-
-import javax.imageio.*;
-import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
-import javax.imageio.stream.FileImageOutputStream;
-import javax.imageio.stream.ImageInputStream;
-import javax.imageio.stream.ImageOutputStream;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import static com.gentics.mesh.core.rest.error.Errors.error;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 /**
  * The ImgScalr Manipulator uses a pure java imageio image resizer.


### PR DESCRIPTION
## Abstract
Mesh supports now the auto value in height or width. The changes are done in the Image Manipulation and in BinaryFieldResponse. The height and width are now strings.
## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
