### PR TITLE
Add user admin flag handling

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,7 +34,8 @@ icon:check[] Permissions: Various flaws in the admin permission handling have be
 ____
 
 * The `resetAdminPassword` command line operation will now also re-create the admin user if it can't be found.
-* The admin permission is no longer bound to the `admin` role. Instead a dedicated `admin` flag can be set for users in order to grant admin privileges on a per-user basis. Mesh will automatically set the user admin flag for all users which have access to the role with the name `admin`. The permissions of the `admin` role will not be changed.
+* The admin permission is no longer bound to the `admin` role. Instead a dedicated `admin` flag can be set for users in order to grant admin privileges on a per-user basis. Mesh will automatically set the user admin flag for all users which have access to the role with the name `admin`. The permissions of the `admin` role will not be changed. It is advised to remove the admin group and admin role since those are no longer needed to cover admin privileges.
+* The admin user flag is also part of the user principal and can be used by plugins to check for admin privileges.
 * Admin endpoints will now check for the `admin` user flag and disregard any role that has been assigned to the user.
 ____
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,16 @@ include::content/docs/variables.adoc-include[]
 [[pending]]
 == Pending
 
+icon:check[] Permissions: Various flaws in the admin permission handling have been fixed.
+
+[quote]
+____
+
+* The `resetAdminPassword` command line operation will now also re-create the admin user if it can't be found.
+* The admin permission is no longer bound to the `admin` role. Instead a dedicated `admin` flag can be set for users in order to grant admin privileges on a per-user basis. Mesh will automatically set the user admin flag for all users which have access to the role with the name `admin`. The permissions of the `admin` role will not be changed.
+* Admin endpoints will now check for the `admin` user flag and disregard any role that has been assigned to the user.
+____
+
 icon:plus[] Elasticsearch: The `branchUuid` property was added to documents in the search index.
 
 icon:check[] Security: A minor security issue has been fixed.

--- a/api/src/main/java/com/gentics/mesh/cli/MeshCLI.java
+++ b/api/src/main/java/com/gentics/mesh/cli/MeshCLI.java
@@ -59,7 +59,7 @@ public final class MeshCLI {
 
 		// TODO remove this and replace it by an option which will read a new password from stdin
 		Option resetAdminPassword = new Option(RESET_ADMIN_PASSWORD, true,
-			"Reset the admin password. It is advised to change the password once again after the reset has been performed.");
+			"Reset the admin password. It is advised to change the password once again after the reset has been performed. The command will also recreate the admin user if it can't be found in the system.");
 		resetAdminPassword.setArgName("password");
 		options.addOption(resetAdminPassword);
 

--- a/common/src/main/java/com/gentics/mesh/context/AbstractInternalActionContext.java
+++ b/common/src/main/java/com/gentics/mesh/context/AbstractInternalActionContext.java
@@ -86,8 +86,7 @@ public abstract class AbstractInternalActionContext extends AbstractActionContex
 		if (user == null) {
 			return false;
 		}
-
-		return user.hasAdminRole();
+		return user.isAdmin();
 	}
 
 }

--- a/common/src/main/java/com/gentics/mesh/core/data/User.java
+++ b/common/src/main/java/com/gentics/mesh/core/data/User.java
@@ -372,13 +372,6 @@ public interface User extends MeshCoreVertex<UserResponse, User>, ReferenceableE
 	}
 
 	/**
-	 * Check whether the admin role was assigned to the user.
-	 *
-	 * @return
-	 */
-	boolean hasAdminRole();
-
-	/**
 	 * Check whether the user is allowed to read the given node. Internally this check the currently configured version scope and check for
 	 * {@link GraphPermission#READ_PERM} or {@link GraphPermission#READ_PUBLISHED_PERM}.
 	 *
@@ -547,5 +540,19 @@ public interface User extends MeshCoreVertex<UserResponse, User>, ReferenceableE
 	 * @return
 	 */
 	MeshAuthUser toAuthUser();
+
+	/**
+	 * Return the admin flag of the user.
+	 * 
+	 * @return
+	 */
+	boolean isAdmin();
+
+	/**
+	 * Set the admin flag for the user.
+	 * 
+	 * @param flag
+	 */
+	void setAdmin(boolean flag);
 
 }

