### PR TITLE
Include all previous schema versions when migrating remaining nodes 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,8 @@ icon:plus[] Server: The `serverTokens` flag and `MESH_HTTP_SERVER_TOKENS` env ha
 
 icon:check[] Changelog: The automated recovery from v1.4.4 now renames duplicate versions instead of deleting them.
 
+icon:check[] Core: Migrating remaining nodes via the `/{project}/branches/{branchUuid}/migrateSchemas` and `/{project}/branches/{branchUuid}/migrateMicroschemas` now includes all previous schema versions instead of only active schema versions.
+
 [[v1.4.4]]
 == 1.4.4 (14.04.2020)
 

--- a/common/src/main/java/com/gentics/mesh/core/data/schema/GraphFieldSchemaContainerVersion.java
+++ b/common/src/main/java/com/gentics/mesh/core/data/schema/GraphFieldSchemaContainerVersion.java
@@ -120,21 +120,32 @@ public interface GraphFieldSchemaContainerVersion<R extends FieldSchemaContainer
 
 	/**
 	 * Return the previous version of this schema.
-	 * 
+	 *
 	 * @return
 	 */
 	SCV getPreviousVersion();
 
 	/**
+	 * Returns a stream of all previous versions.
+	 * @return
+	 */
+	default Stream<SCV> getPreviousVersions() {
+		return StreamUtil.untilNull(
+			this::getPreviousVersion,
+			GraphFieldSchemaContainerVersion::getPreviousVersion
+		);
+	}
+
+	/**
 	 * Set the previous version of the container.
-	 * 
+	 *
 	 * @param container
 	 */
 	void setPreviousVersion(SCV container);
 
 	/**
 	 * Generate a schema change list by comparing the schema with the specified schema update model which is extracted from the action context.
-	 * 
+	 *
 	 * @param ac
 	 *            Action context that provides the schema update request
 	 * @param comparator
@@ -147,7 +158,7 @@ public interface GraphFieldSchemaContainerVersion<R extends FieldSchemaContainer
 
 	/**
 	 * Apply changes which will be extracted from the action context.
-	 * 
+	 *
 	 * @param ac
 	 *            Action context that provides the migration request data
 	 * @param batch
@@ -157,7 +168,7 @@ public interface GraphFieldSchemaContainerVersion<R extends FieldSchemaContainer
 
 	/**
 	 * Apply the given list of changes to the schema container. This method will invoke the schema migration process.
-	 * 
+	 *
 	 * @param ac
 	 * @param listOfChanges
 	 * @param batch
@@ -167,42 +178,42 @@ public interface GraphFieldSchemaContainerVersion<R extends FieldSchemaContainer
 
 	/**
 	 * Return the parent schema container of the version.
-	 * 
+	 *
 	 * @return
 	 */
 	SC getSchemaContainer();
 
 	/**
 	 * Set the parent schema container of this version.
-	 * 
+	 *
 	 * @param container
 	 */
 	void setSchemaContainer(SC container);
 
 	/**
 	 * Get the branches to which the container was assigned.
-	 * 
+	 *
 	 * @return Found branches of this version
 	 */
 	TraversalResult<? extends Branch> getBranches();
 
 	/**
 	 * Load the stored schema JSON data.
-	 * 
+	 *
 	 * @return
 	 */
 	String getJson();
 
 	/**
 	 * Update the stored schema JSON data.
-	 * 
+	 *
 	 * @param json
 	 */
 	void setJson(String json);
 
 	/**
 	 * Compare two versions.
-	 * 
+	 *
 	 * @param version
 	 */
 	default int compareTo(SCV version) {
@@ -211,14 +222,14 @@ public interface GraphFieldSchemaContainerVersion<R extends FieldSchemaContainer
 
 	/**
 	 * Return an iterable of all jobs which reference the version via the _to_ reference.
-	 * 
+	 *
 	 * @return
 	 */
 	Iterable<Job> referencedJobsViaTo();
 
 	/**
 	 * Return an iterable of all jobs which reference the version via the _from_ reference.
-	 * 
+	 *
 	 * @return
 	 */
 	Iterable<Job> referencedJobsViaFrom();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/branch/BranchCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/branch/BranchCrudHandler.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
@@ -280,10 +281,8 @@ public class BranchCrudHandler extends AbstractCrudHandler<Branch, BranchRespons
 					.map(list -> (T) list.stream().max(Comparator.comparing(Function.identity())).get())
 					.collect(Collectors.toMap(GraphFieldSchemaContainerVersion::getName, Function.identity()));
 
-				versions.stream()
-					.flatMap(Collection::stream)
-					// We don't need to migrate the latest active version
-					.filter(version -> version != latestVersions.get(version.getName()))
+				latestVersions.values().stream()
+					.flatMap(v -> (Stream<T>) v.getPreviousVersions())
 					.forEach(schemaVersion -> {
 						enqueueMigration.apply(boot.jobRoot(), ac.getUser(), branch, schemaVersion, latestVersions.get(schemaVersion.getName()));
 					});


### PR DESCRIPTION
## Abstract
When migrating, currently only schemas that are active to the branch are considered for migration. Under certain circumstances, other older nodes can exist. This fix ensures that these older Nodes are migrated as well.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
