### PR TITLE
Add check for failed plugin deployments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,11 @@ include::content/docs/variables.adoc-include[]
 
 * The Mesh Server will require Java 11 with the release of 2.0.0. The runtime support for Java 8 will be dropped. The Mesh Java REST client will still be usable with Java 8.
 
+[[next]]
+== Next
+
+icon:plus[] Monitoring: The readiness probe will now also check for plugin status. Failed plugin deployments will let the readiness probe fail.
+
 [[v1.5.3]]
 == 1.5.3 (16.07.2020)
 

--- a/core/src/test/java/com/gentics/mesh/plugin/FailingShutdownPlugin.java
+++ b/core/src/test/java/com/gentics/mesh/plugin/FailingShutdownPlugin.java
@@ -7,7 +7,7 @@ import com.gentics.mesh.plugin.env.PluginEnvironment;
 import io.reactivex.Completable;
 
 /**
- * Plugin that will fail the start
+ * Plugin that will fail the stop
  */
 public class FailingShutdownPlugin extends AbstractPlugin {
 


### PR DESCRIPTION
## Abstract

Adds plugin status checks to the readiness probe. This way mesh will only indicate that it is ready when all plugins have been registered.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
