### PR TITLE
Add perm checks for server tokens

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,8 @@ include::content/docs/variables.adoc-include[]
 [[v1.4.7]]
 == 1.4.7 (TBD)
 
+icon:plus[] Server: The `/api/v1/RAML` endpoint can now only be accessed by admin users.
+
 icon:plus[] Server: Admin users can now always see the `serverTokens` regardless of the `serverTokens` setting.
 
 icon:checked[] Elasticsearch: Fixed a bug that prevented Elasticsearch synchronization of projects after deleting a role. link:https://github.com/gentics/mesh/issues/1041[#1041]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,8 @@ include::content/docs/variables.adoc-include[]
 [[v1.4.7]]
 == 1.4.7 (TBD)
 
+icon:plus[] Server: Admin users can now always see the `serverTokens` regardless of the `serverTokens` setting.
+
 icon:checked[] Elasticsearch: Fixed a bug that prevented Elasticsearch synchronization of projects after deleting a role. link:https://github.com/gentics/mesh/issues/1041[#1041]
 
 [[v1.4.6]]

--- a/common/src/main/java/com/gentics/mesh/context/AbstractInternalActionContext.java
+++ b/common/src/main/java/com/gentics/mesh/context/AbstractInternalActionContext.java
@@ -2,7 +2,10 @@ package com.gentics.mesh.context;
 
 import static com.gentics.mesh.core.rest.error.Errors.error;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+
 import com.gentics.mesh.core.data.Branch;
+import com.gentics.mesh.core.data.MeshAuthUser;
 import com.gentics.mesh.core.data.Project;
 import com.gentics.mesh.core.rest.common.RestModel;
 import com.gentics.mesh.core.rest.error.GenericRestException;
@@ -75,6 +78,16 @@ public abstract class AbstractInternalActionContext extends AbstractActionContex
 	public InternalActionContext skipWriteLock() {
 		this.data().put(SKIP_LOCK_DATA_KEY, true);
 		return this;
+	}
+
+	@Override
+	public boolean isAdmin() {
+		MeshAuthUser user = getUser();
+		if (user == null) {
+			return false;
+		}
+
+		return user.hasAdminRole();
 	}
 
 }

--- a/common/src/main/java/com/gentics/mesh/context/InternalActionContext.java
+++ b/common/src/main/java/com/gentics/mesh/context/InternalActionContext.java
@@ -201,4 +201,11 @@ public interface InternalActionContext extends ActionContext, ParameterProviderC
 	 */
 	InternalActionContext skipWriteLock();
 
+	/**
+	 * Check whether the context provides a user which is admin.
+	 * 
+	 * @return
+	 */
+	boolean isAdmin();
+
 }

--- a/common/src/main/java/com/gentics/mesh/router/route/AbstractInternalEndpoint.java
+++ b/common/src/main/java/com/gentics/mesh/router/route/AbstractInternalEndpoint.java
@@ -54,6 +54,15 @@ public abstract class AbstractInternalEndpoint implements InternalEndpoint {
 	}
 
 	/**
+	 * Add the auth chain to the endpoint.
+	 * 
+	 * @param endpoint
+	 */
+	protected void secure(InternalEndpointRoute endpoint) {
+		chain.secure(endpoint.getRoute());
+	}
+
+	/**
 	 * Register all endpoints to the local router.
 	 */
 	public abstract void registerEndPoints();

--- a/common/src/main/java/com/gentics/mesh/router/route/AbstractInternalEndpoint.java
+++ b/common/src/main/java/com/gentics/mesh/router/route/AbstractInternalEndpoint.java
@@ -54,12 +54,14 @@ public abstract class AbstractInternalEndpoint implements InternalEndpoint {
 	}
 
 	/**
-	 * Add the auth chain to the endpoint.
+	 * Add a route which will secure the given path.
 	 * 
 	 * @param endpoint
 	 */