--- a/common/src/main/java/com/gentics/mesh/core/verticle/handler/HandlerUtilities.java
+++ b/common/src/main/java/com/gentics/mesh/core/verticle/handler/HandlerUtilities.java
@@ -325,7 +325,7 @@ public class HandlerUtilities {
 
 	public void requiresAdminRole(RoutingContext context) {
 		InternalRoutingActionContextImpl rc = new InternalRoutingActionContextImpl(context);
-		if (database.tx(() -> !rc.getUser().hasAdminRole())) {
+		if (database.tx(() -> !rc.getUser().isAdmin())) {
 			throw error(FORBIDDEN, "error_admin_permission_required");
 		} else {
 			context.next();

--- a/common/src/main/java/com/gentics/mesh/example/UserExamples.java
+++ b/common/src/main/java/com/gentics/mesh/example/UserExamples.java
@@ -35,6 +35,7 @@ public class UserExamples extends AbstractExamples {
 		user2.setEdited(createNewTimestamp());
 		user2.setCreated(createOldTimestamp());
 		user2.setEmailAddress("j.roe@nowhere.com");
+		user2.setAdmin(true);
 		user2.getGroups().add(new GroupReference().setName("webclient").setUuid(USER_WEBCLIENT_UUID));
 		user2.getGroups().add(new GroupReference().setName("editors").setUuid(USER_EDITOR_UUID));
 		user2.setEnabled(true);

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -98,6 +98,7 @@ user_permission_path_missing=Es wurde kein Pfad angegeben.
 user_error_missing_old_password=Um das Passwort zu aktualisieren muss das aktuelle Password angegeben werden.
 user_error_password_check_failed=Das angegebene Passwort stimmt nicht mit dem aktuell verwendeten Password überein.
 user_error_provided_token_invalid=Der angegebene Token ist ungültig.
+user_error_admin_privilege_needed_for_admin_flag=Die Admin Berechtigung ist notwendig um das Admin Feld zu setzen.
 
 role_deleted=Rolle "{0}" wurde gelöscht.
 role_not_found=Rolle mit uuid "{0}" konnte nicht gefunden werden.

--- a/common/src/main/resources/i18n/translations_en.properties
+++ b/common/src/main/resources/i18n/translations_en.properties
@@ -97,6 +97,7 @@ user_permission_path_missing=No path was specified.
 user_error_missing_old_password=In order to update the current password the original old password must be specified.
 user_error_password_check_failed=The provided old password did not match up with the currently stored password
 user_error_provided_token_invalid=The provided token is invalid.
+user_error_admin_privilege_needed_for_admin_flag=The admin privilege is needed to set the admin flag.
 
 role_deleted=Role "{0}" was deleted.
 role_not_found=Role with uuid "{0}" could not be found.

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/HighLevelChangesList.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/HighLevelChangesList.java
@@ -9,6 +9,7 @@ import javax.inject.Singleton;
 import com.gentics.mesh.changelog.highlevel.change.ExtractPlainText;
 import com.gentics.mesh.changelog.highlevel.change.FixNodeVersionOrder;
 import com.gentics.mesh.changelog.highlevel.change.RestructureWebrootIndex;
+import com.gentics.mesh.changelog.highlevel.change.SetAdminUserFlag;
 import com.gentics.mesh.core.data.changelog.HighLevelChange;
 
 /**
@@ -27,6 +28,9 @@ public class HighLevelChangesList {
 	public FixNodeVersionOrder fixNodeVersionOrder;
 
 	@Inject
+	public SetAdminUserFlag setAdminUserFlag;
+
+	@Inject
 	public HighLevelChangesList() {
 	}
 
@@ -34,7 +38,8 @@ public class HighLevelChangesList {
 		return Arrays.asList(
 			restructureWebroot,
 			plainText,
-			fixNodeVersionOrder
+			fixNodeVersionOrder,
+			setAdminUserFlag
 		// ADD NEW CHANGES HERE!
 		);
 	}

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/SetAdminUserFlag.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/SetAdminUserFlag.java
@@ -1,0 +1,53 @@
+package com.gentics.mesh.changelog.highlevel.change;
+
+import javax.inject.Inject;
+
+import com.gentics.mesh.changelog.highlevel.AbstractHighLevelChange;
+import com.gentics.mesh.cli.BootstrapInitializer;
+import com.gentics.mesh.core.data.Group;
+import com.gentics.mesh.core.data.Role;
+import com.gentics.mesh.core.data.User;
+
+import dagger.Lazy;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class SetAdminUserFlag extends AbstractHighLevelChange {
+
+	private static final Logger log = LoggerFactory.getLogger(SetAdminUserFlag.class);
+
+	private final Lazy<BootstrapInitializer> boot;
+
+	@Inject
+	public SetAdminUserFlag(Lazy<BootstrapInitializer> boot) {
+		this.boot = boot;
+	}
+
+	@Override
+	public String getUuid() {
+		return "21093BF213A244B484F3369A14AE7076";
+	}
+
+	@Override
+	public String getName() {
+		return "AdminUserFlagUpdater";
+	}
+
+	@Override
+	public String getDescription() {
+		return "This change assigns the admin user flag to all users which have access to the admin role";
+	}
+
+	@Override
+	public void apply() {
+		log.info("Applying change: " + getName());
+		for (Role role : boot.get().roleRoot().findAll()) {
+			for (Group group : role.getGroups()) {
+				for (User user : group.getUsers()) {
+					log.info("Setting admin flag for user " + user.getUsername());
+					user.setAdmin(true);
+				}
+			}
+		}
+	}
+}

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/SetAdminUserFlag.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/SetAdminUserFlag.java
@@ -42,6 +42,9 @@ public class SetAdminUserFlag extends AbstractHighLevelChange {
 	public void apply() {
 		log.info("Applying change: " + getName());
 		for (Role role : boot.get().roleRoot().findAll()) {
+			if (!"admin".equals(role.getName())) {
+				continue;
+			}
 			for (Group group : role.getGroups()) {
 				for (User user : group.getUsers()) {
 					log.info("Setting admin flag for user " + user.getUsername());

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -593,7 +593,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				} else {
 					// Recreate the user if it can't be found.
 					UserRoot userRoot = meshRoot.getUserRoot();
-					adminUser = userRoot.create(ADMIN_USERNAME, adminUser);
+					adminUser = userRoot.create(ADMIN_USERNAME, null);
 					adminUser.setCreator(adminUser);
 					adminUser.setCreationTimestamp();
 					adminUser.setEditor(adminUser);

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -127,6 +127,8 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 
 	private static Logger log = LoggerFactory.getLogger(BootstrapInitializer.class);
 
+	private static final String ADMIN_USERNAME = "admin";
+
 	@Inject
 	public ServerSchemaStorage schemaStorage;
 
@@ -584,9 +586,20 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 		String password = configuration.getAdminPassword();
 		if (password != null) {
 			db.tx(tx -> {
-				User adminUser = userRoot().findByName("admin");
+				User adminUser = userRoot().findByName(ADMIN_USERNAME);
 				if (adminUser != null) {
 					adminUser.setPassword(password);
+					adminUser.setAdmin(true);
+				} else {
+					// Recreate the user if it can't be found.
+					UserRoot userRoot = meshRoot.getUserRoot();
+					adminUser = userRoot.create(ADMIN_USERNAME, adminUser);
+					adminUser.setCreator(adminUser);
+					adminUser.setCreationTimestamp();
+					adminUser.setEditor(adminUser);
+					adminUser.setLastEditedTimestamp();
+					adminUser.setPassword(password);
+					adminUser.setAdmin(true);
 				}
 				tx.success();
 			});
@@ -844,10 +857,10 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 			SchemaContainerRoot schemaContainerRoot = meshRoot.getSchemaContainerRoot();
 
 			// Verify that an admin user exists
-			User adminUser = userRoot.findByUsername("admin");
+			User adminUser = userRoot.findByUsername(ADMIN_USERNAME);
 			if (adminUser == null) {
-				adminUser = userRoot.create("admin", adminUser);
-
+				adminUser = userRoot.create(ADMIN_USERNAME, adminUser);
+				adminUser.setAdmin(true);
 				adminUser.setCreator(adminUser);
 				adminUser.setCreationTimestamp();
 				adminUser.setEditor(adminUser);

--- a/core/src/main/java/com/gentics/mesh/context/impl/NodeMigrationActionContextImpl.java
+++ b/core/src/main/java/com/gentics/mesh/context/impl/NodeMigrationActionContextImpl.java
@@ -293,11 +293,6 @@ public class NodeMigrationActionContextImpl extends AbstractInternalActionContex
 			}
 
 			@Override
-			public boolean hasAdminRole() {
-				return false;
-			}
-
-			@Override
 			public String getUsername() {
 				return "node_migration";
 			}
@@ -364,6 +359,16 @@ public class NodeMigrationActionContextImpl extends AbstractInternalActionContex
 			@Override
 			public TraversalResult<? extends Group> getGroups() {
 				return new TraversalResult<>(() -> Collections.emptyIterator());
+			}
+
+			@Override
+			public boolean isAdmin() {
+				return true;
+			}
+
+			@Override
+			public void setAdmin(boolean flag) {
+
 			}
 
 			@Override

--- a/core/src/main/java/com/gentics/mesh/context/impl/NodeMigrationActionContextImpl.java
+++ b/core/src/main/java/com/gentics/mesh/context/impl/NodeMigrationActionContextImpl.java
@@ -363,7 +363,7 @@ public class NodeMigrationActionContextImpl extends AbstractInternalActionContex
 
 			@Override
 			public boolean isAdmin() {
-				return true;
+				return false;
 			}
 
 			@Override

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/MeshAuthUserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/MeshAuthUserImpl.java
@@ -50,6 +50,7 @@ public class MeshAuthUserImpl extends UserImpl implements MeshAuthUser {
 			user.put("firstname", getFirstname());
 			user.put("lastname", getLastname());
 			user.put("emailAddress", getEmailAddress());
+			user.put("admin", isAdmin());
 
 			JsonArray rolesArray = new JsonArray();
 			user.put("roles", rolesArray);

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -262,7 +262,7 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 			.sorted()
 			.collect(Collectors.joining());
 
-		return ETag.hash(roles);
+		return ETag.hash(roles + String.valueOf(isAdmin()));
 	}
 
 	@Override
@@ -664,6 +664,7 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 		for (Group group : getGroups()) {
 			keyBuilder.append(group.getUuid());
 		}
+		keyBuilder.append(String.valueOf(isAdmin()));
 
 		return keyBuilder.toString();
 	}

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -333,6 +333,12 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 		if (permissionCache.hasPermission(id(), permission, elementId)) {
 			return true;
 		} else {
+			// Admin users have all permissions
+			if (isAdmin()) {
+				permissionCache.store(id(), permission, elementId);
+				return true;
+			}
+
 			FramedGraph graph = getGraph();
 			// Find all roles that are assigned to the user by checking the
 			// shortcut edge from the index

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -335,7 +335,9 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 		} else {
 			// Admin users have all permissions
 			if (isAdmin()) {
-				permissionCache.store(id(), permission, elementId);
+				for (GraphPermission perm : GraphPermission.values()) {
+					permissionCache.store(id(), perm, elementId);
+				}
 				return true;
 			}
 
@@ -570,6 +572,8 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 		if (shouldUpdate(requestModel.getAdmin(), isAdmin())) {
 			if (ac.getUser().isAdmin()) {
 				setAdmin(requestModel.getAdmin());
+				// Permissions need to be purged
+				mesh().permissionCache().clear();
 			} else {
 				throw error(FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
 			}

--- a/core/src/main/java/com/gentics/mesh/core/data/root/impl/UserRootImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/root/impl/UserRootImpl.java
@@ -159,6 +159,15 @@ public class UserRootImpl extends AbstractRootVertex<User> implements UserRoot {
 			user.setForcedPasswordChange(forcedPasswordChange);
 		}
 
+		Boolean adminFlag = requestModel.getAdmin();
+		if (adminFlag != null) {
+			if (requestUser.isAdmin()) {
+				user.setAdmin(adminFlag);
+			} else {
+				throw error(FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
+			}
+		}
+
 		requestUser.inheritRolePermissions(this, user);
 		ExpandableNode reference = requestModel.getNodeReference();
 		batch.add(user.onCreated());

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
@@ -114,7 +114,7 @@ public class AdminHandler extends AbstractHandler {
 	 */
 	public void handleBackup(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			backup();
@@ -169,7 +169,7 @@ public class AdminHandler extends AbstractHandler {
 		}
 
 		db.tx((tx) -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 		});
@@ -221,7 +221,7 @@ public class AdminHandler extends AbstractHandler {
 	 */
 	public void handleExport(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			String exportDir = options.getStorageOptions().getExportDirectory();
@@ -240,7 +240,7 @@ public class AdminHandler extends AbstractHandler {
 	 */
 	public void handleImport(InternalActionContext ac) {
 		db.tx(tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 		});
@@ -265,7 +265,7 @@ public class AdminHandler extends AbstractHandler {
 	public void handleClusterStatus(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
 			User user = ac.getUser();
-			if (user != null && !user.hasAdminRole()) {
+			if (user != null && !user.isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			if (options.getClusterOptions() != null && options.getClusterOptions().isEnabled()) {
@@ -311,7 +311,7 @@ public class AdminHandler extends AbstractHandler {
 	public void handleLoadClusterConfig(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
 			User user = ac.getUser();
-			if (user != null && !user.hasAdminRole()) {
+			if (user != null && !user.isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			return db.loadClusterConfig();
@@ -322,7 +322,7 @@ public class AdminHandler extends AbstractHandler {
 		try (WriteLock lock = writeLock.lock(ac)) {
 			utils.syncTx(ac, tx -> {
 				User user = ac.getUser();
-				if (user != null && !user.hasAdminRole()) {
+				if (user != null && !user.isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
 				ClusterConfigRequest request = ac.fromJson(ClusterConfigRequest.class);
@@ -335,7 +335,7 @@ public class AdminHandler extends AbstractHandler {
 	public void handleLoadCoordinationMaster(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
 			User user = ac.getUser();
-			if (user != null && !user.hasAdminRole()) {
+			if (user != null && !user.isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			MasterServer master = coordinator.getMasterMember();
@@ -350,7 +350,7 @@ public class AdminHandler extends AbstractHandler {
 		try (WriteLock lock = writeLock.lock(ac)) {
 			utils.syncTx(ac, tx -> {
 				User user = ac.getUser();
-				if (user != null && !user.hasAdminRole()) {
+				if (user != null && !user.isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
 				if (coordinator.isElectable()) {
@@ -373,7 +373,7 @@ public class AdminHandler extends AbstractHandler {
 	public void handleLoadCoordinationConfig(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
 			User user = ac.getUser();
-			if (user != null && !user.hasAdminRole()) {
+			if (user != null && !user.isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			return coordinator.loadConfig();
@@ -384,7 +384,7 @@ public class AdminHandler extends AbstractHandler {
 		try (WriteLock lock = writeLock.lock(ac)) {
 			utils.syncTx(ac, tx -> {
 				User user = ac.getUser();
-				if (user != null && !user.hasAdminRole()) {
+				if (user != null && !user.isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
 				CoordinatorConfig request = ac.fromJson(CoordinatorConfig.class);

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/JobHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/JobHandler.java
@@ -56,7 +56,7 @@ public class JobHandler extends AbstractCrudHandler<Job, JobResponse> {
 	@Override
 	public void handleReadList(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			JobRoot root = boot.jobRoot();
@@ -82,7 +82,7 @@ public class JobHandler extends AbstractCrudHandler<Job, JobResponse> {
 
 		try (WriteLock lock = writeLock.lock(ac)) {
 			utils.syncTx(ac, () -> {
-				if (!ac.getUser().hasAdminRole()) {
+				if (!ac.getUser().isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
 				JobRoot root = boot.jobRoot();
@@ -104,7 +104,7 @@ public class JobHandler extends AbstractCrudHandler<Job, JobResponse> {
 	public void handleRead(InternalActionContext ac, String uuid) {
 		validateParameter(uuid, "uuid");
 		utils.syncTx(ac, (tx) -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			JobRoot root = boot.jobRoot();
@@ -132,7 +132,7 @@ public class JobHandler extends AbstractCrudHandler<Job, JobResponse> {
 	 */
 	public void handleResetJob(InternalActionContext ac, String uuid) {
 		utils.syncTx(ac, (tx) -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			JobRoot root = boot.jobRoot();
@@ -148,7 +148,7 @@ public class JobHandler extends AbstractCrudHandler<Job, JobResponse> {
 		validateParameter(uuid, "uuid");
 		try (WriteLock lock = writeLock.lock(ac)) {
 			utils.syncTx(ac, (tx) -> {
-				if (!ac.getUser().hasAdminRole()) {
+				if (!ac.getUser().isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
 				JobRoot root = boot.jobRoot();
@@ -172,7 +172,7 @@ public class JobHandler extends AbstractCrudHandler<Job, JobResponse> {
 	 */
 	public void handleInvokeJobWorker(InternalActionContext ac) {
 		utils.syncTx(ac, (tx) -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			MeshEvent.triggerJobWorker(boot.mesh());

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/ConsistencyCheckHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/ConsistencyCheckHandler.java
@@ -12,7 +12,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.endpoint.admin.consistency.check.BinaryCheck;
 import com.gentics.mesh.core.endpoint.admin.consistency.check.BranchCheck;
@@ -106,7 +105,7 @@ public class ConsistencyCheckHandler extends AbstractHandler {
 
 	private void invokeAction(InternalActionContext ac, boolean attemptRepair) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			return checkConsistency(attemptRepair).runInExistingTx(tx);

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/DebugInfoHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/DebugInfoHandler.java
@@ -42,7 +42,7 @@ public class DebugInfoHandler {
 
 	public void handle(RoutingContext ac) {
 		InternalRoutingActionContextImpl iac = new InternalRoutingActionContextImpl(ac);
-		if (db.tx(() -> !iac.getUser().hasAdminRole())) {
+		if (db.tx(() -> !iac.getUser().isAdmin())) {
 			throw error(FORBIDDEN, "error_admin_permission_required");
 		}
 		setHeaders(ac);

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/plugin/PluginHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/plugin/PluginHandler.java
@@ -54,7 +54,7 @@ public class PluginHandler extends AbstractHandler {
 
 	public void handleRead(InternalActionContext ac, String id) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			PluginWrapper pluginWrapper = manager.getPlugin(id);
@@ -71,7 +71,7 @@ public class PluginHandler extends AbstractHandler {
 
 	public void handleDeploy(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			PluginDeploymentRequest requestModel = JsonUtil.readValue(ac.getBodyAsString(), PluginDeploymentRequest.class);
@@ -95,7 +95,7 @@ public class PluginHandler extends AbstractHandler {
 
 	public void handleUndeploy(InternalActionContext ac, String pluginId) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			if (StringUtils.isEmpty(pluginId)) {
@@ -112,7 +112,7 @@ public class PluginHandler extends AbstractHandler {
 
 	public void handleReadList(InternalActionContext ac) {
 		utils.syncTx(ac, tx -> {
-			if (!ac.getUser().hasAdminRole()) {
+			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
 			List<MeshPlugin> startedPlugins = manager.getStartedMeshPlugins();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
@@ -72,7 +72,7 @@ public class ProjectCrudHandler extends AbstractCrudHandler<Project, ProjectResp
 
 		try (WriteLock lock = writeLock.lock(ac)) {
 			utils.syncTx(ac, (tx) -> {
-				if (!ac.getUser().hasAdminRole()) {
+				if (!ac.getUser().isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
 				RootVertex<Project> root = getRootVertex(ac);

--- a/core/src/test/java/com/gentics/mesh/core/RestInfoEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/RestInfoEndpointTest.java
@@ -25,7 +25,7 @@ public class RestInfoEndpointTest extends AbstractMeshTest {
 		MeshServerInfoModel info = call(() -> client().getApiInfo());
 		assertNull(info.getMeshVersion());
 
-		grantAdminRole();
+		grantAdmin();
 		info = call(() -> client().getApiInfo());
 		assertNotNull(info.getMeshVersion());
 	}
@@ -45,7 +45,7 @@ public class RestInfoEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testLoadRAML() {
-		grantAdminRole();
+		grantAdmin();
 		String raml = call(() -> client().getRAML());
 		assertNotNull(raml);
 	}

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupClusteredTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupClusteredTest.java
@@ -35,7 +35,7 @@ public class AdminEndpointBackupClusteredTest extends AbstractMeshTest {
 		final String backupDir = testContext.getOptions().getStorageOptions().getBackupDirectory();
 
 		assertFilesInDir(backupDir, 0);
-		grantAdminRole();
+		grantAdmin();
 		GenericMessageResponse message = call(() -> client().invokeBackup());
 		assertThat(message).matches("backup_finished");
 		assertFilesInDir(backupDir, 1);

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupFail2LocalTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupFail2LocalTest.java
@@ -28,7 +28,7 @@ public class AdminEndpointBackupFail2LocalTest extends AbstractMeshTest {
 		testContext.getOptions().getStorageOptions().setBackupDirectory(testFile.getAbsolutePath());
 		testFile.createNewFile();
 		testFile.deleteOnExit();
-		grantAdminRole();
+		grantAdmin();
 
 		// Override the current status
 		status(READY);

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupFailLocalTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupFailLocalTest.java
@@ -25,7 +25,7 @@ public class AdminEndpointBackupFailLocalTest extends AbstractMeshTest {
 		final String backupDir = testContext.getOptions().getStorageOptions().getBackupDirectory();
 		org.apache.commons.io.FileUtils.deleteDirectory(new File(backupDir));
 		new File(backupDir).delete();
-		grantAdminRole();
+		grantAdmin();
 
 		// Override the current status
 		status(READY);

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupLocalTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupLocalTest.java
@@ -30,7 +30,7 @@ public class AdminEndpointBackupLocalTest extends AbstractMeshTest {
 		final String NEW_PROJECT_NAME = "enemenemuh";
 		final String backupDir = testContext.getOptions().getStorageOptions().getBackupDirectory();
 		assertFilesInDir(backupDir, 0);
-		grantAdminRole();
+		grantAdmin();
 
 		expect(GRAPH_BACKUP_START).one();
 		expect(GRAPH_BACKUP_FINISHED).one();
@@ -61,7 +61,7 @@ public class AdminEndpointBackupLocalTest extends AbstractMeshTest {
 	@Test
 	@Ignore("Endpoint disabled")
 	public void testExportImport() {
-		grantAdminRole();
+		grantAdmin();
 		GenericMessageResponse message = call(() -> client().invokeExport());
 		assertThat(message).matches("export_finished");
 

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupMemoryTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupMemoryTest.java
@@ -17,7 +17,7 @@ public class AdminEndpointBackupMemoryTest extends AbstractMeshTest {
 
 	@Test
 	public void testBackup() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		call(() -> client().invokeBackup(), SERVICE_UNAVAILABLE, "backup_error_not_supported_in_memory_mode");
 	}
 

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupServerTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointBackupServerTest.java
@@ -22,7 +22,7 @@ public class AdminEndpointBackupServerTest extends AbstractMeshTest {
 	public void testBackupRestore() throws IOException {
 		final String NEW_PROJECT_NAME = "enemenemuh";
 		final String backupDir = testContext.getOptions().getStorageOptions().getBackupDirectory();
-		grantAdminRole();
+		grantAdmin();
 
 		assertFilesInDir(backupDir, 0);
 		GenericMessageResponse message = call(() -> client().invokeBackup());

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointTest.java
@@ -27,7 +27,7 @@ public class AdminEndpointTest extends AbstractMeshTest {
 	public void testClusterStatusInNoClusterMode() {
 		call(() -> client().clusterStatus(), FORBIDDEN, "error_admin_permission_required");
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		call(() -> client().clusterStatus(), BAD_REQUEST, "error_cluster_status_only_available_in_cluster_mode");
 	}

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminPluginEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminPluginEndpointTest.java
@@ -39,23 +39,23 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testDeployPluginMissingPermission() throws IOException {
-		revokeAdminRole();
+		revokeAdmin();
 		copyAndDeploy(BASIC_PATH, "plugin.jar", FORBIDDEN, "error_admin_permission_required");
 	}
 
 	@Test
 	public void testReadPluginMissingPermission() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		PluginResponse deployment = copyAndDeploy(BASIC_PATH, "plugin.jar");
 
-		revokeAdminRole();
+		revokeAdmin();
 		String id = deployment.getId();
 		call(() -> client().findPlugin(id), FORBIDDEN, "error_admin_permission_required");
 	}
 
 	@Test
 	public void testNonPluginDeployment() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		String name = "non-mesh.jar";
 
 		int before = meshApi().pluginIds().size();
@@ -67,24 +67,24 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testUndeployPluginMissingPermission() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		PluginResponse deployment = copyAndDeploy(BASIC_PATH, "plugin.jar");
 
-		revokeAdminRole();
+		revokeAdmin();
 		String id = deployment.getId();
 		call(() -> client().undeployPlugin(id), FORBIDDEN, "error_admin_permission_required");
 	}
 
 	@Test
 	public void testUndeployBogusPlugin() {
-		grantAdminRole();
+		grantAdmin();
 		String id = "bogus";
 		call(() -> client().undeployPlugin(id), NOT_FOUND, "object_not_found_for_uuid", id);
 	}
 
 	@Test
 	public void testReadPluginListMissingPermission() {
-		revokeAdminRole();
+		revokeAdmin();
 		call(() -> client().findPlugins(), FORBIDDEN, "error_admin_permission_required");
 	}
 
@@ -95,7 +95,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 	 */
 	@Test
 	public void testDeployPlugin() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		PluginResponse deployment = copyAndDeploy(BASIC_PATH, "basic-plugin.jar");
 		assertEquals("basic", deployment.getId());
@@ -122,7 +122,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testPluginList() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		PluginResponse response = copyAndDeploy(BASIC_PATH, "plugin.jar");
 		assertEquals(1, pluginManager().getPluginIds().size());
 
@@ -161,7 +161,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testStaticHandler() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		copyAndDeploy(BASIC_PATH, "plugin.jar");
 		copyAndDeploy(BASIC2_PATH, "plugin2.jar");
@@ -175,7 +175,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testClassLoaderHandling() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		copyAndDeploy(CLASSLOADER_PATH, "plugin.jar");
 		waitForPluginRegistration();
@@ -196,7 +196,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 			.setVersion(null);
 		ManifestInjectorPlugin.apiName = "api";
 
-		grantAdminRole();
+		grantAdmin();
 		deployPlugin(ManifestInjectorPlugin.class, "inject", BAD_REQUEST, "admin_plugin_error_validation_failed_field_missing", "version");
 	}
 
@@ -212,7 +212,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 			.setVersion("1.0");
 		ManifestInjectorPlugin.apiName = "api with spaces";
 
-		grantAdminRole();
+		grantAdmin();
 
 		deployPlugin(ManifestInjectorPlugin.class, "injector", BAD_REQUEST, "admin_plugin_error_validation_failed_apiname_invalid", "injector");
 
@@ -225,7 +225,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testMultipleDeployments() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		for (int i = 1; i <= 100; i++) {
 			deployPlugin(ClonePlugin.class, "clone" + i);
@@ -247,7 +247,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testDuplicateDeployment() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		copyAndDeploy(BASIC_PATH, "plugin.jar");
 		assertEquals(1, pluginManager().getPluginIds().size());
@@ -260,7 +260,7 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 
 	@Test
 	public void testExtensionHandling() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		copyAndDeploy(EXTENSION_CONSUMER_PATH, "extension-consumer.jar");
 		copyAndDeploy(EXTENSION_PROVIDER_PATH, "extension-provider.jar");

--- a/core/src/test/java/com/gentics/mesh/core/admin/ClusterStatusTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/ClusterStatusTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
-import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.core.rest.admin.cluster.ClusterInstanceInfo;
 import com.gentics.mesh.core.rest.admin.cluster.ClusterStatusResponse;
 import com.gentics.mesh.test.context.AbstractMeshTest;
@@ -19,10 +18,7 @@ public class ClusterStatusTest extends AbstractMeshTest {
 
 	@Test
 	public void testLoadStatus() {
-		try (Tx tx = tx()) {
-			group().addRole(roles().get("admin"));
-			tx.success();
-		}
+		grantAdmin();
 
 		ClusterStatusResponse response = call(() -> client().clusterStatus());
 		assertThat(response.getInstances()).hasSize(1);

--- a/core/src/test/java/com/gentics/mesh/core/admin/ConsistencyCheckTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/ConsistencyCheckTest.java
@@ -49,7 +49,7 @@ public class ConsistencyCheckTest extends AbstractMeshTest {
 
 	@Test
 	public void testConsistencyRepair() {
-		grantAdminRole();
+		grantAdmin();
 
 		ConsistencyCheckResponse response = call(() -> client().checkConsistency());
 		assertThat(response.getInconsistencies()).isEmpty();

--- a/core/src/test/java/com/gentics/mesh/core/admin/DebugInfoTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/DebugInfoTest.java
@@ -88,7 +88,7 @@ public class DebugInfoTest extends AbstractMeshTest {
 	}
 
 	private DebugInfo getDebugInfo(String... includes) throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		MeshBinaryResponse response = client().debugInfo(includes).blockingGet();
 		return new DebugInfo(response);
 	}

--- a/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
@@ -426,8 +426,10 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testCreateWithoutBaseBranch() {
+		grantAdmin();
 		Branch latest = createBranch("Latest", true);
 
+		grantAdmin();
 		BranchCreateRequest request = new BranchCreateRequest();
 		request.setName("New Branch");
 		Branch created = createBranch(request);
@@ -446,6 +448,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 		BranchCreateRequest request = new BranchCreateRequest();
 		request.setName("New Branch");
 		request.setBaseBranch(new BranchReference().setUuid(baseUuid));
+		grantAdmin();
 		Branch created = createBranch(request);
 
 		tx(() -> {
@@ -462,6 +465,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 		BranchCreateRequest request = new BranchCreateRequest();
 		request.setName("New Branch");
 		request.setBaseBranch(new BranchReference().setName(baseName));
+		grantAdmin();
 		Branch created = createBranch(request);
 
 		tx(() -> {
@@ -553,6 +557,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 	@Test
 	@Override
 	public void testReadByUUIDWithMissingPermission() throws Exception {
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			role().revokePermissions(project().getInitialBranch(), READ_PERM);
 			tx.success();
@@ -605,6 +610,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 			thirdBranch = project.getBranchRoot().create("Three", user(), batch);
 			tx.success();
 		}
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			role().revokePermissions(firstBranch, READ_PERM);
 			role().revokePermissions(thirdBranch, READ_PERM);
@@ -670,6 +676,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 	@Test
 	@Override
 	public void testUpdateByUUIDWithoutPerm() throws Exception {
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			role().revokePermissions(project().getInitialBranch(), UPDATE_PERM);
 			tx.success();
@@ -801,6 +808,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testSetLatestNoPerm() {
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			role().revokePermissions(project().getInitialBranch(), UPDATE_PERM);
 			tx.success();
@@ -1039,6 +1047,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testAssignSchemaVersionNoPermission() throws Exception {
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			Project project = project();
 			role().revokePermissions(project.getInitialBranch(), UPDATE_PERM);
@@ -1234,6 +1243,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testAssignMicroschemaVersionNoPermission() throws Exception {
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			Project project = project();
 			role().revokePermissions(project.getInitialBranch(), UPDATE_PERM);

--- a/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
@@ -101,12 +101,6 @@ import static org.junit.Assert.assertNotNull;
 @MeshTestSetting(testSize = FULL, startServer = true)
 public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTestcases {
 
-	@Before
-	public void addAdminPerms() {
-		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdmin();
-	}
-
 	@Override
 	public void testUpdateMultithreaded() throws Exception {
 		// TODO Auto-generated method stub
@@ -982,7 +976,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 		}, COMPLETED, 1);
 		awaitEvents();
 
-		JobListResponse jobList = call(() -> client().findJobs());
+		JobListResponse jobList = adminCall(() -> client().findJobs());
 		JobResponse job = jobList.getData().stream().filter(j -> j.getProperties().get("schemaUuid").equals(schema.getUuid())).findAny().get();
 
 		BranchInfoSchemaList schemaList = call(() -> client().getBranchSchemaVersions(PROJECT_NAME, initialBranchUuid()));

--- a/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
@@ -104,7 +104,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 	@Before
 	public void addAdminPerms() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 	}
 
 	@Override
@@ -910,7 +910,7 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 	@Test
 	public void testAssignSchemaVersion() throws Exception {
 		// Grant admin perm
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		// create version 1 of a schema
 		SchemaResponse schema = createSchema("schemaname");

--- a/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/branch/BranchEndpointTest.java
@@ -1,5 +1,51 @@
 package com.gentics.mesh.core.branch;
 
+import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
+import static com.gentics.mesh.core.data.relationship.GraphPermission.CREATE_PERM;
+import static com.gentics.mesh.core.data.relationship.GraphPermission.READ_PERM;
+import static com.gentics.mesh.core.data.relationship.GraphPermission.UPDATE_PERM;
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_CREATED;
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_MIGRATION_FINISHED;
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_MIGRATION_START;
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.MICROSCHEMA_BRANCH_ASSIGN;
+import static com.gentics.mesh.core.rest.MeshEvent.NODE_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_LATEST_BRANCH_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_BRANCH_ASSIGN;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_MIGRATION_FINISHED;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_MIGRATION_START;
+import static com.gentics.mesh.core.rest.common.Permission.CREATE;
+import static com.gentics.mesh.core.rest.common.Permission.DELETE;
+import static com.gentics.mesh.core.rest.common.Permission.READ;
+import static com.gentics.mesh.core.rest.common.Permission.UPDATE;
+import static com.gentics.mesh.core.rest.job.JobStatus.COMPLETED;
+import static com.gentics.mesh.handler.VersionHandler.CURRENT_API_BASE_PATH;
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.INITIAL_BRANCH_NAME;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.Branch;
@@ -51,52 +97,6 @@ import com.gentics.mesh.test.util.TestUtils;
 import com.gentics.mesh.util.UUIDUtil;
 
 import io.reactivex.Observable;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
-import static com.gentics.mesh.core.data.relationship.GraphPermission.CREATE_PERM;
-import static com.gentics.mesh.core.data.relationship.GraphPermission.READ_PERM;
-import static com.gentics.mesh.core.data.relationship.GraphPermission.UPDATE_PERM;
-import static com.gentics.mesh.core.rest.common.Permission.CREATE;
-import static com.gentics.mesh.core.rest.common.Permission.DELETE;
-import static com.gentics.mesh.core.rest.common.Permission.READ;
-import static com.gentics.mesh.core.rest.common.Permission.UPDATE;
-import static com.gentics.mesh.handler.VersionHandler.CURRENT_API_BASE_PATH;
-import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.TestDataProvider.INITIAL_BRANCH_NAME;
-import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
-import static com.gentics.mesh.test.TestSize.FULL;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
-import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.junit.Assert.assertEquals;
-
-import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_CREATED;
-import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_MIGRATION_FINISHED;
-import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_MIGRATION_START;
-import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_UPDATED;
-import static com.gentics.mesh.core.rest.MeshEvent.MICROSCHEMA_BRANCH_ASSIGN;
-import static com.gentics.mesh.core.rest.MeshEvent.NODE_UPDATED;
-import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_LATEST_BRANCH_UPDATED;
-import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_BRANCH_ASSIGN;
-import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_MIGRATION_FINISHED;
-import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_MIGRATION_START;
-import static com.gentics.mesh.core.rest.job.JobStatus.COMPLETED;
-import static org.junit.Assert.assertNotNull;
 
 @MeshTestSetting(testSize = FULL, startServer = true)
 public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTestcases {
@@ -420,10 +420,8 @@ public class BranchEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testCreateWithoutBaseBranch() {
-		grantAdmin();
 		Branch latest = createBranch("Latest", true);
 
-		grantAdmin();
 		BranchCreateRequest request = new BranchCreateRequest();
 		request.setName("New Branch");
 		Branch created = createBranch(request);

--- a/core/src/test/java/com/gentics/mesh/core/branch/BranchMigrationEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/branch/BranchMigrationEndpointTest.java
@@ -47,7 +47,7 @@ public class BranchMigrationEndpointTest extends AbstractMeshTest {
 		DeploymentOptions options = new DeploymentOptions();
 		options.setWorker(true);
 		vertx().deployVerticle(meshDagger().jobWorkerVerticle(), options);
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 	}
 
 	@Test
@@ -186,7 +186,7 @@ public class BranchMigrationEndpointTest extends AbstractMeshTest {
 			call(() -> client().publishNode(PROJECT_NAME, node.getUuid()));
 		}
 
-		grantAdminRole();
+		grantAdmin();
 		waitForJobs(() -> {
 			call(() -> client().createBranch(PROJECT_NAME, new BranchCreateRequest().setName("branch1")));
 		}, COMPLETED, 1);

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
@@ -343,7 +343,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 	private NodeResponse createBinaryNode() {
 		String parentUuid = tx(() -> folder("2015").getUuid());
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		NodeCreateRequest nodeCreateRequest = new NodeCreateRequest();
 		nodeCreateRequest.setLanguage("en").setParentNodeUuid(parentUuid).setSchemaName("binary_content");

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointBranchTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointBranchTest.java
@@ -27,7 +27,7 @@ public class GraphQLEndpointBranchTest extends AbstractMeshTest {
 
 	@Before
 	public void setupData() {
-		grantAdminRole();
+		grantAdmin();
 		createBranchRestAndWait(BRANCH_NAME, false);
 
 		NodeResponse content1 = createContent("test1", "test");

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLMeshTypeTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLMeshTypeTest.java
@@ -32,7 +32,7 @@ public class GraphQLMeshTypeTest extends AbstractMeshTest {
 
 	@Test
 	public void testWithDisabledServerTokensAsAdmin() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		options().getHttpServerOptions().setServerTokens(false);
 		assertType("mesh/mesh-query");
 	}

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLPluginTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLPluginTest.java
@@ -22,7 +22,7 @@ public class GraphQLPluginTest extends AbstractPluginTest {
 
 	@Test
 	public void testGraphQL() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		for (int i = 1; i <= 100; i++) {
 			deployPlugin(ClonePlugin.class, "clone" + i);
@@ -38,7 +38,7 @@ public class GraphQLPluginTest extends AbstractPluginTest {
 
 	@Test
 	public void testGraphQLPlugin() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		copyAndDeploy(GRAPHQL_PATH, "graphql.jar");
 		waitForPluginRegistration();
@@ -51,7 +51,7 @@ public class GraphQLPluginTest extends AbstractPluginTest {
 
 	@Test
 	public void testInvalidGraphQLPlugin() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 
 		copyAndDeploy(INVALID_GRAPHQL_PATH, "graphql.jar", BAD_REQUEST, "admin_plugin_error_invalid_gql_name", "invalid-plugin");
 

--- a/core/src/test/java/com/gentics/mesh/core/job/JobEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/job/JobEndpointTest.java
@@ -37,7 +37,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 		call(() -> client().findJobs(), FORBIDDEN, "error_admin_permission_required");
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		JobListResponse jobList = call(() -> client().findJobs());
 		assertThat(jobList.getData()).isEmpty();
@@ -70,7 +70,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 		call(() -> client().deleteJob(jobUuid), FORBIDDEN, "error_admin_permission_required");
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		call(() -> client().deleteJob(jobUuid), BAD_REQUEST, "job_error_invalid_state", jobUuid);
 
@@ -94,7 +94,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 			return job.getUuid();
 		});
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		waitForJob(() -> {
 			GenericMessageResponse msg = call(() -> client().invokeJobProcessing());
@@ -111,8 +111,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testLoadBogusJob() {
-		tx(() -> group().addRole(roles().get("admin")));
-
+		grantAdmin();
 		call(() -> client().findJobByUuid("bogus"), NOT_FOUND, "object_not_found_for_uuid", "bogus");
 	}
 
@@ -122,8 +121,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 		call(() -> client().invokeJobProcessing(), FORBIDDEN, "error_admin_permission_required");
 
-		tx(() -> group().addRole(roles().get("admin")));
-
+		grantAdmin();
 		JobResponse response = waitForJob(() -> {
 			GenericMessageResponse message = call(() -> client().invokeJobProcessing());
 			assertThat(message).matches("job_processing_invoked");
@@ -151,7 +149,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 			return job.getUuid();
 		});
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		JobResponse jobResponse = call(() -> client().findJobByUuid(job3Uuid));
 		try (Tx tx = tx()) {
@@ -177,7 +175,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 		call(() -> client().resetJob(jobUuid), FORBIDDEN, "error_admin_permission_required");
 
-		grantAdminRole();
+		grantAdmin();
 
 		triggerAndWaitForJob(jobUuid, FAILED);
 
@@ -198,7 +196,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 		call(() -> client().processJob(jobUuid), FORBIDDEN, "error_admin_permission_required");
 
-		grantAdminRole();
+		grantAdmin();
 
 		triggerAndWaitForJob(jobUuid, FAILED);
 
@@ -222,7 +220,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testJobStatusWithNoMigrationRunning() {
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		JobListResponse status = call(() -> client().findJobs());
 		assertEquals(0, status.getMetainfo().getTotalCount());
 	}

--- a/core/src/test/java/com/gentics/mesh/core/job/JobEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/job/JobEndpointTest.java
@@ -54,7 +54,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 			boot().jobRoot().enqueueBranchMigration(user(), initialBranch());
 		});
 
-		jobList = call(() -> client().findJobs());
+		jobList = runAsAdmin(() -> call(() -> client().findJobs()));
 		JobResponse job = jobList.getData().get(1);
 		assertThat(job.getProperties()).doesNotContainKey("microschemaUuid");
 		assertThat(job.getProperties()).doesNotContainKey("microschemaName");
@@ -204,7 +204,7 @@ public class JobEndpointTest extends AbstractMeshTest {
 		assertNotNull(jobResonse.getErrorMessage());
 
 		// Change the job so that it will no longer fail
-		tx(()-> {
+		tx(() -> {
 			Branch branch = project().getBranchRoot().create("testBranch", user(), null, true, initialBranch(), createBatch());
 			job.setBranch(branch);
 		});

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeDeleteBranchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeDeleteBranchEndpointTest.java
@@ -22,7 +22,7 @@ public class NodeDeleteBranchEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void deleteNodeInBranch() {
-		grantAdminRole();
+		grantAdmin();
 		NodeResponse parent = createNode();
 		NodeResponse otherParent = createNode();
 		publishNode(parent);

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeDeleteEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeDeleteEndpointTest.java
@@ -70,7 +70,7 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 	 */
 	@Test
 	public void testDeleteLastLanguageFromNode() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		Node node = folder("news");
 		String branchName = "newBranch";
 
@@ -171,7 +171,7 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testDeleteNodeFromRelease() {
-		grantAdminRole();
+		grantAdmin();
 		final String schemaUuid = tx(() -> schemaContainer("content").getUuid());
 		final String parentNodeUuid = tx(() -> folder("news").getUuid());
 		final String SECOND_BRANCH_NAME = "branch2";
@@ -328,7 +328,7 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 	@Test
 	@Ignore
 	public void testDeleteRecursiveFromBranch2() throws InterruptedException {
-		grantAdminRole();
+		grantAdmin();
 		String newsFolderUuid = tx(() -> folder("news").getUuid());
 
 		List<String> uuids = new ArrayList<>();
@@ -437,7 +437,7 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testDeleteRecursiveFromBranch() {
-		grantAdminRole();
+		grantAdmin();
 		String newsFolderUuid = tx(() -> folder("news").getUuid());
 		String branchedNodeUuid = tx(() -> content("concorde").getUuid());
 		String nodeInBoth = createNode(null, newsFolderUuid, "root", initialBranchUuid(), false).getUuid();

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointBinaryFieldTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointBinaryFieldTest.java
@@ -57,7 +57,7 @@ public class NodeEndpointBinaryFieldTest extends AbstractMeshTest {
 
 	@Before
 	public void setupPerm() {
-		grantAdminRole();
+		grantAdmin();
 	}
 
 	@Test
@@ -188,7 +188,7 @@ public class NodeEndpointBinaryFieldTest extends AbstractMeshTest {
 			SchemaUpdateRequest.class);
 		schemaRequest.getFields().add(FieldUtil.createBinaryFieldSchema("binary"));
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		waitForJobs(() -> {
 			call(() -> client().updateSchema(schemaUuid, schemaRequest));
 		}, COMPLETED, 1);

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointBinaryFieldTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointBinaryFieldTest.java
@@ -94,6 +94,7 @@ public class NodeEndpointBinaryFieldTest extends AbstractMeshTest {
 		Node node = prepareSchema();
 
 		// Only grant read_published perm
+		revokeAdmin();
 		try (Tx tx = tx()) {
 			role().revokePermissions(node, READ_PERM);
 			role().grantPermissions(node, READ_PUBLISHED_PERM);

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointTest.java
@@ -98,7 +98,7 @@ public class NodeEndpointTest extends AbstractMeshTest implements BasicRestTestc
 	@Before
 	public void addAdminPerms() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdminRole();
+		grantAdmin();
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeEndpointTest.java
@@ -27,6 +27,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -42,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -95,11 +95,6 @@ import io.vertx.core.logging.LoggerFactory;
 
 @MeshTestSetting(elasticsearch = TRACKING, testSize = FULL, startServer = true)
 public class NodeEndpointTest extends AbstractMeshTest implements BasicRestTestcases {
-	@Before
-	public void addAdminPerms() {
-		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdmin();
-	}
 
 	@Test
 	public void testCreateNodeWithNoLanguageCode() {

--- a/core/src/test/java/com/gentics/mesh/core/node/NodePublishEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodePublishEndpointTest.java
@@ -48,11 +48,6 @@ import com.gentics.mesh.test.context.MeshTestSetting;
 
 @MeshTestSetting(elasticsearch = TRACKING, testSize = FULL, startServer = true)
 public class NodePublishEndpointTest extends AbstractMeshTest {
-	@Before
-	public void addAdminPerms() {
-		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdmin();
-	}
 
 	/**
 	 * Folder /news/2015 is not published. A new node will be created in folder 2015. Publishing the created folder should fail since the parent folder

--- a/core/src/test/java/com/gentics/mesh/core/node/NodePublishEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodePublishEndpointTest.java
@@ -51,7 +51,7 @@ public class NodePublishEndpointTest extends AbstractMeshTest {
 	@Before
 	public void addAdminPerms() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 	}
 
 	/**

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeTagEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeTagEndpointTest.java
@@ -289,7 +289,7 @@ public class NodeTagEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testTaggingAcrossMultipleBranches() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		String branchOne = "BranchV1";
 		String branchTwo = "BranchV2";
 

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeTakeOfflineEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeTakeOfflineEndpointTest.java
@@ -41,7 +41,7 @@ public class NodeTakeOfflineEndpointTest extends AbstractMeshTest {
 	@Before
 	public void addAdminPerms() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeTakeOfflineEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeTakeOfflineEndpointTest.java
@@ -1,5 +1,26 @@
 package com.gentics.mesh.core.node;
 
+import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
+import static com.gentics.mesh.core.data.relationship.GraphPermission.PUBLISH_PERM;
+import static com.gentics.mesh.core.rest.MeshEvent.NODE_CONTENT_DELETED;
+import static com.gentics.mesh.core.rest.MeshEvent.NODE_DELETED;
+import static com.gentics.mesh.core.rest.MeshEvent.NODE_PUBLISHED;
+import static com.gentics.mesh.core.rest.MeshEvent.NODE_UNPUBLISHED;
+import static com.gentics.mesh.core.rest.common.ContainerType.DRAFT;
+import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
 import com.gentics.madl.tx.Tx;
 import com.gentics.mesh.FieldUtil;
 import com.gentics.mesh.core.data.Branch;
@@ -15,34 +36,8 @@ import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Arrays;
-
-import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
-import static com.gentics.mesh.core.data.relationship.GraphPermission.PUBLISH_PERM;
-import static com.gentics.mesh.core.rest.MeshEvent.NODE_CONTENT_DELETED;
-import static com.gentics.mesh.core.rest.MeshEvent.NODE_DELETED;
-import static com.gentics.mesh.core.rest.MeshEvent.NODE_PUBLISHED;
-import static com.gentics.mesh.core.rest.MeshEvent.NODE_UNPUBLISHED;
-import static com.gentics.mesh.core.rest.common.ContainerType.DRAFT;
-import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
-import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
-import static com.gentics.mesh.test.TestSize.FULL;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.junit.Assert.assertFalse;
-
 @MeshTestSetting(testSize = FULL, startServer = true)
 public class NodeTakeOfflineEndpointTest extends AbstractMeshTest {
-	@Before
-	public void addAdminPerms() {
-		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdmin();
-	}
 
 	@Test
 	public void testTakeNodeOfflineManyChildren() throws Exception {

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
@@ -778,7 +778,7 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 		String uuid = projectUuid();
 		String branchName = "Branch_V1";
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		BranchCreateRequest request = new BranchCreateRequest();
 		request.setName(branchName);

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
@@ -778,8 +778,6 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 		String uuid = projectUuid();
 		String branchName = "Branch_V1";
 
-		grantAdmin();
-
 		BranchCreateRequest request = new BranchCreateRequest();
 		request.setName(branchName);
 

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectVersionPurgeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectVersionPurgeEndpointTest.java
@@ -42,7 +42,6 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testPurge() {
-		grantAdmin();
 		disableAutoPurge();
 		String nodeUuid = contentUuid();
 		waitForJob(() -> {
@@ -61,7 +60,9 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 
 		// Now only D I and P must remain.
 		waitForJob(() -> {
-			call(() -> client().purgeProject(projectUuid()));
+			runAsAdmin(() -> {
+				call(() -> client().purgeProject(projectUuid()));
+			});
 		});
 		assertVersions(nodeUuid, "en", "D(1.5)=>P(1.0)=>I(0.1)");
 	}

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectVersionPurgeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectVersionPurgeEndpointTest.java
@@ -36,8 +36,7 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testBogusProject() {
-		grantAdmin();
-		call(() -> client().purgeProject(userUuid()), NOT_FOUND, "object_not_found_for_uuid", userUuid());
+		adminCall(() -> client().purgeProject(userUuid()), NOT_FOUND, "object_not_found_for_uuid", userUuid());
 	}
 
 	@Test
@@ -45,7 +44,7 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 		disableAutoPurge();
 		String nodeUuid = contentUuid();
 		waitForJob(() -> {
-			call(() -> client().purgeProject(projectUuid()));
+			adminCall(() -> client().purgeProject(projectUuid()));
 		});
 		assertVersions(nodeUuid, "en", "PD(1.0)=>I(0.1)");
 
@@ -69,7 +68,6 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testPurgeWithBefore() throws InterruptedException, ExecutionException {
-		grantAdmin();
 		disableAutoPurge();
 		String nodeUuid = contentUuid();
 		String middle = null;
@@ -96,7 +94,7 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 		waitForJob(() -> {
 			ProjectPurgeParameters purgeParams = new ProjectPurgeParametersImpl();
 			purgeParams.setBefore(middleDate);
-			call(() -> client().purgeProject(projectUuid(), purgeParams));
+			adminCall(() -> client().purgeProject(projectUuid(), purgeParams));
 		});
 
 		assertVersions(nodeUuid, "en", "D(1.12)=>(1.11)=>(1.10)=>(1.9)=>(1.8)=>(1.7)=>(1.6)=>PI(1.0)=>I(0.1)");

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectVersionPurgeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectVersionPurgeEndpointTest.java
@@ -36,13 +36,13 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testBogusProject() {
-		grantAdminRole();
+		grantAdmin();
 		call(() -> client().purgeProject(userUuid()), NOT_FOUND, "object_not_found_for_uuid", userUuid());
 	}
 
 	@Test
 	public void testPurge() {
-		grantAdminRole();
+		grantAdmin();
 		disableAutoPurge();
 		String nodeUuid = contentUuid();
 		waitForJob(() -> {
@@ -68,7 +68,7 @@ public class ProjectVersionPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testPurgeWithBefore() throws InterruptedException, ExecutionException {
-		grantAdminRole();
+		grantAdmin();
 		disableAutoPurge();
 		String nodeUuid = contentUuid();
 		String middle = null;

--- a/core/src/test/java/com/gentics/mesh/core/schema/MicronodeMigrationAllFieldsTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/MicronodeMigrationAllFieldsTest.java
@@ -48,7 +48,7 @@ public class MicronodeMigrationAllFieldsTest extends AbstractMeshTest {
 
 	@Test
 	public void testMigration() {
-		grantAdminRole();
+		grantAdmin();
 		createSchema();
 		createAllFieldsNode();
 		updateMicroschema();

--- a/core/src/test/java/com/gentics/mesh/core/schema/MicronodeMigrationEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/MicronodeMigrationEndpointTest.java
@@ -25,7 +25,7 @@ public class MicronodeMigrationEndpointTest extends AbstractMeshTest {
 	 */
 	@Test
 	public void testUpdate() {
-		grantAdminRole();
+		grantAdmin();
 		String uuid = tx(() -> microschemaContainer("vcard").getUuid());
 		MicroschemaResponse microschema = call(() -> client().findMicroschemaByUuid(uuid));
 

--- a/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaChangesEndpointTest.java
@@ -42,7 +42,7 @@ public class MicroschemaChangesEndpointTest extends AbstractMeshTest {
 	@Before
 	public void addAdminPerms() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaMigrationTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaMigrationTest.java
@@ -49,7 +49,7 @@ public class MicroschemaMigrationTest extends AbstractMeshTest {
 
 	@Test
 	public void migrateNewNode() {
-		grantAdminRole();
+		grantAdmin();
 		createTestSchema();
 		createMicroschemas();
 
@@ -62,7 +62,7 @@ public class MicroschemaMigrationTest extends AbstractMeshTest {
 
 	@Test
 	public void migrateUpdatedNode() {
-		grantAdminRole();
+		grantAdmin();
 		createTestSchema();
 		createMicroschemas();
 
@@ -81,7 +81,7 @@ public class MicroschemaMigrationTest extends AbstractMeshTest {
 
 	@Test
 	public void migrateNewNodeNoPurge() {
-		grantAdminRole();
+		grantAdmin();
 		createTestSchema(false);
 		createMicroschemas();
 
@@ -94,7 +94,7 @@ public class MicroschemaMigrationTest extends AbstractMeshTest {
 
 	@Test
 	public void migrateUpdatedNodeNoPurge() {
-		grantAdminRole();
+		grantAdmin();
 		createTestSchema(false);
 		createMicroschemas();
 

--- a/core/src/test/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -86,7 +86,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 	@Before
 	public void setup() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdminRole();
+		grantAdmin();
 	}
 
 	/**

--- a/core/src/test/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -788,7 +788,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			"text2_value");
 
 		triggerAndWaitForAllJobs(COMPLETED);
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1);
 
 		assertThat(call(() -> client().findNodeByUuid(PROJECT_NAME, draftResponse.getUuid()))).hasStringField("text", "text2_value").hasVersion("2.1")
@@ -874,7 +874,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		assertThat(call(() -> client().findNodeByUuid(PROJECT_NAME, draftResponse.getUuid()))).hasVersion("2.0").hasStringField("text", "text_value")
 			.hasSchemaVersion("dummy", "2.0");
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1);
 
 		// Assert that the draft and publish version both have version 2.0 since they share the same NGFC.
@@ -1109,7 +1109,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				newFieldName).getString()).as("Migrated field value").isEqualTo("third content");
 		}
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1);
 
 	}
@@ -1217,7 +1217,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				"firstName").getString()).as("Not migrated field value").isEqualTo("Max");
 		}
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1);
 
 	}

--- a/core/src/test/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -10,6 +10,7 @@ import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
 import static com.gentics.mesh.test.context.ElasticsearchTestMode.TRACKING;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -21,7 +22,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.gentics.madl.tx.Tx;
@@ -83,12 +83,6 @@ import io.vertx.core.json.JsonObject;
 @MeshTestSetting(elasticsearch = TRACKING, testSize = FULL, startServer = true, clusterMode = false)
 public class NodeMigrationEndpointTest extends AbstractMeshTest {
 
-	@Before
-	public void setup() {
-		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdmin();
-	}
-
 	/**
 	 * Create a schema model and assign it to the project/branch. Assert that an index has been created.
 	 * 
@@ -120,7 +114,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			assertNull(edge1.getJobUuid());
 			assertTrue("The assignment should be active.", edge1.isActive());
 		}
-		assertThat(call(() -> client().findJobs())).isEmpty();
+		assertThat(adminCall(() -> client().findJobs())).isEmpty();
 
 		waitForSearchIdleEvent();
 		assertThat(trackingSearchProvider()).hasCreate(NodeGraphFieldContainer.composeIndexName(projectUuid(), initialBranchUuid(), versionUuid,
@@ -162,7 +156,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				DRAFT)).hasNoDropEvents();
 			assertThat(trackingSearchProvider()).hasCreate(NodeGraphFieldContainer.composeIndexName(projectUuid(), initialBranchUuid(), versionBUuid,
 				PUBLISHED)).hasNoDropEvents();
-			assertThat(call(() -> client().findJobs())).hasInfos(1);
+			assertThat(adminCall(() -> client().findJobs())).hasInfos(1);
 		}
 
 		/**
@@ -230,7 +224,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				DRAFT)).hasNoDropEvents();
 			assertThat(trackingSearchProvider()).hasCreate(NodeGraphFieldContainer.composeIndexName(projectUuid(), initialBranchUuid(), versionCUuid,
 				PUBLISHED)).hasNoDropEvents();
-			assertThat(call(() -> client().findJobs())).hasInfos(2);
+			assertThat(adminCall(() -> client().findJobs())).hasInfos(2);
 		}
 
 		// Now start the worker again
@@ -455,7 +449,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			assertThat(trackingSearchProvider()).hasEvents(store, update, delete, indexDrop, indexCreate);
 		}
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1).containsJobs(jobUuid);
 	}
 
@@ -488,7 +482,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			call(() -> client().updateSchema(schemaUuid, request));
 		});
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1);
 		waitForSearchIdleEvent();
 
@@ -566,7 +560,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				"first content");
 		}
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(2);
 		assertThat(status).containsJobs(jobAUuid);
 	}
@@ -608,7 +602,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				.isOf(versionB).hasVersion("2.0");
 		}
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED);
 	}
 
@@ -692,7 +686,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		assertThat(migratedNode2.getFields().getMicronodeFieldList("micronode").getItems()).isNotEmpty();
 		assertNotEquals("The node should have been migrated due to the schema update.", migratedNode.getVersion(), migratedNode2.getVersion());
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(4);
 
 	}
@@ -713,7 +707,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		client().deleteProject(projectUuid()).blockingAwait();
 		triggerAndWaitForJob(jobUuid, FAILED);
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(FAILED).hasInfos(1);
 		assertNotNull("An error should be stored along with the info.", status.getData().get(0).getErrorDetail());
 	}
@@ -735,7 +729,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		triggerAndWaitForAllJobs(COMPLETED);
 
 		// Verify that the expected amount of jobs is listed
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(10);
 
 	}
@@ -993,7 +987,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 				.isEqualTo("second content");
 		}
 
-		JobListResponse status = call(() -> client().findJobs());
+		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(1);
 
 	}

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
@@ -72,7 +72,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 	@Before
 	public void addAdminPerms() {
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
@@ -69,12 +69,6 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 		super(elasticsearch);
 	}
 
-	@Before
-	public void addAdminPerms() {
-		// Grant admin perms. Otherwise we can't check the jobs
-		grantAdmin();
-	}
-
 	@Test
 	public void testUpdateName() throws GenericRestException, Exception {
 		String name = "new_name";

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
@@ -395,7 +395,6 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 		SchemaUpdateRequest request = JsonUtil.readValue(json, SchemaUpdateRequest.class);
 		request.setUrlFields("slug");
 
-		grantAdmin();
 		waitForJob(() -> {
 			call(() -> client().updateSchema(uuid, request));
 		});
@@ -403,7 +402,6 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testSetAutoPurgeToNull() {
-		grantAdmin();
 		String schemaUuid = tx(() -> schemaContainer("folder").getUuid());
 		SchemaResponse response = call(() -> client().findSchemaByUuid(schemaUuid));
 		assertNull(response.getAutoPurge());

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
@@ -94,7 +94,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@After
 	public void waitForJobs() {
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		triggerAndWaitForAllJobs(COMPLETED);
 	}
 
@@ -308,11 +308,11 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 		request.setDescription("New description");
 		request.addField(FieldUtil.createHtmlFieldSchema("someHtml"));
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		waitForJobs(() -> {
 			call(() -> client().updateSchema(uuid, request));
 		}, JobStatus.COMPLETED, 1);
-		tx(() -> group().removeRole(roles().get("admin")));
+		revokeAdmin();
 
 		// Load the previous version
 		restSchema = call(() -> client().findSchemaByUuid(uuid, new VersioningParametersImpl().setVersion(latestVersion)));
@@ -395,7 +395,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 		SchemaUpdateRequest request = JsonUtil.readValue(json, SchemaUpdateRequest.class);
 		request.setUrlFields("slug");
 
-		grantAdminRole();
+		grantAdmin();
 		waitForJob(() -> {
 			call(() -> client().updateSchema(uuid, request));
 		});
@@ -403,7 +403,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 	@Test
 	public void testSetAutoPurgeToNull() {
-		grantAdminRole();
+		grantAdmin();
 		String schemaUuid = tx(() -> schemaContainer("folder").getUuid());
 		SchemaResponse response = call(() -> client().findSchemaByUuid(schemaUuid));
 		assertNull(response.getAutoPurge());
@@ -510,11 +510,11 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 			assertMigrationEvent(event, schemaVersion, schemaUuid);
 		});
 
-		grantAdminRole();
+		grantAdmin();
 		waitForJob(() -> {
 			call(() -> client().updateSchema(schemaUuid, schemaUpdate));
 		});
-		revokeAdminRole();
+		revokeAdmin();
 
 		awaitEvents();
 
@@ -593,7 +593,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 
 		call(() -> client().deleteSchema(uuid), BAD_REQUEST, "schema_delete_still_in_use", uuid);
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		waitForJobs(() -> {
 			SchemaResponse schemaResponse = call(() -> client().findSchemaByUuid(uuid));
 			SchemaUpdateRequest request = JsonUtil.readValue(schemaResponse.toJson(), SchemaUpdateRequest.class);

--- a/core/src/test/java/com/gentics/mesh/core/schema/field/string/StringFieldEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/field/string/StringFieldEndpointTest.java
@@ -22,7 +22,7 @@ public class StringFieldEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testResetAllowField() {
-		grantAdminRole();
+		grantAdmin();
 		final String schemaUuid = tx(() -> schemaContainer("content").getUuid());
 		final String nodeUuid = tx(() -> contentUuid());
 

--- a/core/src/test/java/com/gentics/mesh/core/schema/versioning/SchemaAutoPurgeEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/versioning/SchemaAutoPurgeEndpointTest.java
@@ -136,7 +136,7 @@ public class SchemaAutoPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testAutoPurgeForSchemaMigration() {
-		grantAdminRole();
+		grantAdmin();
 		enableAutoPurgeOnSchema();
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
 		String nodeUuid = contentUuid();
@@ -175,7 +175,7 @@ public class SchemaAutoPurgeEndpointTest extends AbstractMeshTest {
 
 	@Test
 	public void testAutoPurgeForMicroschemaMigration() {
-		grantAdminRole();
+		grantAdmin();
 		String microschemaUuid = tx(() -> microschemaContainer("vcard").getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
 		String nodeUuid = contentUuid();
@@ -210,7 +210,7 @@ public class SchemaAutoPurgeEndpointTest extends AbstractMeshTest {
 	}
 
 	private void enableAutoPurgeOnSchema() {
-		grantAdminRole();
+		grantAdmin();
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
 		assertThat(call(() -> client().findSchemaByUuid(contentSchemaUuid))).autoPurgeIsNotSet();
 		waitForJob(() -> {

--- a/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -413,6 +413,45 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 	}
 
 	@Test
+	public void testCreateAdmin() {
+		UserCreateRequest request = new UserCreateRequest();
+		request.setUsername("test1234");
+		request.setAdmin(true);
+		request.setPassword("finger");
+
+		grantAdmin();
+		UserResponse response = call(() -> client().createUser(request));
+		assertThat(response).isAdmin();
+
+		// Test missing permission
+		revokeAdmin();
+		request.setUsername("test4321");
+		call(() -> client().createUser(request), FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
+	}
+
+	@Test
+	public void testUpdateAdmin() {
+		UserCreateRequest createRequest = new UserCreateRequest();
+		createRequest.setUsername("test1234");
+		createRequest.setAdmin(false);
+		createRequest.setPassword("finger");
+
+		grantAdmin();
+		UserResponse response = call(() -> client().createUser(createRequest));
+		assertThat(response).isNotAdmin();
+
+		UserUpdateRequest updateRequest = new UserUpdateRequest();
+		updateRequest.setAdmin(true);
+		UserResponse response2 = call(() -> client().updateUser(response.getUuid(), updateRequest));
+		assertThat(response2).isAdmin();
+
+		// Test missing permission
+		revokeAdmin();
+		updateRequest.setAdmin(false);
+		call(() -> client().updateUser(response.getUuid(),updateRequest), FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
+	}
+
+	@Test
 	@Override
 	public void testReadMultiple() throws Exception {
 		final int intialUserCount = users().size();
@@ -1388,7 +1427,8 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 			assertNotNull("User should have been created.", user);
 			assertEquals(CREATED.code(), response.getStatusCode());
 			String location = response.getHeader(LOCATION.toString()).orElse(null);
-			assertEquals("Location header value did not match", "http://localhost:" + port() + CURRENT_API_BASE_PATH + "/users/" + user.getUuid(), location);
+			assertEquals("Location header value did not match", "http://localhost:" + port() + CURRENT_API_BASE_PATH + "/users/" + user.getUuid(),
+				location);
 		}
 	}
 
@@ -1408,7 +1448,8 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 			assertNotNull("User should have been created.", user);
 			assertEquals(CREATED.code(), response.getStatusCode());
 			String location = response.getHeader(LOCATION.toString()).orElse(null);
-			assertEquals("Location header value did not match", "http://jotschi.de:" + port() + CURRENT_API_BASE_PATH + "/users/" + user.getUuid(), location);
+			assertEquals("Location header value did not match", "http://jotschi.de:" + port() + CURRENT_API_BASE_PATH + "/users/" + user.getUuid(),
+				location);
 		}
 	}
 

--- a/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -419,12 +419,10 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		request.setAdmin(true);
 		request.setPassword("finger");
 
-		grantAdmin();
-		UserResponse response = call(() -> client().createUser(request));
+		UserResponse response = adminCall(() -> client().createUser(request));
 		assertThat(response).isAdmin();
 
 		// Test missing permission
-		revokeAdmin();
 		request.setUsername("test4321");
 		call(() -> client().createUser(request), FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
 	}
@@ -436,17 +434,15 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		createRequest.setAdmin(false);
 		createRequest.setPassword("finger");
 
-		grantAdmin();
-		UserResponse response = call(() -> client().createUser(createRequest));
+		UserResponse response = adminCall(() -> client().createUser(createRequest));
 		assertThat(response).isNotAdmin();
 
 		UserUpdateRequest updateRequest = new UserUpdateRequest();
 		updateRequest.setAdmin(true);
-		UserResponse response2 = call(() -> client().updateUser(response.getUuid(), updateRequest));
+		UserResponse response2 = adminCall(() -> client().updateUser(response.getUuid(), updateRequest));
 		assertThat(response2).isAdmin();
 
 		// Test missing permission
-		revokeAdmin();
 		updateRequest.setAdmin(false);
 		call(() -> client().updateUser(response.getUuid(),updateRequest), FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
 	}

--- a/core/src/test/java/com/gentics/mesh/core/user/UserTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/user/UserTest.java
@@ -568,7 +568,7 @@ public class UserTest extends AbstractMeshTest implements BasicObjectTestcases {
 			String hash = oldUser.getRolesHash();
 
 			// Add another role to the groups only oldUser is in.
-			grantAdminRole();
+			grantAdmin();
 
 			// The roles have changed for oldUser ...
 			assertNotEquals(hash, oldUser.getRolesHash());

--- a/core/src/test/java/com/gentics/mesh/core/webroot/WebRootEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/webroot/WebRootEndpointTest.java
@@ -507,7 +507,7 @@ public class WebRootEndpointTest extends AbstractMeshTest {
 		String newsUuid = tx(() -> folder("news").getUuid());
 
 		// 1. create new branch and migrate node
-		grantAdminRole();
+		grantAdmin();
 		waitForJobs(() -> {
 			BranchCreateRequest branchCreateRequest = new BranchCreateRequest();
 			branchCreateRequest.setName(newBranchName);

--- a/core/src/test/java/com/gentics/mesh/linkrenderer/BranchLinkRendererTest.java
+++ b/core/src/test/java/com/gentics/mesh/linkrenderer/BranchLinkRendererTest.java
@@ -86,7 +86,7 @@ public class BranchLinkRendererTest extends AbstractMeshTest {
 		latestBranchUuid = call(() -> client().findBranches(PROJECT_NAME)).getData().get(0).getUuid();
 
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		contentUuid = tx(() -> content("news overview").getUuid());
 

--- a/core/src/test/java/com/gentics/mesh/search/AbstractNodeSearchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/AbstractNodeSearchEndpointTest.java
@@ -179,11 +179,11 @@ public abstract class AbstractNodeSearchEndpointTest extends AbstractMultiESTest
 			SchemaUpdateRequest.class));
 		request.getField("teaser").setElasticsearch(IndexOptionHelper.getRawFieldOption());
 
-		grantAdminRole();
+		grantAdmin();
 		waitForJob(() -> {
 			call(() -> client().updateSchema(schemaUuid, request));
 		});
-		revokeAdminRole();
+		revokeAdmin();
 	}
 
 }

--- a/core/src/test/java/com/gentics/mesh/search/LanguageOverrideSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/LanguageOverrideSearchTest.java
@@ -56,7 +56,6 @@ public class LanguageOverrideSearchTest extends AbstractMultiESTest {
 
 	@Test
 	public void testIndexCountAfterRemovingSettings() {
-		grantAdmin();
 		int originalIndexCount = getIndexCount();
 		SchemaResponse schema = createSchema(loadResourceJsonAsPojo("schemas/languageOverride/page.json", SchemaCreateRequest.class));
 		waitForSearchIdleEvent();

--- a/core/src/test/java/com/gentics/mesh/search/LanguageOverrideSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/LanguageOverrideSearchTest.java
@@ -56,7 +56,7 @@ public class LanguageOverrideSearchTest extends AbstractMultiESTest {
 
 	@Test
 	public void testIndexCountAfterRemovingSettings() {
-		grantAdminRole();
+		grantAdmin();
 		int originalIndexCount = getIndexCount();
 		SchemaResponse schema = createSchema(loadResourceJsonAsPojo("schemas/languageOverride/page.json", SchemaCreateRequest.class));
 		waitForSearchIdleEvent();
@@ -77,7 +77,7 @@ public class LanguageOverrideSearchTest extends AbstractMultiESTest {
 
 	@Test
 	public void testSchemaMigration() {
-		grantAdminRole();
+		grantAdmin();
 		int originalIndexCount = getIndexCount();
 		SchemaResponse schema = createSchema(loadResourceJsonAsPojo("schemas/languageOverride/page.json", SchemaCreateRequest.class));
 		createContent();
@@ -99,7 +99,7 @@ public class LanguageOverrideSearchTest extends AbstractMultiESTest {
 
 	@Test
 	public void testIndexCountAfterMigratingOldSchema() {
-		grantAdminRole();
+		grantAdmin();
 		int originalIndexCount = getIndexCount();
 		SchemaResponse schema = createSchema(loadResourceJsonAsPojo("schemas/languageOverride/pageNoEs.json", SchemaCreateRequest.class));
 		waitForSearchIdleEvent();

--- a/core/src/test/java/com/gentics/mesh/search/NodeBinaryDisabledSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeBinaryDisabledSearchTest.java
@@ -52,7 +52,7 @@ public class NodeBinaryDisabledSearchTest extends AbstractNodeSearchEndpointTest
 	@Test
 	@Category({FailingTests.class})
 	public void testBinarySearchMapping() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
@@ -117,7 +117,7 @@ public class NodeBinaryDisabledSearchTest extends AbstractNodeSearchEndpointTest
 
 	@Test
 	public void testDocumentSearch() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
@@ -160,7 +160,7 @@ public class NodeBinaryDisabledSearchTest extends AbstractNodeSearchEndpointTest
 
 	@Test
 	public void testImageSearch() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());

--- a/core/src/test/java/com/gentics/mesh/search/NodeBinaryDisabledSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeBinaryDisabledSearchTest.java
@@ -117,7 +117,6 @@ public class NodeBinaryDisabledSearchTest extends AbstractNodeSearchEndpointTest
 
 	@Test
 	public void testDocumentSearch() throws Exception {
-		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());

--- a/core/src/test/java/com/gentics/mesh/search/NodeBinaryDocumentMigrationTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeBinaryDocumentMigrationTest.java
@@ -30,7 +30,7 @@ public class NodeBinaryDocumentMigrationTest extends AbstractMultiESTest {
 
 	@Test
 	public void schemaMigrationWithDocumentBinary() {
-		grantAdminRole();
+		grantAdmin();
 		uploadDocumentNode();
 		waitForJobs(this::migrateSchema, JobStatus.COMPLETED, 1);
 	}

--- a/core/src/test/java/com/gentics/mesh/search/NodeBinarySearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeBinarySearchTest.java
@@ -52,7 +52,7 @@ public class NodeBinarySearchTest extends AbstractNodeSearchEndpointTest {
 
 	@Test
 	public void testBinarySearchMapping() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
@@ -146,7 +146,7 @@ public class NodeBinarySearchTest extends AbstractNodeSearchEndpointTest {
 
 	@Test
 	public void testDocumentSearch() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());
@@ -189,7 +189,7 @@ public class NodeBinarySearchTest extends AbstractNodeSearchEndpointTest {
 
 	@Test
 	public void testImageSearch() throws IOException {
-		grantAdminRole();
+		grantAdmin();
 		Node nodeA = content("concorde");
 		String nodeUuid = tx(() -> nodeA.getUuid());
 		String contentSchemaUuid = tx(() -> schemaContainer("content").getUuid());

--- a/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointATest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointATest.java
@@ -100,7 +100,7 @@ public class NodeSearchEndpointATest extends AbstractNodeSearchEndpointTest {
 	@Test
 	public void testSearchWithBranchUuid() throws Exception {
 		recreateIndices();
-		grantAdminRole();
+		grantAdmin();
 
 		String query = getSimpleTermQuery("branchUuid", initialBranchUuid());
 		long initialCount = call(() -> client().searchNodes(PROJECT_NAME, query)).getMetainfo().getTotalCount();
@@ -132,7 +132,7 @@ public class NodeSearchEndpointATest extends AbstractNodeSearchEndpointTest {
 		fields.add(new StringFieldSchemaImpl().setName("test").setLabel("Test"));
 
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		// Wait for migration to complete
 		waitForJobs(() -> {

--- a/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointBTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointBTest.java
@@ -132,7 +132,7 @@ public class NodeSearchEndpointBTest extends AbstractNodeSearchEndpointTest {
 
 	@Test
 	public void testSearchDraftInBranch() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		recreateIndices();
 
 		NodeResponse concorde = call(() -> client().findNodeByUuid(PROJECT_NAME, db().tx(() -> content("concorde").getUuid()),

--- a/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointCTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointCTest.java
@@ -120,8 +120,7 @@ public class NodeSearchEndpointCTest extends AbstractNodeSearchEndpointTest {
 		addRawToSchemaField();
 		recreateIndices();
 
-		// Add the user to the admin group - this way the user is in fact an admin.
-		tx(() -> user().addGroup(groups().get("admin")));
+		grantAdmin();
 
 		waitForEvent(INDEX_SYNC_FINISHED, () -> {
 			GenericMessageResponse message = call(() -> client().invokeIndexSync());

--- a/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointDTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointDTest.java
@@ -134,12 +134,12 @@ public class NodeSearchEndpointDTest extends AbstractNodeSearchEndpointTest {
 		SchemaResponse updatedSchema = call(() -> client().findSchemaByUuid(schemaUuid));
 
 		// Wait for migration to complete
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		waitForJobs(() -> {
 			call(() -> client().assignBranchSchemaVersions(PROJECT_NAME, db().tx(() -> project().getLatestBranch().getUuid()),
 				new SchemaReferenceImpl().setUuid(updatedSchema.getUuid()).setVersion(updatedSchema.getVersion())));
 		}, COMPLETED, 1);
-		tx(() -> group().removeRole(roles().get("admin")));
+		revokeAdmin();
 
 		waitForSearchIdleEvent();
 

--- a/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointGTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointGTest.java
@@ -108,11 +108,11 @@ public class NodeSearchEndpointGTest extends AbstractNodeSearchEndpointTest {
 		schemaUpdate.addField(FieldUtil.createMicronodeFieldSchema("micro").setAllowedMicroSchemas("TestMicroschema"));
 
 		// Trigger the migration
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		waitForJobs(() -> {
 			call(() -> client().updateSchema(schemaUuid, schemaUpdate));
 		}, COMPLETED, 1);
-		tx(() -> group().removeRole(roles().get("admin")));
+		revokeAdmin();
 
 		waitForSearchIdleEvent();
 
@@ -143,11 +143,11 @@ public class NodeSearchEndpointGTest extends AbstractNodeSearchEndpointTest {
 		microschemaUpdate.addField(FieldUtil.createStringFieldSchema("textNew"));
 		microschemaUpdate.addField(FieldUtil.createNodeFieldSchema("nodeRefNew").setAllowedSchemas("content"));
 
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 		waitForJobs(() -> {
 			call(() -> client().updateMicroschema(microschemaUuid, microschemaUpdate));
 		}, COMPLETED, 1);
-		tx(() -> group().removeRole(roles().get("admin")));
+		revokeAdmin();
 
 		// Update the node and populate the new fields
 		NodeUpdateRequest updateRequest = new NodeUpdateRequest();
@@ -175,7 +175,7 @@ public class NodeSearchEndpointGTest extends AbstractNodeSearchEndpointTest {
 
 	@Test
 	public void testSearchPublishedInBranch() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		recreateIndices();
 
 		String uuid = tx(() -> content("concorde").getUuid());

--- a/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointStrictModeTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/NodeSearchEndpointStrictModeTest.java
@@ -46,11 +46,11 @@ public class NodeSearchEndpointStrictModeTest extends AbstractNodeSearchEndpoint
 		JsonObject keywordMapping = new JsonObject().put("index", true).put("type", "keyword");
 		request.getField("teaser").setElasticsearch(keywordMapping);
 
-		grantAdminRole();
+		grantAdmin();
 		waitForJob(() -> {
 			call(() -> client().updateSchema(schemaUuid, request));
 		});
-		revokeAdminRole();
+		revokeAdmin();
 
 	}
 

--- a/core/src/test/java/com/gentics/mesh/search/SchemaSearchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/SchemaSearchEndpointTest.java
@@ -58,7 +58,7 @@ public class SchemaSearchEndpointTest extends AbstractMultiESTest implements Bas
 	public void testEmptySchema() throws Exception {
 		final String SCHEMA_NAME = "TestSchema";
 		final String parentNodeUuid = tx(() -> project().getBaseNode().getUuid());
-		grantAdminRole();
+		grantAdmin();
 		try (Tx tx = tx()) {
 			recreateIndices();
 		}

--- a/core/src/test/java/com/gentics/mesh/search/index/BasicIndexSyncTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/BasicIndexSyncTest.java
@@ -52,7 +52,7 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 	@Test
 	@Ignore("Fails on CI pipeline. See https://github.com/gentics/mesh/issues/608")
 	public void testIndexSyncLock() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		tx(() -> {
 			for (int i = 0; i < 900; i++) {
 				boot().groupRoot().create("group_" + i, user(), null);
@@ -66,14 +66,14 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 
 	@Test
 	public void testNoPermSync() {
-		revokeAdminRole();
+		revokeAdmin();
 		call(() -> client().invokeIndexSync(), FORBIDDEN, "error_admin_permission_required");
 	}
 
 	@Test
 	public void testResync() throws Exception {
 		// Add the user to the admin group - this way the user is in fact an admin.
-		grantAdminRole();
+		grantAdmin();
 		searchProvider().refreshIndex().blockingAwait();
 
 		waitForEvent(INDEX_SYNC_FINISHED, () -> {

--- a/core/src/test/java/com/gentics/mesh/search/index/BranchIndexSyncTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/BranchIndexSyncTest.java
@@ -23,8 +23,6 @@ public class BranchIndexSyncTest extends AbstractMeshTest {
 
 	@Test
 	public void testSyncWithUnmigratedBranch() {
-		grantAdmin();
-
 		// 1. Create second branch
 		waitForJob(() -> {
 			BranchCreateRequest branchCreateRequest = new BranchCreateRequest();

--- a/core/src/test/java/com/gentics/mesh/search/index/BranchIndexSyncTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/BranchIndexSyncTest.java
@@ -23,7 +23,7 @@ public class BranchIndexSyncTest extends AbstractMeshTest {
 
 	@Test
 	public void testSyncWithUnmigratedBranch() {
-		grantAdminRole();
+		grantAdmin();
 
 		// 1. Create second branch
 		waitForJob(() -> {

--- a/core/src/test/java/com/gentics/mesh/search/index/IndexClearTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/IndexClearTest.java
@@ -25,7 +25,7 @@ public class IndexClearTest extends AbstractMeshTest {
 		waitForEvent(INDEX_SYNC_FINISHED, () -> SyncEventHandler.invokeSync(vertx()));
 
 		call(() -> client().invokeIndexClear(), FORBIDDEN, "error_admin_permission_required");
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		GenericMessageResponse message = call(() -> client().invokeIndexClear());
 		assertThat(message).matches("search_admin_index_clear");

--- a/core/src/test/java/com/gentics/mesh/search/index/IndexSyncCleanupTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/IndexSyncCleanupTest.java
@@ -39,7 +39,7 @@ public class IndexSyncCleanupTest extends AbstractMeshTest {
 
 	@Before
 	public void setup() {
-		grantAdminRole();
+		grantAdmin();
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/search/index/NodeIndexSyncTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/NodeIndexSyncTest.java
@@ -45,11 +45,7 @@ public class NodeIndexSyncTest extends AbstractMeshTest {
 		response = call(() -> client().searchNodes(PROJECT_NAME, getSimpleQuery("fields.content", oldContent)));
 		assertThat(response.getData()).as("Published search result").usingElementComparatorOnFields("uuid").containsOnly(concorde);
 
-		// Add the user to the admin group - this way the user is in fact an admin.
-		try (Tx tx = tx()) {
-			user().addGroup(data().getGroups().get("admin"));
-			tx.success();
-		}
+		grantAdmin();
 
 		// Now clear all data
 		searchProvider().clear().blockingAwait();

--- a/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTest.java
@@ -158,7 +158,6 @@ public class NodeMigrationSearchTest extends AbstractNodeSearchEndpointTest {
 	@Test
 	@Category({FailingTests.class})
 	public void searchDuringMigration() throws Exception {
-		grantAdmin();
 		String query = getSimpleTermQuery("schema.name.raw", "folder");
 
 		recreateIndices();
@@ -174,11 +173,7 @@ public class NodeMigrationSearchTest extends AbstractNodeSearchEndpointTest {
 		waitForLatestJob(() -> {
 			migrateSchema("folder", false).blockingAwait();
 
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-			}
+			sleep(1000);
 
 			NodeListResponse duringMigration = client().searchNodes(query, new SearchParametersImpl().setWait(false)).blockingGet();
 

--- a/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTest.java
@@ -93,7 +93,7 @@ public class NodeMigrationSearchTest extends AbstractNodeSearchEndpointTest {
 		schemaUpdateRequest.setName(SCHEMA_NAME);
 		schemaUpdateRequest.getFields().add(FieldUtil.createStringFieldSchema("name").setElasticsearch(IndexOptionHelper.getRawFieldOption()));
 		schemaUpdateRequest.setSegmentField("name");
-		grantAdminRole();
+		grantAdmin();
 
 		waitForJobs(() -> {
 			call(() -> client().updateSchema(schemaResponse.getUuid(), schemaUpdateRequest));
@@ -139,7 +139,7 @@ public class NodeMigrationSearchTest extends AbstractNodeSearchEndpointTest {
 		fields.add(new StringFieldSchemaImpl().setName("test").setLabel("Test"));
 
 		// Grant admin perms. Otherwise we can't check the jobs
-		tx(() -> group().addRole(roles().get("admin")));
+		grantAdmin();
 
 		// Wait for migration to complete
 		waitForJobs(() -> {
@@ -158,7 +158,7 @@ public class NodeMigrationSearchTest extends AbstractNodeSearchEndpointTest {
 	@Test
 	@Category({FailingTests.class})
 	public void searchDuringMigration() throws Exception {
-		grantAdminRole();
+		grantAdmin();
 		String query = getSimpleTermQuery("schema.name.raw", "folder");
 
 		recreateIndices();

--- a/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTrackingTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTrackingTest.java
@@ -22,7 +22,7 @@ public class NodeMigrationSearchTrackingTest extends AbstractNodeSearchEndpointT
 
 	@Test
 	public void testMigrationRequests() {
-		grantAdminRole();
+		grantAdmin();
 		waitForJob(() -> {
 			waitForSearchIdleEvent(migrateSchema("folder"));
 		});

--- a/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTrackingTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/migration/NodeMigrationSearchTrackingTest.java
@@ -22,7 +22,6 @@ public class NodeMigrationSearchTrackingTest extends AbstractNodeSearchEndpointT
 
 	@Test
 	public void testMigrationRequests() {
-		grantAdmin();
 		waitForJob(() -> {
 			waitForSearchIdleEvent(migrateSchema("folder"));
 		});

--- a/core/src/test/java/com/gentics/mesh/search/raw/NodeRawSearchEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/raw/NodeRawSearchEndpointTest.java
@@ -7,7 +7,7 @@ import static com.gentics.mesh.test.TestSize.FULL;
 import static com.gentics.mesh.test.context.ElasticsearchTestMode.CONTAINER_ES6;
 import static com.gentics.mesh.test.context.MeshTestHelper.getSimpleQuery;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 
@@ -81,11 +81,11 @@ public class NodeRawSearchEndpointTest extends AbstractMeshTest {
 
 		JsonObject hitOne = hits.getJsonObject(0);
 		String uuid1 = hitOne.getString("_id");
-		assertEquals(initialBranchUuid(), hitOne.getJsonObject("_source").getString("branchUuid"));
+		assertNotNull(hitOne.getJsonObject("_source").getString("branchUuid"));
 
 		JsonObject hitTwo = hits.getJsonObject(1);
 		String uuid2 = hitTwo.getString("_id");
-		assertEquals(initialBranchUuid(), hitTwo.getJsonObject("_source").getString("branchUuid"));
+		assertNotNull(initialBranchUuid(), hitTwo.getJsonObject("_source").getString("branchUuid"));
 
 		assertThat(Arrays.asList(uuid1, uuid2)).containsExactlyInAnyOrder(nodeA.getUuid() + "-en", nodeB.getUuid() + "-en");
 

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -681,12 +681,12 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		meshApi().getOptions().getAuthenticationOptions().setEnableAnonymousAccess(false);
 	}
 
-	default void grantAdminRole() {
-		tx(() -> group().addRole(roles().get("admin")));
+	default void grantAdmin() {
+		tx(() -> user().setAdmin(true));
 	}
 
-	default void revokeAdminRole() {
-		tx(() -> group().removeRole(roles().get("admin")));
+	default void revokeAdmin() {
+		tx(() -> user().setAdmin(false));
 	}
 
 	default void assertFilesInDir(String path, long expectedCount) {

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -27,6 +27,7 @@ import com.gentics.mesh.FieldUtil;
 import com.gentics.mesh.MeshStatus;
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
+import com.gentics.mesh.core.data.Branch;
 import com.gentics.mesh.core.data.Group;
 import com.gentics.mesh.core.data.MeshAuthUser;
 import com.gentics.mesh.core.data.Role;
@@ -111,6 +112,14 @@ public interface TestHelper extends EventHelper, ClientHelper {
 
 	default Role anonymousRole() {
 		return data().getAnonymousRole();
+	}
+
+	@Override
+	default Branch createBranch(String name, boolean latest) {
+		grantAdmin();
+		Branch branch = ClientHelper.super.createBranch(name, latest);
+		revokeAdmin();
+		return branch;
 	}
 
 	default MeshRoot meshRoot() {

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -45,6 +45,7 @@ import com.gentics.mesh.core.rest.common.GenericMessageResponse;
 import com.gentics.mesh.core.rest.group.GroupCreateRequest;
 import com.gentics.mesh.core.rest.group.GroupResponse;
 import com.gentics.mesh.core.rest.group.GroupUpdateRequest;
+import com.gentics.mesh.core.rest.job.JobListResponse;
 import com.gentics.mesh.core.rest.microschema.impl.MicroschemaCreateRequest;
 import com.gentics.mesh.core.rest.microschema.impl.MicroschemaResponse;
 import com.gentics.mesh.core.rest.microschema.impl.MicroschemaUpdateRequest;
@@ -106,20 +107,8 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		return data().getUserInfo().getUser().reframe(MeshAuthUserImpl.class);
 	}
 
-	default User user() {
-		return data().user();
-	}
-
 	default Role anonymousRole() {
 		return data().getAnonymousRole();
-	}
-
-	@Override
-	default Branch createBranch(String name, boolean latest) {
-		grantAdmin();
-		Branch branch = ClientHelper.super.createBranch(name, latest);
-		revokeAdmin();
-		return branch;
 	}
 
 	default MeshRoot meshRoot() {
@@ -688,14 +677,6 @@ public interface TestHelper extends EventHelper, ClientHelper {
 
 	default void disableAnonymousAccess() {
 		meshApi().getOptions().getAuthenticationOptions().setEnableAnonymousAccess(false);
-	}
-
-	default void grantAdmin() {
-		tx(() -> user().setAdmin(true));
-	}
-
-	default void revokeAdmin() {
-		tx(() -> user().setAdmin(false));
 	}
 
 	default void assertFilesInDir(String path, long expectedCount) {

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/BaseHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/BaseHelper.java
@@ -8,6 +8,7 @@ import com.gentics.madl.tx.TxAction2;
 import com.gentics.mesh.Mesh;
 import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.core.data.Project;
+import com.gentics.mesh.core.data.User;
 import com.gentics.mesh.dagger.MeshComponent;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.etc.config.search.ComplianceMode;
@@ -39,6 +40,18 @@ public interface BaseHelper {
 
 	default TestDataProvider data() {
 		return getTestContext().getData();
+	}
+
+	default User user() {
+		return data().user();
+	}
+
+	default void grantAdmin() {
+		tx(() -> user().setAdmin(true));
+	}
+
+	default void revokeAdmin() {
+		tx(() -> user().setAdmin(false));
 	}
 
 	/**

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/ClientHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/ClientHelper.java
@@ -20,7 +20,10 @@ import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaUpdateRequest;
 import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
 import com.gentics.mesh.rest.client.MeshRequest;
+import com.gentics.mesh.rest.client.MeshRestClientMessageException;
+import com.gentics.mesh.test.context.ClientHandler;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -137,6 +140,19 @@ public interface ClientHelper extends EventHelper {
 		request.setSchemaName("binary_content");
 		request.setParentNodeUuid(parentUuid);
 		return client().createNode(uuid, PROJECT_NAME, request).toSingle();
+	}
+
+	default <T> MeshRestClientMessageException adminCall(ClientHandler<T> handler, HttpResponseStatus status, String bodyMessageI18nKey,
+		String... i18nParams) {
+		return runAsAdmin(() -> {
+			return com.gentics.mesh.test.ClientHelper.call(handler, status, bodyMessageI18nKey, i18nParams);
+		});
+	}
+
+	default <T> T adminCall(ClientHandler<T> handler) {
+		return runAsAdmin(() -> {
+			return com.gentics.mesh.test.ClientHelper.call(handler);
+		});
 	}
 
 }

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
@@ -233,7 +233,7 @@ public interface EventHelper extends BaseHelper {
 
 	default void waitForLatestJob(Runnable action, JobStatus status) {
 		// Load a status just before the action
-		JobListResponse before = call(() -> client().findJobs());
+		JobListResponse before = runAsAdmin(() -> call(() -> client().findJobs()));
 
 		// Invoke the action
 		action.run();
@@ -241,7 +241,7 @@ public interface EventHelper extends BaseHelper {
 		// Now poll the migration status and check the response
 		final int MAX_WAIT = 120;
 		for (int i = 0; i < MAX_WAIT; i++) {
-			JobListResponse response = call(() -> client().findJobs());
+			JobListResponse response = runAsAdmin(() -> call(() -> client().findJobs()));
 			List<JobResponse> diff = TestUtils.difference(response.getData(), before.getData(), JobResponse::getUuid);
 			if (diff.size() > 1) {
 				System.out.println(response.toJson());
@@ -281,7 +281,7 @@ public interface EventHelper extends BaseHelper {
 		// Now poll the migration status and check the response
 		final int MAX_WAIT = 120;
 		for (int i = 0; i < MAX_WAIT; i++) {
-			JobResponse response = call(() -> client().findJobByUuid(jobUuid));
+			JobResponse response = runAsAdmin(() -> call(() -> client().findJobByUuid(jobUuid)));
 
 			if (response.getStatus().equals(status)) {
 				return response;
@@ -325,7 +325,7 @@ public interface EventHelper extends BaseHelper {
 		waitForJob(() -> {
 			MeshEvent.triggerJobWorker(meshApi());
 		}, jobUuid, status);
-		return call(() -> client().findJobs());
+		return runAsAdmin(() -> call(() -> client().findJobs()));
 	}
 
 	default void triggerAndWaitForAllJobs(JobStatus expectedStatus) {
@@ -334,7 +334,7 @@ public interface EventHelper extends BaseHelper {
 		// Now poll the migration status and check the response
 		final int MAX_WAIT = 120;
 		for (int i = 0; i < MAX_WAIT; i++) {
-			JobListResponse response = call(() -> client().findJobs(new PagingParametersImpl().setPerPage(200L)));
+			JobListResponse response = runAsAdmin(() -> call(() -> client().findJobs(new PagingParametersImpl().setPerPage(200L))));
 
 			boolean allDone = true;
 			for (JobResponse info : response.getData()) {

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import com.gentics.mesh.cli.BootstrapInitializerImpl;
 import com.gentics.mesh.core.rest.MeshEvent;
@@ -145,6 +146,37 @@ public interface EventHelper extends BaseHelper {
 	}
 
 	/**
+	 * Run the given action with admin permissions enabled.
+	 * 
+	 * @param action
+	 * @throws Exception
+	 */
+	default <T> T runAsAdmin(Supplier<T> action) {
+		boolean isAdmin = tx(() -> user().isAdmin());
+		// Grant perms to check the job
+		if (!isAdmin) {
+			grantAdmin();
+		}
+		T t = action.get();
+		if (isAdmin) {
+			revokeAdmin();
+		}
+		return t;
+	}
+
+	default void runAsAdmin(Runnable action) {
+		boolean isAdmin = tx(() -> user().isAdmin());
+		// Grant perms to check the job
+		if (!isAdmin) {
+			grantAdmin();
+		}
+		action.run();
+		if (isAdmin) {
+			revokeAdmin();
+		}
+	}
+
+	/**
 	 * Execute the action and check that the jobs are executed and yields the given status.
 	 *
 	 * @param action
@@ -156,8 +188,11 @@ public interface EventHelper extends BaseHelper {
 	 * @return Migration status
 	 */
 	default JobListResponse waitForJobs(Runnable action, JobStatus status, int expectedJobs) {
+
 		// Load a status just before the action
-		JobListResponse before = call(() -> client().findJobs());
+		JobListResponse before = runAsAdmin(() -> {
+			return call(() -> client().findJobs());
+		});
 
 		// Invoke the action
 		action.run();
@@ -165,7 +200,9 @@ public interface EventHelper extends BaseHelper {
 		// Now poll the migration status and check the response
 		final int MAX_WAIT = 120;
 		for (int i = 0; i < MAX_WAIT; i++) {
-			JobListResponse response = call(() -> client().findJobs());
+
+			JobListResponse response = runAsAdmin(() -> call(() -> client().findJobs()));
+
 			if (response.getMetainfo().getTotalCount() == before.getMetainfo().getTotalCount() + expectedJobs) {
 				if (status != null) {
 					boolean allMatching = true;

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
@@ -158,7 +158,7 @@ public interface EventHelper extends BaseHelper {
 			grantAdmin();
 		}
 		T t = action.get();
-		if (isAdmin) {
+		if (!isAdmin) {
 			revokeAdmin();
 		}
 		return t;
@@ -171,7 +171,7 @@ public interface EventHelper extends BaseHelper {
 			grantAdmin();
 		}
 		action.run();
-		if (isAdmin) {
+		if (!isAdmin) {
 			revokeAdmin();
 		}
 	}

--- a/core/src/test/resources/graphql/user-query
+++ b/core/src/test/resources/graphql/user-query
@@ -6,6 +6,10 @@
 	user(name: "admin") {
 		# [$.data.user.username=admin]
 		username
+
+		# [$.data.user.admin=true]
+		admin
+
 		emailAddress
 		# [$.data.user.forcedPasswordChange=false]
 		forcedPasswordChange

--- a/doc/src/main/docs/administration-guide.asciidoc
+++ b/doc/src/main/docs/administration-guide.asciidoc
@@ -98,19 +98,20 @@ include::content/docs/examples/models/mesh-cli-help.txt[]
 On first startup, Gentics Mesh will create all files and folders.
 
  data
-    binaryFiles
-    binaryImageCache
-    graphdb
-    tmp
+    binaryFiles                # Folder for uploads
+    binaryImageCache           # Folder for resized and cached images
+    graphdb                    # Main Graph Database storage which contains all contents
+    tmp                        # Temporary directory
  config
-    keystore.jceks
-    default-distributed-db-config.json
-    orientdb-server-config.xml
-    security.json
-    hazelcast.xml
-    mesh-ui-config.js
-    mesh.yml
-elasticsearch
+    mesh.yml                   # Main Gentics Mesh configuration
+    automatic-backup.json      # OrientDB Automatic Backup configuration 
+    default-distributed-db-config.json # Default configuration for new Cluster Nodes
+    hazelcast.xml              # Hazelcast cluster configuration
+    keystore.jceks             # Gentics Mesh keystore used to generate and validate JWT's
+    logback.xml                # Logging configuration file
+    orientdb-server-config.xml # OrientDB Cluster Server configuration
+    security.json              # OrientDB security configuration
+    mesh-ui-config.js          # Configuration of the Mesh UI
 
 Gentics Mesh ships with two configuration files:
 
@@ -323,6 +324,17 @@ The following numbers serve the purpose to roughly estimate the memory requireme
 | 10_000 to 100_000    | `-Xms1250m -Xmx1250m -XX:MaxDirectMemorySize=512m  -Dstorage.diskCache.bufferSize=512`
 | 100_000 to 1_000_000 | `-Xms2500m -Xmx2500m -XX:MaxDirectMemorySize=1024m -Dstorage.diskCache.bufferSize=1024`
 |======
+
+== Admin Access
+
+By default an `admin` user will be created during initial startup. The password of this user will be printed in the log. 
+It is mandatory to update the admin password during the first login.
+
+NOTE: For demo installations the password is `admin`.
+
+Additional admin users can be created by setting the `admin` flag the users.
+
+NOTE: The admin access can be restored via the use of the `resetAdminPassword` link:#cli[mesh server argument].
 
 == Backup & Recovery
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/AdminIndexHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/AdminIndexHandler.java
@@ -79,9 +79,9 @@ public class AdminIndexHandler {
 	}
 
 	public void handleSync(InternalActionContext ac) {
-		db.asyncTx(() -> Single.just(ac.getUser().hasAdminRole()))
-			.subscribe(hasAdminRole -> {
-				if (hasAdminRole) {
+		db.asyncTx(() -> Single.just(ac.getUser().isAdmin()))
+			.subscribe(isAdmin -> {
+				if (isAdmin) {
 					SyncEventHandler.invokeSync(vertx);
 					ac.send(message(ac, "search_admin_index_sync_invoked"), OK);
 				} else {
@@ -91,8 +91,8 @@ public class AdminIndexHandler {
 	}
 
 	public void handleClear(InternalActionContext ac) {
-		db.asyncTx(() -> Single.just(ac.getUser().hasAdminRole())).flatMapCompletable(hasAdminRole -> {
-			if (hasAdminRole) {
+		db.asyncTx(() -> Single.just(ac.getUser().isAdmin())).flatMapCompletable(isAdmin -> {
+			if (isAdmin) {
 				return searchProvider.clear()
 					.andThen(Observable.fromIterable(registry.getHandlers())
 					.flatMapCompletable(handler -> handler.init()));

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/user/UserCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/user/UserCreateRequest.java
@@ -41,6 +41,10 @@ public class UserCreateRequest implements RestModel {
 	@JsonPropertyDescription("When true, the user needs to change their password on the next login.")
 	private Boolean forcedPasswordChange;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag which indicates whether the user is an admin.")
+	private Boolean admin;
+
 	public UserCreateRequest() {
 	}
 
@@ -205,5 +209,23 @@ public class UserCreateRequest implements RestModel {
 	 */
 	public Boolean getForcedPasswordChange() {
 		return forcedPasswordChange;
+	}
+
+	/**
+	 * Return the admin flag for the user.
+	 * 
+	 * @return
+	 */
+	public Boolean getAdmin() {
+		return admin;
+	}
+
+	/**
+	 * Set the admin flag on the user. Note that only admins can create admin users.
+	 * 
+	 * @param flag
+	 */
+	public void setAdmin(Boolean flag) {
+		this.admin = flag;
 	}
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/user/UserResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/user/UserResponse.java
@@ -51,6 +51,10 @@ public class UserResponse extends AbstractGenericRestResponse {
 	@JsonPropertyDescription("When true, the user needs to change their password on the next login.")
 	private Boolean forcedPasswordChange;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag which indicates whether the user is an admin.")
+	private Boolean admin;
+
 	public UserResponse() {
 	}
 
@@ -270,6 +274,24 @@ public class UserResponse extends AbstractGenericRestResponse {
 	public UserResponse setForcedPasswordChange(Boolean forcedPasswordChange) {
 		this.forcedPasswordChange = forcedPasswordChange;
 		return this;
+	}
+
+	/**
+	 * Return the admin flag.
+	 * 
+	 * @return
+	 */
+	public Boolean getAdmin() {
+		return admin;
+	}
+
+	/**
+	 * Set the admin flag.
+	 * 
+	 * @param flag
+	 */
+	public void setAdmin(Boolean flag) {
+		this.admin = flag;
 	}
 
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/user/UserUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/user/UserUpdateRequest.java
@@ -39,6 +39,9 @@ public class UserUpdateRequest implements RestModel {
 	@JsonPropertyDescription("When true, the user needs to change their password on the next login.")
 	private Boolean forcedPasswordChange;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag which indicates whether the user is an admin.")
+	private Boolean admin;
 
 	public UserUpdateRequest() {
 	}
@@ -204,6 +207,24 @@ public class UserUpdateRequest implements RestModel {
 	public UserUpdateRequest setForcedPasswordChange(Boolean forcedPasswordChange) {
 		this.forcedPasswordChange = forcedPasswordChange;
 		return this;
+	}
+
+	/**
+	 * Return the admin flag.
+	 * 
+	 * @return
+	 */
+	public Boolean getAdmin() {
+		return admin;
+	}
+
+	/**
+	 * Set the user update flag. Note that only admins can alter the flag.
+	 * 
+	 * @param flag
+	 */
+	public void setAdmin(Boolean flag) {
+		this.admin = flag;
 	}
 
 }

--- a/server/src/main/java/com/gentics/mesh/server/DevRunner.java
+++ b/server/src/main/java/com/gentics/mesh/server/DevRunner.java
@@ -21,6 +21,9 @@ public class DevRunner {
 	static {
 		System.setProperty("vertx.httpServiceFactory.cacheDir", "data" + File.separator + "tmp");
 		System.setProperty("vertx.cacheDirBase", "data" + File.separator + "tmp");
+		if ("jotschi".equalsIgnoreCase(System.getProperty("user.name"))) {
+			System.setProperty("storage.wal.allowDirectIO", "false");
+		}
 	}
 
 	public static void main(String[] args) throws Exception {

--- a/test-common/src/main/java/com/gentics/mesh/assertj/impl/UserResponseAssert.java
+++ b/test-common/src/main/java/com/gentics/mesh/assertj/impl/UserResponseAssert.java
@@ -9,6 +9,8 @@ import org.assertj.core.api.AbstractAssert;
 import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class UserResponseAssert extends AbstractAssert<UserResponseAssert, UserResponse> {
 
@@ -88,6 +90,20 @@ public class UserResponseAssert extends AbstractAssert<UserResponseAssert, UserR
 
 	public UserResponseAssert hasName(String name) {
 		assertThat(actual.getUsername()).as(String.format("User has name %s", name)).isEqualTo(name);
+		return this;
+	}
+
+	public UserResponseAssert isNotAdmin() {
+		Boolean flag = actual.getAdmin();
+		if (flag != null && flag == true) {
+			fail("The user should not have the admin flag set.");
+		}
+		return this;
+	}
+
+	public UserResponseAssert isAdmin() {
+		assertNotNull(actual.getAdmin());
+		assertTrue(actual.getAdmin());
 		return this;
 	}
 }

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/PluginTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/PluginTypeProvider.java
@@ -53,7 +53,7 @@ public class PluginTypeProvider extends AbstractTypeProvider {
 		return newFieldDefinition().name("plugin").description("Load plugin by id").argument(createIdArg("Id of the plugin."))
 			.type(new GraphQLTypeReference(PLUGIN_TYPE_NAME)).dataFetcher(env -> {
 				GraphQLContext gc = env.getContext();
-				if (!gc.getUser().hasAdminRole()) {
+				if (!gc.getUser().isAdmin()) {
 					return new PermissionException("plugins", "Missing admin permission");
 				}
 				String id = env.getArgument("id");
@@ -78,7 +78,7 @@ public class PluginTypeProvider extends AbstractTypeProvider {
 		return newFieldDefinition().name("plugins").description("Load plugins").argument(createPagingArgs())
 			.type(new GraphQLTypeReference(PLUGIN_PAGE_TYPE_NAME)).dataFetcher(env -> {
 				GraphQLContext gc = env.getContext();
-				if (!gc.getUser().hasAdminRole()) {
+				if (!gc.getUser().isAdmin()) {
 					return new PermissionException("plugins", "Missing admin permission");
 				}
 				Map<String, MeshPlugin> deployments = manager.getPluginsMap();

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/UserTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/UserTypeProvider.java
@@ -79,6 +79,15 @@ public class UserTypeProvider extends AbstractTypeProvider {
 			return user.isForcedPasswordChange();
 		}));
 
+		// .admin
+		root.field(newFieldDefinition()
+		.name("admin")
+		.description("Flag which indicates whether the user has admin privileges.")
+		.type(GraphQLBoolean).dataFetcher((env) -> {
+			User user = env.getSource();
+			return user.isAdmin();
+		}));
+
 		// .groups
 		root.field(newPagingFieldWithFetcher("groups", "Groups to which the user belongs.", (env) -> {
 			User user = env.getSource();


### PR DESCRIPTION
## Abstract

Fixes https://github.com/gentics/mesh/issues/1095 by adding a dedicated admin flag for users and avoid the usage of the role for admin operations.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
