### PR TITLE
Allow empty binaries without inconsistency

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,8 @@ include::content/docs/variables.adoc-include[]
 
 icon:check[] Config: It is now possible to configure the image cache directory path using the `MESH_IMAGE_CACHE_DIRECTORY` environment variable. Fixes link:https://github.com/gentics/mesh/issues/1067[#1067]
 
+icon:check[] Consistency Checks: An empty binary will no longer be considered inconsistent.
+
 [[v1.5.1]]
 == 1.5.1 (11.05.2020)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/check/BinaryCheck.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/check/BinaryCheck.java
@@ -36,7 +36,7 @@ public class BinaryCheck extends AbstractConsistencyCheck {
 			result.addInconsistency("The binary has no sha512sum", uuid, MEDIUM);
 		}
 
-		if (binary.getSize() == 0) {
+		if (binary.getSize() < 0) {
 			result.addInconsistency("The binary has no valid size specified", uuid, LOW);
 		}
 

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.NullInputStream;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.NullInputStream;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -405,4 +406,29 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 			"binary", new ImageManipulationParametersImpl().setWidth(250)),
 			NOT_FOUND, "node_error_binary_data_not_found");
 	}
+
+	@Test
+	public void testUploadEmptyFile() {
+		NodeResponse binaryNode = createBinaryNode();
+
+		InputStream emptyStream = new InputStream() {
+			@Override
+			public int read() throws IOException {
+				return -1;
+			}
+		};
+
+		client().updateNodeBinaryField(
+			PROJECT_NAME,
+			binaryNode.getUuid(),
+			binaryNode.getLanguage(),
+			binaryNode.getVersion(),
+			"binary",
+			emptyStream,
+			0,
+			"emptyFile",
+			"application/binary"
+		).blockingAwait();
+	}
+
 }


### PR DESCRIPTION
## Abstract
Uploading a binary with size 0 should not cause an inconsistency in the `/admin/consistency/check` endpoint.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