-	protected void secure(InternalEndpointRoute endpoint) {
-		chain.secure(endpoint.getRoute());
+	protected void secure(String path) {
+		if (chain != null) {
+			chain.secure(getRouter().route(path));
+		}
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
@@ -275,12 +275,14 @@ public class AdminHandler extends AbstractHandler {
 	}
 
 	public void handleVersions(InternalActionContext ac) {
-		ac.send(getMeshServerInfoModel(), OK);
+		MeshServerInfoModel model = getMeshServerInfoModel(ac);
+		ac.send(model, OK);
 	}
 
-	public MeshServerInfoModel getMeshServerInfoModel() {
+	public MeshServerInfoModel getMeshServerInfoModel(InternalActionContext ac) {
+		boolean admin = db.tx(() -> ac.isAdmin());
 		MeshServerInfoModel info = new MeshServerInfoModel();
-		if (options.getHttpServerOptions().isServerTokens()) {
+		if (options.getHttpServerOptions().isServerTokens() || admin) {
 			info.setDatabaseVendor(db.getVendorName());
 			info.setSearchVendor(searchProvider.getVendorName());
 			info.setDatabaseVersion(db.getVersion());

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.core.rest.MeshEvent.GRAPH_IMPORT_START;
 import static com.gentics.mesh.core.rest.MeshEvent.GRAPH_RESTORE_FINISHED;
 import static com.gentics.mesh.core.rest.MeshEvent.GRAPH_RESTORE_START;
 import static com.gentics.mesh.core.rest.error.Errors.error;
+import static com.gentics.mesh.http.HttpConstants.APPLICATION_YAML_UTF8;
 import static com.gentics.mesh.rest.Messages.message;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
@@ -38,11 +39,12 @@ import com.gentics.mesh.core.rest.admin.cluster.coordinator.CoordinatorConfig;
 import com.gentics.mesh.core.rest.admin.cluster.coordinator.CoordinatorMasterResponse;
 import com.gentics.mesh.core.rest.admin.status.MeshStatusResponse;
 import com.gentics.mesh.core.rest.error.GenericRestException;
-import com.gentics.mesh.core.verticle.handler.WriteLock;
 import com.gentics.mesh.core.verticle.handler.HandlerUtilities;
+import com.gentics.mesh.core.verticle.handler.WriteLock;
 import com.gentics.mesh.distributed.coordinator.Coordinator;
 import com.gentics.mesh.distributed.coordinator.MasterServer;
 import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.generator.RAMLGenerator;
 import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.router.RouterStorage;
 import com.gentics.mesh.router.RouterStorageRegistry;
@@ -293,6 +295,17 @@ public class AdminHandler extends AbstractHandler {
 			info.setMeshNodeName(options.getNodeName());
 		}
 		return info;
+	}
+
+	public void handleRAML(InternalActionContext ac) {
+		boolean admin = db.tx(() -> ac.isAdmin());
+		if (admin) {
+			RAMLGenerator generator = new RAMLGenerator();
+			String raml = generator.generate();
+			ac.send(raml, OK, APPLICATION_YAML_UTF8);
+		} else {
+			throw error(FORBIDDEN, "error_admin_permission_required");
+		}
 	}
 
 	public void handleLoadClusterConfig(InternalActionContext ac) {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/RestInfoEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/RestInfoEndpoint.java
@@ -62,14 +62,7 @@ public class RestInfoEndpoint extends AbstractInternalEndpoint {
 		endpoint.produces(APPLICATION_YAML);
 		endpoint.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
-			if (ac.isAdmin()) {
-				RAMLGenerator generator = new RAMLGenerator();
-				String raml = generator.generate();
-				rc.response().putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_YAML_UTF8);
-				rc.response().end(raml);
-			} else {
-				rc.response().end();
-			}
+			adminHandler.handleRAML(ac);
 		}, false);
 
 		InternalEndpointRoute infoEndpoint = createRoute();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/RestInfoEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/RestInfoEndpoint.java
@@ -2,7 +2,6 @@ package com.gentics.mesh.core.endpoint.admin;
 
 import static com.gentics.mesh.http.HttpConstants.APPLICATION_JSON;
 import static com.gentics.mesh.http.HttpConstants.APPLICATION_YAML;
-import static com.gentics.mesh.http.HttpConstants.APPLICATION_YAML_UTF8;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.vertx.core.http.HttpMethod.GET;
 
@@ -11,13 +10,11 @@ import javax.inject.Inject;
 import com.gentics.mesh.auth.MeshAuthChain;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.example.RestInfoExamples;
-import com.gentics.mesh.generator.RAMLGenerator;
 import com.gentics.mesh.rest.InternalEndpointRoute;
 import com.gentics.mesh.router.RouterStorage;
 import com.gentics.mesh.router.route.AbstractInternalEndpoint;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.Router;
 
 public class RestInfoEndpoint extends AbstractInternalEndpoint {
@@ -52,7 +49,7 @@ public class RestInfoEndpoint extends AbstractInternalEndpoint {
 	@Override
 	public void registerEndPoints() {
 
-		secureAll();
+		secure("/raml");
 		InternalEndpointRoute endpoint = createRoute();
 		endpoint.path("/raml");
 		endpoint.method(GET);
@@ -65,6 +62,7 @@ public class RestInfoEndpoint extends AbstractInternalEndpoint {
 			adminHandler.handleRAML(ac);
 		}, false);
 
+		secure("/");
 		InternalEndpointRoute infoEndpoint = createRoute();
 		infoEndpoint.path("/");
 		infoEndpoint.description("Endpoint which returns version information");

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/RestInfoEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/RestInfoEndpoint.java
@@ -52,6 +52,7 @@ public class RestInfoEndpoint extends AbstractInternalEndpoint {
 	@Override
 	public void registerEndPoints() {
 
+		secureAll();
 		InternalEndpointRoute endpoint = createRoute();
 		endpoint.path("/raml");
 		endpoint.method(GET);
@@ -60,10 +61,15 @@ public class RestInfoEndpoint extends AbstractInternalEndpoint {
 		endpoint.exampleResponse(OK, "Not yet specified");
 		endpoint.produces(APPLICATION_YAML);
 		endpoint.blockingHandler(rc -> {
-			RAMLGenerator generator = new RAMLGenerator();
-			String raml = generator.generate();
-			rc.response().putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_YAML_UTF8);
-			rc.response().end(raml);
+			InternalActionContext ac = wrap(rc);
+			if (ac.isAdmin()) {
+				RAMLGenerator generator = new RAMLGenerator();
+				String raml = generator.generate();
+				rc.response().putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_YAML_UTF8);
+				rc.response().end(raml);
+			} else {
+				rc.response().end();
+			}
 		}, false);
 
 		InternalEndpointRoute infoEndpoint = createRoute();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/providers/StatusProvider.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/providers/StatusProvider.java
@@ -34,7 +34,7 @@ public class StatusProvider implements DebugInfoProvider {
 	@Override
 	public Flowable<DebugInfoEntry> debugInfoEntries(InternalActionContext ac) {
 		return Flowable.mergeArray(
-			getVersions(),
+			getVersions(ac),
 			getClusterStatus(),
 			getElasticSearchStatus()
 		);
@@ -52,7 +52,7 @@ public class StatusProvider implements DebugInfoProvider {
 			.toFlowable();
 	}
 
-	private Flowable<DebugInfoEntry> getVersions() {
-		return Flowable.just(DebugInfoBufferEntry.fromString("versions.json", adminHandler.getMeshServerInfoModel().toJson()));
+	private Flowable<DebugInfoEntry> getVersions(InternalActionContext ac) {
+		return Flowable.just(DebugInfoBufferEntry.fromString("versions.json", adminHandler.getMeshServerInfoModel(ac).toJson()));
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/handler/AbstractHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/handler/AbstractHandler.java
@@ -5,6 +5,8 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.gentics.mesh.context.InternalActionContext;
+import com.gentics.mesh.core.data.MeshAuthUser;
 import com.gentics.mesh.core.rest.error.GenericRestException;
 
 public class AbstractHandler {
@@ -22,4 +24,5 @@ public class AbstractHandler {
 			throw error(BAD_REQUEST, "error_request_parameter_missing", name);
 		}
 	}
+
 }

--- a/core/src/test/java/com/gentics/mesh/core/RestInfoEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/RestInfoEndpointTest.java
@@ -45,6 +45,7 @@ public class RestInfoEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testLoadRAML() {
+		grantAdminRole();
 		String raml = call(() -> client().getRAML());
 		assertNotNull(raml);
 	}

--- a/core/src/test/java/com/gentics/mesh/core/RestInfoEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/RestInfoEndpointTest.java
@@ -24,6 +24,10 @@ public class RestInfoEndpointTest extends AbstractMeshTest {
 		options().getHttpServerOptions().setServerTokens(false);
 		MeshServerInfoModel info = call(() -> client().getApiInfo());
 		assertNull(info.getMeshVersion());
+
+		grantAdminRole();
+		info = call(() -> client().getApiInfo());
+		assertNotNull(info.getMeshVersion());
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLMeshTypeTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLMeshTypeTest.java
@@ -30,6 +30,13 @@ public class GraphQLMeshTypeTest extends AbstractMeshTest {
 		assertType("mesh/mesh-no-servertoken-query");
 	}
 
+	@Test
+	public void testWithDisabledServerTokensAsAdmin() throws IOException {
+		grantAdminRole();
+		options().getHttpServerOptions().setServerTokens(false);
+		assertType("mesh/mesh-query");
+	}
+
 	public void assertType(String queryName) throws IOException {
 		GraphQLResponse response = call(
 			() -> client().graphqlQuery(PROJECT_NAME, getGraphQLQuery(queryName)));


### PR DESCRIPTION
## Abstract

Add perm checks for server tokens to always allow admin users to see the tokens.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
