### PR TITLE
Add cluster changelog check

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -24,6 +24,8 @@ icon:check[] Clustering: Internal caches will now be cleared when cluster topolo
 
 icon:plus[] Backup: The `?consistencyCheck` query parameter was added to the `/api/v2/admin/backup` endpoint. When set to true it will run the consistency check before invoking the backup. The call will fail when inconsistencies were detected.
 
+icon:check[] Clustering: An additional check has been added which will prevent nodes from joining a cluster which contains an outdated database. The `-initCluster` flag needs to be used for a single instance to migrate the cluster. This is done to prevent concurrency issues during changelog execution and cluster formation.
+
 [[v1.4.16]]
 == 1.4.16 (06.09.2020)
 

--- a/changelog-system/src/main/java/com/gentics/mesh/changelog/ChangelogSystem.java
+++ b/changelog-system/src/main/java/com/gentics/mesh/changelog/ChangelogSystem.java
@@ -75,6 +75,27 @@ public class ChangelogSystem {
 	}
 
 	/**
+	 * Check whether all changes have been applied or whether the changelog would need to apply changes.
+	 * 
+	 * @return
+	 */
+	public boolean requiresChanges() {
+		List<Change> changes = ChangesList.getList(options);
+		TransactionalGraph graph = db.rawTx();
+		try {
+			for (Change change : changes) {
+				if (!change.isApplied()) {
+					log.info("Change " + change.getName() + " has not yet been applied.");
+					return true;
+				}
+			}
+		} finally {
+			graph.shutdown();
+		}
+		return false;
+	}
+
+	/**
 	 * Mark all changelog entries as applied. This is useful if you resolved issues manually or if you want to create a fresh mesh database dump.
 	 */
 	public void markAllAsApplied(List<Change> list) {

--- a/changelog-system/src/main/java/com/gentics/mesh/changelog/ChangelogSystem.java
+++ b/changelog-system/src/main/java/com/gentics/mesh/changelog/ChangelogSystem.java
@@ -84,6 +84,8 @@ public class ChangelogSystem {
 		TransactionalGraph graph = db.rawTx();
 		try {
 			for (Change change : changes) {
+				change.setGraph(graph);
+				change.setDb(db);
 				if (!change.isApplied()) {
 					log.info("Change " + change.getName() + " has not yet been applied.");
 					return true;

--- a/common/src/main/java/com/gentics/mesh/cli/BootstrapInitializer.java
+++ b/common/src/main/java/com/gentics/mesh/cli/BootstrapInitializer.java
@@ -267,4 +267,11 @@ public interface BootstrapInitializer {
 	 */
 	boolean isVertxReady();
 
+	/**
+	 * Check whether the execution of the changelog is required.
+	 * 
+	 * @return 
+	 */
+	boolean requiresChangelog();
+
 }

--- a/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
+++ b/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
@@ -21,7 +21,7 @@ public interface ClusterManager {
 	 * 
 	 * @throws Exception
 	 */
-	void start() throws Exception;
+	void startAndSync() throws Exception;
 
 	/**
 	 * Stop the server and release all used resources.

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/HighLevelChangelogSystem.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/HighLevelChangelogSystem.java
@@ -90,4 +90,22 @@ public class HighLevelChangelogSystem {
 		});
 	}
 
+	/**
+	 * Check whether any high level changelog entry needs to be applied.
+	 * 
+	 * @param meshRoot
+	 * @return
+	 */
+	public boolean requiresChanges(MeshRoot meshRoot) {
+		return db.tx(tx -> {
+			List<HighLevelChange> changes = highLevelChangesList.getList();
+			for (HighLevelChange change : changes) {
+				if (!isApplied(meshRoot, change)) {
+					return true;
+				}
+			}
+			return false;
+		});
+	}
+
 }

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -303,7 +303,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				db.closeConnectionPool();
 				db.shutdown();
 
-				db.clusterManager().start();
+				db.clusterManager().startAndSync();
 				db.clusterManager().registerEventHandlers();
 				db.setupConnectionPool();
 				searchProvider.init();
@@ -313,7 +313,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				}
 			} else {
 				// We need to wait for other nodes and receive the graphdb
-				db.clusterManager().start();
+				db.clusterManager().startAndSync();
 				db.clusterManager().registerEventHandlers();
 				isInitialSetup = false;
 				db.setupConnectionPool();
@@ -341,7 +341,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 			initLocalData(options, false);
 			if (startOrientServer) {
 				db.closeConnectionPool();
-				db.clusterManager().start();
+				db.clusterManager().startAndSync();
 				db.setupConnectionPool();
 			}
 		}

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
@@ -381,7 +381,7 @@ public class OrientDBClusterManager implements ClusterManager {
 	 * @throws Exception
 	 */
 	@Override
-	public void start() throws Exception {
+	public void startAndSync() throws Exception {
 
 		String orientdbHome = new File("").getAbsolutePath();
 		System.setProperty("ORIENTDB_HOME", orientdbHome);


### PR DESCRIPTION
## Abstract

This change prevents nodes from joining a cluster which has an outdated database. The changelog should not be executed by joining members to prevent concurrency issues during the startup process.

This fix addresses the problem of upgrading cluster members without applying the changelog.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
