### PR TITLE
Add liveness probe check for failed plugins

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[TBD]]
+== TBD (TBD)
+
+icon:plus[] Monitoring: The liveness probe will now check for plugin status. Failed plugin deployments will let the liveness probe fail.
+
 [[v1.4.14]]
 == 1.4.14 (02.09.2020)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/handler/MonitoringCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/handler/MonitoringCrudHandler.java
@@ -33,9 +33,7 @@ public class MonitoringCrudHandler {
 		for (String id : pluginManager.getPluginIds()) {
 			PluginStatus status = pluginManager.getStatus(id);
 			if (status == PluginStatus.FAILED) {
-				if (log.isDebugEnabled()) {
-					log.debug("Plugin {" + id + "} is in status failed.");
-				}
+				log.warn("Plugin {" + id + "} is in status failed.");
 				throw error(SERVICE_UNAVAILABLE, "error_internal");
 			}
 		}
@@ -46,9 +44,7 @@ public class MonitoringCrudHandler {
 		for (String id : pluginManager.getPluginIds()) {
 			PluginStatus status = pluginManager.getStatus(id);
 			if (status != PluginStatus.REGISTERED) {
-				if (log.isDebugEnabled()) {
-					log.debug("Plugin {" + id + "} is not ready. Got status {" + status + "}");
-				}
+				log.warn("Plugin {" + id + "} is not ready. Got status {" + status + "}");
 				throw error(SERVICE_UNAVAILABLE, "error_internal");
 			}
 		}
@@ -57,9 +53,7 @@ public class MonitoringCrudHandler {
 		if (status.equals(MeshStatus.READY)) {
 			rc.response().end();
 		} else {
-			if (log.isDebugEnabled()) {
-				log.debug("Status is {" + status.name() + "} - Failing readiness probe");
-			}
+			log.warn("Status is {" + status.name() + "} - Failing readiness probe");
 			throw error(SERVICE_UNAVAILABLE, "error_internal");
 		}
 	}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/handler/MonitoringCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/handler/MonitoringCrudHandler.java
@@ -30,7 +30,15 @@ public class MonitoringCrudHandler {
 	}
 
 	public void handleLive(RoutingContext rc) {
-		// We currently don't have a situation which would justify to let the service being restarted automatically.
+		for (String id : pluginManager.getPluginIds()) {
+			PluginStatus status = pluginManager.getStatus(id);
+			if (status == PluginStatus.FAILED) {
+				if (log.isDebugEnabled()) {
+					log.debug("Plugin {" + id + "} is in status failed.");
+				}
+				throw error(SERVICE_UNAVAILABLE, "error_internal");
+			}
+		}
 		rc.response().setStatusCode(200).end();
 	}
 

--- a/core/src/test/java/com/gentics/mesh/core/monitoring/MonitoringServerEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/monitoring/MonitoringServerEndpointTest.java
@@ -56,12 +56,27 @@ public class MonitoringServerEndpointTest extends AbstractMeshTest {
 	}
 
 	@Test
-	public void testFailingPlugin() {
+	public void testReadinessFailingPlugin() {
 		MeshPluginManager manager = pluginManager();
 		manager.deploy(FailingInitializePlugin.class, "failing").blockingAwait();
 		try {
 			call(() -> monClient().ready());
 			fail("The ready probe should fail");
+		} catch (Exception e) {
+			// NOOP
+		}
+		manager.undeploy("failing").blockingAwait(2, TimeUnit.SECONDS);
+		assertEquals(0, manager.getPluginIds().size());
+		call(() -> monClient().ready());
+	}
+
+	@Test
+	public void testLivenessFailingPlugin() {
+		MeshPluginManager manager = pluginManager();
+		manager.deploy(FailingInitializePlugin.class, "failing").blockingAwait();
+		try {
+			call(() -> monClient().live());
+			fail("The liveness probe should fail");
 		} catch (Exception e) {
 			// NOOP
 		}


### PR DESCRIPTION
## Abstract

Adds liveness probe checks for failed plugins. This way K8S will restart the pod whenever a plugin deployment fails.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
