### PR TITLE
Use url fields for link resolving as fallback

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,10 @@ include::content/docs/variables.adoc-include[]
 
 * The support for the *embedded* version of Elasticsearch will be dropped in the future. It is highly recommended to link:{{< relref "elasticsearch.asciidoc" >}}#_dedicated_elasticsearch[setup Elasticsearch as a dedicated service].
 
+== TBD
+
+icon:plus[] Core: The link renderer now tries to use url fields to render the link if it cannot be constructed using segment fields.
+
 [[v1.7.1]]
 == 1.7.1 (05.09.2020)
 

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/RestructureWebrootIndex.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/RestructureWebrootIndex.java
@@ -4,6 +4,8 @@ import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_FIE
 import static com.gentics.mesh.core.rest.common.ContainerType.DRAFT;
 import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
 
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -72,7 +74,7 @@ public class RestructureWebrootIndex extends AbstractHighLevelChange {
 				if (container == null) {
 					continue;
 				}
-				edge.setUrlFieldInfo(contentDao.getUrlFieldValues(container));
+				edge.setUrlFieldInfo(contentDao.getUrlFieldValues(container).collect(Collectors.toSet()));
 				String segment = contentDao.getSegmentFieldValue(container);
 				if (segment != null && !segment.trim().isEmpty()) {
 					HibNode node = contentDao.getNode(container);

--- a/core/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
@@ -321,7 +321,8 @@ public class NodeImpl extends AbstractGenericFieldContainerVertex<NodeResponse, 
 	 */
 	private String getUrlFieldPath(String branchUuid, ContainerType type, String... languages) {
 		return Stream.of(languages)
-			.flatMap(language -> getGraphFieldContainer(language, branchUuid, type).getUrlFieldValues())
+			.flatMap(language -> Stream.ofNullable(getGraphFieldContainer(language, branchUuid, type)))
+			.flatMap(NodeGraphFieldContainer::getUrlFieldValues)
 			.findFirst()
 			.orElse(null);
 	}

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/BranchMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/BranchMigrationImpl.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.core.rest.job.JobStatus.RUNNING;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -143,7 +144,7 @@ public class BranchMigrationImpl extends AbstractMigrationHandler implements Bra
 					} else {
 						draftEdge.setSegmentInfo(null);
 					}
-					draftEdge.setUrlFieldInfo(container.getUrlFieldValues());
+					draftEdge.setUrlFieldInfo(container.getUrlFieldValues().collect(Collectors.toSet()));
 					batch.add(container.onUpdated(newBranch.getUuid(), DRAFT));
 				});
 
@@ -163,7 +164,7 @@ public class BranchMigrationImpl extends AbstractMigrationHandler implements Bra
 					} else {
 						publishEdge.setSegmentInfo(null);
 					}
-					publishEdge.setUrlFieldInfo(container.getUrlFieldValues());
+					publishEdge.setUrlFieldInfo(container.getUrlFieldValues().collect(Collectors.toSet()));
 					batch.add(container.onUpdated(newBranch.getUuid(), PUBLISHED));
 				});
 

