### PR TITLE
Allow user to change its node reference

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,10 @@ include::content/docs/variables.adoc-include[]
 
 * The Mesh Server will require Java 11 with the release of 2.0.0. The runtime support for Java 8 will be dropped. The Mesh Java REST client will still be usable with Java 8.
 
+[[TBD]]
+
+icon:check[] Core: Fixed a bug that which prevented to update a node reference of a user if the user already had one set. link:https://github.com/gentics/mesh/issues/1114[#1114]
+
 [[v1.4.9]]
 == 1.4.9 (07.04.2020)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -287,7 +287,7 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 
 	@Override
 	public User setReferencedNode(Node node) {
-		setUniqueLinkOutTo(node, HAS_NODE_REFERENCE);
+		setSingleLinkOutTo(node, HAS_NODE_REFERENCE);
 		return this;
 	}
 

--- a/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -1,7 +1,6 @@
 package com.gentics.mesh.core.user;
 
 import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
-
 import static com.gentics.mesh.core.data.User.composeIndexName;
 import static com.gentics.mesh.core.data.relationship.GraphPermission.CREATE_PERM;
 import static com.gentics.mesh.core.data.relationship.GraphPermission.DELETE_PERM;
@@ -636,7 +635,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		String nodeUuid = tx(() -> folder("news").getUuid());
 		String nodeUuid2 = tx(() -> folder("2015").getUuid());
 		String userUuid = userUuid();
-		HibUser user = user();
+		User user = user();
 		UserUpdateRequest updateRequest = new UserUpdateRequest();
 		String username = tx(() -> user.getUsername());
 		try (Tx tx = tx()) {
@@ -658,14 +657,13 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		UserResponse restUser = call(() -> client().updateUser(userUuid, updateRequest));
 
 		try (Tx tx = tx()) {
-			UserDaoWrapper userDao = tx.data().userDao();
 			assertNotNull(user().getReferencedNode());
 			assertNotNull(restUser.getNodeReference());
 			assertEquals(PROJECT_NAME, ((NodeReference) restUser.getNodeReference()).getProjectName());
 			assertEquals(nodeUuid, restUser.getNodeReference().getUuid());
 			assertThat(restUser).matches(updateRequest);
-			assertNull("The user node should have been updated and thus no user should be found.", userDao.findByUsername(username));
-			HibUser reloadedUser = userDao.findByUsername("dummy_user_changed");
+			assertNull("The user node should have been updated and thus no user should be found.", boot().userRoot().findByUsername(username));
+			User reloadedUser = boot().userRoot().findByUsername("dummy_user_changed");
 			assertNotNull(reloadedUser);
 			assertEquals("Epic Stark", reloadedUser.getLastname());
 			assertEquals("Tony Awesome", reloadedUser.getFirstname());


### PR DESCRIPTION
## Abstract
Fixes part of #1114 
See `UserEndpointTest#testUpdateNodeReferenceTwice` for the test
## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
