### PR TITLE
Improve webroot cache error handling

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,8 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.0.34`.
 
+icon:check[] Rest: The webroot cache error handling has been improved.
+
 [[1.4.15]]
 == 1.4.15 (23.09.2020)
 

--- a/common/src/main/java/com/gentics/mesh/path/Path.java
+++ b/common/src/main/java/com/gentics/mesh/path/Path.java
@@ -5,10 +5,17 @@ import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
+import com.gentics.mesh.core.data.NodeGraphFieldContainer;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 /**
  * A webroot path consists of multiple segments. This class provides a useful container which can be used when resolving webroot paths.
  */
 public class Path {
+
+	private static final Logger log = LoggerFactory.getLogger(Path.class);
 
 	private List<PathSegment> segments = new ArrayList<>();
 
@@ -116,6 +123,27 @@ public class Path {
 
 	public boolean isPrefixMismatch() {
 		return prefixMismatch;
+	}
+
+	/**
+	 * Check whether all segments in the path are valid.
+	 * 
+	 * @return
+	 */
+	public boolean isValid() {
+		for (PathSegment segment : segments) {
+			try {
+				NodeGraphFieldContainer container = segment.getContainer();
+				if (container == null || container.getElement() == null) {
+					log.debug("Container or element of container is null. Segment is invalid.");
+					return false;
+				}
+			} catch (RuntimeException e) {
+				log.debug("Error while checking path segment {" + segment.getSegment() + "}", e);
+				return false;
+			}
+		}
+		return true;
 	}
 
 }

--- a/core/src/main/java/com/gentics/mesh/cache/WebrootPathCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/WebrootPathCacheImpl.java
@@ -73,7 +73,12 @@ public class WebrootPathCacheImpl extends AbstractMeshCache<String, Path> implem
 			return null;
 		}
 		String key = createCacheKey(project, branch, type, path);
-		return cache.get(key);
+		Path value = cache.get(key);
+		if (value == null || !value.isValid()) {
+			return null;
+		} else {
+			return value;
+		}
 	}
 
 	@Override

--- a/core/src/main/java/com/gentics/mesh/dagger/MeshComponent.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/MeshComponent.java
@@ -12,6 +12,7 @@ import com.gentics.mesh.auth.provider.MeshJWTAuthProvider;
 import com.gentics.mesh.cache.PermissionCache;
 import com.gentics.mesh.cache.ProjectBranchNameCache;
 import com.gentics.mesh.cache.ProjectNameCache;
+import com.gentics.mesh.cache.WebrootPathCache;
 import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.core.data.binary.Binaries;
@@ -169,6 +170,8 @@ public interface MeshComponent {
 	PermissionProperties permissionProperties();
 
 	WriteLock globalLock();
+
+	WebrootPathCache pathCache();
 
 	RoleCrudHandler roleCrudHandler();
 

--- a/core/src/test/java/com/gentics/mesh/core/webroot/WebRootEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/webroot/WebRootEndpointTest.java
@@ -27,10 +27,14 @@ import com.gentics.mesh.FieldUtil;
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.core.data.Branch;
 import com.gentics.mesh.core.data.NodeGraphFieldContainer;
+import com.gentics.mesh.core.data.container.impl.NodeGraphFieldContainerImpl;
 import com.gentics.mesh.core.data.node.Node;
+import com.gentics.mesh.core.data.node.field.StringGraphField;
+import com.gentics.mesh.core.data.node.field.impl.StringGraphFieldImpl;
 import com.gentics.mesh.core.data.relationship.GraphPermission;
 import com.gentics.mesh.core.data.schema.SchemaContainer;
 import com.gentics.mesh.core.rest.branch.BranchCreateRequest;
+import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.job.JobStatus;
 import com.gentics.mesh.core.rest.node.NodeCreateRequest;
 import com.gentics.mesh.core.rest.node.NodeResponse;
@@ -42,6 +46,8 @@ import com.gentics.mesh.parameter.LinkType;
 import com.gentics.mesh.parameter.impl.NodeParametersImpl;
 import com.gentics.mesh.parameter.impl.PublishParametersImpl;
 import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
+import com.gentics.mesh.path.Path;
+import com.gentics.mesh.path.PathSegment;
 import com.gentics.mesh.rest.client.MeshBinaryResponse;
 import com.gentics.mesh.rest.client.MeshResponse;
 import com.gentics.mesh.rest.client.MeshWebrootResponse;
@@ -93,6 +99,28 @@ public class WebRootEndpointTest extends AbstractMeshTest {
 		assertThat(response.getNodeResponse()).is(node).hasLanguage("en");
 		assertFalse(response.isBinary());
 		assertEquals("Webroot response node uuid header value did not match", nodeUuid, response.getNodeUuid());
+	}
+
+	@Test
+	public void testInvaliedWebrootPath() {
+		Node node = folder("2015");
+		String path = "/News/2015";
+
+		call(() -> client().webroot(PROJECT_NAME, path, new VersioningParametersImpl().draft()));
+		call(() -> client().webroot(PROJECT_NAME, path, new VersioningParametersImpl().draft()));
+
+		// Modify the cache entry by adding another bogus segment. The validation should pick up the inconsistency and invalidate the whole path entry
+		tx(tx -> {
+			NodeGraphFieldContainerImpl bogusContainer = tx.addVertex(NodeGraphFieldContainerImpl.class);
+			StringGraphField bogusField = new StringGraphFieldImpl("name", bogusContainer);
+			Path entry = mesh().pathCache().getPath(project(), initialBranch(), ContainerType.DRAFT, path);
+			entry.addSegment(new PathSegment(bogusContainer, bogusField, "en", "bogus"));
+			tx.rollback();
+		});
+
+		// Now ensure that the bogus cache entry is ignored and regular response is returned
+		MeshWebrootResponse response = call(() -> client().webroot(PROJECT_NAME, path, new VersioningParametersImpl().draft()));
+		assertThat(response.getNodeResponse()).is(node).hasLanguage("en");
 	}
 
 	@Test


### PR DESCRIPTION
## Abstract

Improves webroot cache entry error handling by validating graph elements within the cache entries.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