--- a/core/src/test/java/com/gentics/mesh/linkrenderer/ResolveUrlFieldsTest.java
+++ b/core/src/test/java/com/gentics/mesh/linkrenderer/ResolveUrlFieldsTest.java
@@ -1,0 +1,145 @@
+package com.gentics.mesh.linkrenderer;
+
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gentics.mesh.core.rest.node.FieldMap;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.field.StringField;
+import com.gentics.mesh.core.rest.node.field.list.impl.StringFieldListImpl;
+import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.impl.ListFieldSchemaImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaReferenceImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
+import com.gentics.mesh.parameter.LinkType;
+import com.gentics.mesh.parameter.impl.NodeParametersImpl;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+@MeshTestSetting(testSize = FULL, startServer = true)
+public class ResolveUrlFieldsTest extends AbstractMeshTest {
+	public static final String SCHEMA_NAME = "urlFieldSchema";
+	private String parentNodeUuid;
+
+	@Before
+	public void setUp() {
+		parentNodeUuid = getProject().getRootNode().getUuid();
+	}
+
+	@Test
+	public void testSingleStringField() {
+		addSchema(new StringFieldSchemaImpl().setName("url"));
+		NodeResponse referencedNode = addNode(FieldMap.of("url", StringField.of("/some/test/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testMultipleStringFields() {
+		addSchema(new StringFieldSchemaImpl().setName("url"), new StringFieldSchemaImpl().setName("url2"));
+		NodeResponse referencedNode = addNode(FieldMap.of("url2", StringField.of("/some/test/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testStringListField() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"));
+		NodeResponse referencedNode = addNode(FieldMap.of("urls", StringFieldListImpl.of("/some/test/url", "/some/other/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testStringListFieldWithEmptyEntry() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"));
+		NodeResponse referencedNode = addNode(FieldMap.of("urls", StringFieldListImpl.of("", "/some/other/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/other/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testMultipleStringListFields() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"), new ListFieldSchemaImpl().setListType("string").setName("urls2"));
+		NodeResponse referencedNode = addNode(FieldMap.of(
+			"urls", StringFieldListImpl.of("/some/test/url", "/some/other/url"),
+			"urls2", StringFieldListImpl.of("/some/test/url2", "/some/other/url2")
+		));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testMixedFields() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"), new StringFieldSchemaImpl().setName("url"));
+		NodeResponse referencedNode = addNode(FieldMap.of(
+			"url", StringField.of("/some/test/url")
+		));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	private String resolveLink(NodeResponse referencedNode) {
+		return client().resolveLinks(
+			createLink(referencedNode.getUuid()),
+			new NodeParametersImpl().setResolveLinks(LinkType.SHORT)
+		).blockingGet();
+	}
+
+	private SchemaResponse addSchema(FieldSchema... fieldSchemas) {
+		SchemaCreateRequest request = new SchemaCreateRequest();
+		request.setName(SCHEMA_NAME);
+		request.setFields(Arrays.asList(fieldSchemas));
+		request.setUrlFields(Stream.of(fieldSchemas)
+			.map(FieldSchema::getName)
+			.collect(Collectors.toList()));
+		SchemaResponse schemaResponse = client().createSchema(request).blockingGet();
+		client().assignSchemaToProject(PROJECT_NAME, schemaResponse.getUuid()).blockingAwait();
+		return schemaResponse;
+	}
+
+	private NodeResponse addReferencingNode(NodeResponse referencedNode) {
+		NodeCreateRequest request = new NodeCreateRequest();
+		request.setParentNodeUuid(parentNodeUuid);
+		request.setSchema(new SchemaReferenceImpl().setName("content"));
+		request.setLanguage("en");
+		request.setFields(FieldMap.of("content", StringField.of(createLink(referencedNode.getUuid()))));
+		return client().createNode(PROJECT_NAME, request).blockingGet();
+	}
+
+	private NodeResponse addNode(FieldMap fields) {
+		NodeCreateRequest request = new NodeCreateRequest();
+		request.setParentNodeUuid(parentNodeUuid);
+		request.setSchema(new SchemaReferenceImpl().setName(SCHEMA_NAME));
+		request.setLanguage("en");
+		request.setFields(fields);
+		return client().createNode(PROJECT_NAME, request).blockingGet();
+	}
+
+	private String createLink(String uuid) {
+		return String.format("{{mesh.link('%s')}}", uuid);
+	}
+}

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/NodeGraphFieldContainer.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/NodeGraphFieldContainer.java
@@ -7,6 +7,7 @@ import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
@@ -321,11 +322,11 @@ public interface NodeGraphFieldContainer extends GraphFieldContainer, EditorTrac
 	void postfixSegmentFieldValue();
 
 	/**
-	 * Return the URL field values for the container.
+	 * Return the URL field values for the container. The order of fields returned is the same order defined in the schema.
 	 * 
 	 * @return
 	 */
-	Set<String> getUrlFieldValues();
+	Stream<String> getUrlFieldValues();
 
 	/**
 	 * Traverse to the base node and build up the path to this container.

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/dao/ContentDaoWrapper.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/dao/ContentDaoWrapper.java
@@ -707,7 +707,7 @@ public interface ContentDaoWrapper extends ContentDao {
 	 *
 	 * @return
 	 */
-	Set<String> getUrlFieldValues(NodeGraphFieldContainer content);
+	Stream<String> getUrlFieldValues(NodeGraphFieldContainer content);
 
 	/**
 	 * Traverse to the base node and build up the path to this container.

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/ContentDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/ContentDaoWrapperImpl.java
@@ -249,7 +249,7 @@ public class ContentDaoWrapperImpl implements ContentDaoWrapper {
 	}
 
 	@Override
-	public Set<String> getUrlFieldValues(NodeGraphFieldContainer content) {
+	public Stream<String> getUrlFieldValues(NodeGraphFieldContainer content) {
 		return content.getUrlFieldValues();
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/ContentWrapper.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/ContentWrapper.java
@@ -647,7 +647,7 @@ public class ContentWrapper implements NodeGraphFieldContainer, HibContent {
 		delegate.postfixSegmentFieldValue();
 	}
 
-	public Set<String> getUrlFieldValues() {
+	public Stream<String> getUrlFieldValues() {
 		return delegate.getUrlFieldValues();
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/list/impl/StringFieldListImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/list/impl/StringFieldListImpl.java
@@ -1,4 +1,17 @@
 package com.gentics.mesh.core.rest.node.field.list.impl;
 
+import java.util.Arrays;
+
 public class StringFieldListImpl extends AbstractFieldList<String> {
+	/**
+	 * Creates a string field list.
+	 *
+	 * @param values
+	 * @return
+	 */
+	public static StringFieldListImpl of(String... values) {
+		StringFieldListImpl stringFieldList = new StringFieldListImpl();
+		stringFieldList.setItems(Arrays.asList(values));
+		return stringFieldList;
+	}
 }


### PR DESCRIPTION
## Abstract
If a link cannot be resolved via segment fields, url fields should be used as a fallback, if they exist.
This happens if a node or one of its ascendents has no segment field set.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
