### PR TITLE
Add branchUuid to node search index documents

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,11 @@ include::content/docs/variables.adoc-include[]
 
 * The Mesh Server will require Java 11 with the release of 2.0.0. The runtime support for Java 8 will be dropped. The Mesh Java REST client will still be usable with Java 8.
 
+[[pending]]
+== Pending
+
+icon:plus[] Elasticsearch: The `branchUuid` property was added to documents in the search index.
+
 [[v1.5.2]]
 == 1.5.2 (22.06.2020)
 

--- a/core/src/test/java/com/gentics/mesh/search/raw/NodeRawSearchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/raw/NodeRawSearchEndpointTest.java
@@ -7,6 +7,7 @@ import static com.gentics.mesh.test.TestSize.FULL;
 import static com.gentics.mesh.test.context.ElasticsearchTestMode.CONTAINER_ES6;
 import static com.gentics.mesh.test.context.MeshTestHelper.getSimpleQuery;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 
@@ -26,6 +27,7 @@ import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @MeshTestSetting(elasticsearch = CONTAINER_ES6, startServer = true, testSize = FULL)
@@ -75,10 +77,16 @@ public class NodeRawSearchEndpointTest extends AbstractMeshTest {
 			path = "responses[0].hits.total.value";
 		}
 		assertThat(response).has(path, "2", "Not exactly two item was found.");
-		String uuid1 = response.getJsonArray("responses").getJsonObject(0).getJsonObject("hits").getJsonArray("hits").getJsonObject(0)
-			.getString("_id");
-		String uuid2 = response.getJsonArray("responses").getJsonObject(0).getJsonObject("hits").getJsonArray("hits").getJsonObject(1)
-			.getString("_id");
+		JsonArray hits = response.getJsonArray("responses").getJsonObject(0).getJsonObject("hits").getJsonArray("hits");
+
+		JsonObject hitOne = hits.getJsonObject(0);
+		String uuid1 = hitOne.getString("_id");
+		assertEquals(initialBranchUuid(), hitOne.getJsonObject("_source").getString("branchUuid"));
+
+		JsonObject hitTwo = hits.getJsonObject(1);
+		String uuid2 = hitTwo.getString("_id");
+		assertEquals(initialBranchUuid(), hitTwo.getJsonObject("_source").getString("branchUuid"));
+
 		assertThat(Arrays.asList(uuid1, uuid2)).containsExactlyInAnyOrder(nodeA.getUuid() + "-en", nodeB.getUuid() + "-en");
 
 	}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProvider.java
@@ -146,6 +146,7 @@ public class NodeContainerMappingProvider extends AbstractMappingProvider {
 		displayFieldMappingProperties.put("value", trigramTextType());
 		displayFieldMapping.put("properties", displayFieldMappingProperties);
 		typeProperties.put("displayField", displayFieldMapping);
+		typeProperties.put("branchUuid", notAnalyzedType(KEYWORD));
 
 		// .parentNode
 		JsonObject parentNodeMapping = new JsonObject();

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerTransformer.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerTransformer.java
@@ -528,6 +528,7 @@ public class NodeContainerTransformer extends AbstractTransformer<NodeGraphField
 		displayField.put("key", container.getSchemaContainerVersion().getSchema().getDisplayField());
 		displayField.put("value", container.getDisplayFieldValue());
 		document.put("displayField", displayField);
+		document.put("branchUuid", branchUuid);
 		document.put(VERSION_KEY, generateVersion(container, branchUuid, type));
 		return document;
 	}


### PR DESCRIPTION
## Abstract

Adds extra field to search index so that the search plugin can better identify branches for search hits.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
