### PR TITLE
Resolve to relative URLs when referencing a node in the same branch

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,9 +32,9 @@ icon:check[] Config: It is now possible to configure the image cache directory p
 
 icon:check[] Consistency Checks: An empty binary will no longer be considered inconsistent.
 
-[[Unreleased]]
-
 icon:check[] REST: Allow field during node field update is now validated strictly in the API. Fixes link:https://github.com/gentics/mesh/issues/975[#975]
+
+icon:check[] Core: Resolving node links to nodes in the same project and branch will now yield relative URLs, as documented.
 
 [[v1.5.1]]
 == 1.5.1 (11.05.2020)

--- a/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacer.java
+++ b/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacer.java
@@ -153,6 +153,32 @@ public class WebRootLinkReplacer {
 	 */
 	public String resolve(InternalActionContext ac, String branch, ContainerType edgeType, String uuid, LinkType type, String projectName,
 		String... languageTags) {
+		return resolve(ac, branch, edgeType, uuid, type, projectName, false, languageTags);
+	}
+
+	/**
+	 * Resolve the link to the node with uuid (in the given language) into an observable
+	 * 
+	 * @param ac
+	 * @param branch
+	 *            branch Uuid or name
+	 * @param edgeType
+	 *            edge type
+	 * @param uuid
+	 *            target uuid
+	 * @param type
+	 *            link type
+	 * @param projectName
+	 *            project name (which is used for 404 links)
+	 * @param forceAbsolute
+	 * 			  if true, the resolved link will always be absolute
+	 * @param languageTags
+	 *            optional language tags
+	 * @return observable of the rendered link
+	 */
+	public String resolve(InternalActionContext ac, String branch, ContainerType edgeType, String uuid, LinkType type, String projectName,
+		boolean forceAbsolute,
+		String... languageTags) {
 		// Get rid of additional whitespaces
 		uuid = uuid.trim();
 		Node node = boot.meshRoot().findNodeByUuid(uuid);
@@ -173,7 +199,7 @@ public class WebRootLinkReplacer {
 				throw error(BAD_REQUEST, "Cannot render link with type " + type);
 			}
 		}
-		return resolve(ac, branch, edgeType, node, type, languageTags);
+		return resolve(ac, branch, edgeType, node, type, forceAbsolute, languageTags);
 	}
 
 	/**
@@ -194,6 +220,31 @@ public class WebRootLinkReplacer {
 	 * @return observable of the rendered link
 	 */
 	public String resolve(InternalActionContext ac, String branchNameOrUuid, ContainerType edgeType, Node node, LinkType type,
+		String... languageTags) {
+		return resolve(ac, branchNameOrUuid, edgeType, node, type, false, languageTags);
+	}
+
+	/**
+	 * Resolve the link to the given node.
+	 * 
+	 * @param ac
+	 * @param branchNameOrUuid
+	 *            Branch UUID or name which will be used to render the path to the linked node. If this is invalid, the default branch of the target node will
+	 *            be used.
+	 * @param edgeType
+	 *            edge type
+	 * @param node
+	 *            target node
+	 * @param type
+	 *            link type
+	 * @param forceAbsolute
+	 * 			  if true, the resolved link will always be absolute
+	 * @param languageTags
+	 *            target language
+	 * @return observable of the rendered link
+	 */
+	public String resolve(InternalActionContext ac, String branchNameOrUuid, ContainerType edgeType, Node node, LinkType type,
+		boolean forceAbsolute,
 		String... languageTags) {
 		String defaultLanguage = options.getDefaultLanguage();
 		if (languageTags == null || languageTags.length == 0) {
@@ -229,7 +280,7 @@ public class WebRootLinkReplacer {
 		case SHORT:
 			// We also try to append the scheme and authority part of the uri for foreign nodes.
 			// Otherwise that part will be empty and thus the link relative.
-			if (ac.getBranch().equals(branch)) {
+			if (!forceAbsolute && ac.getProject() != null && ac.getBranch().equals(branch)) {
 				return path;
 			} else {
 				return generateSchemeAuthorityForNode(node, branch) + path;

--- a/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacer.java
+++ b/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacer.java
@@ -229,7 +229,11 @@ public class WebRootLinkReplacer {
 		case SHORT:
 			// We also try to append the scheme and authority part of the uri for foreign nodes.
 			// Otherwise that part will be empty and thus the link relative.
-			return generateSchemeAuthorityForNode(node, branch) + path;
+			if (ac.getBranch().equals(branch)) {
+				return path;
+			} else {
+				return generateSchemeAuthorityForNode(node, branch) + path;
+			}
 		case MEDIUM:
 			return "/" + node.getProject().getName() + path;
 		case FULL:

--- a/core/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
@@ -910,7 +910,7 @@ public class NodeImpl extends AbstractGenericFieldContainerVertex<NodeResponse, 
 
 			// Path
 			WebRootLinkReplacer linkReplacer = mesh().webRootLinkReplacer();
-			String path = linkReplacer.resolve(ac, branchUuid, type, getUuid(), linkType, getProject().getName(), restNode.getLanguage());
+			String path = linkReplacer.resolve(ac, branchUuid, type, getUuid(), linkType, getProject().getName(), true, restNode.getLanguage());
 			restNode.setPath(path);
 
 			// languagePaths
@@ -928,7 +928,7 @@ public class NodeImpl extends AbstractGenericFieldContainerVertex<NodeResponse, 
 		WebRootLinkReplacer linkReplacer = mesh().webRootLinkReplacer();
 		for (GraphFieldContainer currentFieldContainer : getGraphFieldContainers(branch, forVersion(versioiningParameters.getVersion()))) {
 			String currLanguage = currentFieldContainer.getLanguageTag();
-			String languagePath = linkReplacer.resolve(ac, branchUuid, type, this, linkType, currLanguage);
+			String languagePath = linkReplacer.resolve(ac, branchUuid, type, this, linkType, true, currLanguage);
 			languagePaths.put(currLanguage, languagePath);
 		}
 		return languagePaths;

--- a/core/src/test/java/com/gentics/mesh/linkrenderer/BranchLinkRendererTest.java
+++ b/core/src/test/java/com/gentics/mesh/linkrenderer/BranchLinkRendererTest.java
@@ -188,14 +188,15 @@ public class BranchLinkRendererTest extends AbstractMeshTest {
 		VersioningParametersImpl versionParams = new VersioningParametersImpl();
 		versionParams.setBranch(branchUuid);
 		NodeResponse response = call(() -> client().findNodeByUuid(projectName(), contentUuid, nodeParams, versionParams));
-		String expectedPath = getPrefix() + "/News/News%20Overview.en.html";
-		assertEquals("The path did not match", expectedPath, response.getPath());
+		String expectedPath = "/News/News%20Overview.en.html";
+		String expectedPathWithPrefix = getPrefix() + expectedPath;
+		assertEquals("The path did not match", expectedPathWithPrefix, response.getPath());
 
 		// Test resolving the path using a local node to the created branch
 		NodeResponse response2 = call(() -> client().findNodeByUuid(projectName(), localNodeUuid, nodeParams, versionParams));
 		String expectedPath2 = getPrefix() + "/News/localNode";
 		assertEquals("The path did not match", expectedPath2, response2.getPath());
-		assertEquals("Content2: " + expectedPath, response2.getFields().getStringField("content").getString());
+		assertEquals("Content2: " + getPathPrefix() + expectedPath, response2.getFields().getStringField("content").getString());
 	}
 
 	private String getPrefix() {
@@ -203,9 +204,17 @@ public class BranchLinkRendererTest extends AbstractMeshTest {
 		if (!StringUtils.isEmpty(hostname)) {
 			prefix = String.format("http%s://%s", ssl ? "s" : "", hostname);
 		}
-		if (!StringUtils.isEmpty(pathPrefix)) {
-			prefix = prefix + pathPrefix;
-		}
+		prefix = prefix + getPathPrefix();
 		return prefix;
 	}
+
+	private String getPathPrefix() {
+		if (pathPrefix == null) {
+			return "";
+		} else {
+			return pathPrefix;
+		}
+	}
+
+
 }

--- a/core/src/test/java/com/gentics/mesh/linkrenderer/ResolveLinksEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/linkrenderer/ResolveLinksEndpointTest.java
@@ -1,0 +1,52 @@
+package com.gentics.mesh.linkrenderer;
+
+import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gentics.mesh.core.rest.branch.BranchResponse;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.field.StringField;
+import com.gentics.mesh.parameter.LinkType;
+import com.gentics.mesh.parameter.impl.NodeParametersImpl;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+@MeshTestSetting(testSize = FULL, startServer = true)
+public class ResolveLinksEndpointTest extends AbstractMeshTest {
+	private NodeResponse nodeWithReference;
+
+	@Before
+	public void setUp() throws Exception {
+		BranchResponse branch = getBranch();
+		branch.setSsl(true);
+		branch.setHostname("gentics.com");
+		client().updateBranch(PROJECT_NAME, branch.getUuid(), branch.toRequest()).blockingAwait();
+		nodeWithReference = createNode("name", StringField.of("{{mesh.link('" + folderUuid() + "')}}"));
+	}
+
+	@Test
+	public void testShortLink() {
+		// scheme and hostname should not be appended on references to nodes of the same branch
+		assertThat(getNodeWithReference(LinkType.SHORT)).hasStringField("name", "/News");
+	}
+
+	@Test
+	public void testMediumLink() {
+		// scheme and hostname should not be appended on references to nodes of the same branch
+		assertThat(getNodeWithReference(LinkType.MEDIUM)).hasStringField("name", "/dummy/News");
+	}
+
+	@Test
+	public void testFullLink() {
+		// scheme and hostname should not be appended on references to nodes of the same branch
+		assertThat(getNodeWithReference(LinkType.FULL)).hasStringField("name", "/api/v2/dummy/webroot/News");
+	}
+
+	private NodeResponse getNodeWithReference(LinkType linkType) {
+		return client().findNodeByUuid(PROJECT_NAME, nodeWithReference.getUuid(), new NodeParametersImpl().setResolveLinks(linkType)).blockingGet();
+	}
+}

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -146,6 +146,10 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		return client().createBranch(PROJECT_NAME, request).blockingGet();
 	}
 
+	default BranchResponse getBranch() {
+		return client().findBranchByUuid(PROJECT_NAME, initialBranchUuid()).blockingGet();
+	}
+
 	default String roleUuid() {
 		return data().getUserInfo().getRoleUuid();
 	}

--- a/doc/src/main/docs/features.asciidoc
+++ b/doc/src/main/docs/features.asciidoc
@@ -954,9 +954,6 @@ The links will automatically start with `https://` if the ssl flag of the branch
 
 NOTE: Foreign links can only be rendered using the *?resolveLinks=short* type. Other resolver types do not support this mechanism.
 
-NOTE: Foreign links currently don't contain any branch reference thus it is not possible to render links to a foreign node within a specific branch. 
-      Instead the foreign link resolving mechanism will automatically use the latest branch of the node's project to render the links.
-
 [[linkresolvingbranches]]
 === Specifying Branches
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/branch/BranchResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/branch/BranchResponse.java
@@ -151,4 +151,12 @@ public class BranchResponse extends AbstractGenericRestResponse {
 		this.pathPrefix = pathPrefix;
 		return this;
 	}
+
+	public BranchUpdateRequest toRequest() {
+		return new BranchUpdateRequest()
+			.setName(getName())
+			.setPathPrefix(getPathPrefix())
+			.setHostname(getHostname())
+			.setSsl(getSsl());
+	}
 }


### PR DESCRIPTION
## Abstract
Resolving mesh links to nodes in the same project and branch should return a relative URL as already documented here: https://getmesh.io/docs/features/#crossdomainlinks
## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
