### PR TITLE
Use url fields for link resolving as fallback - Backport of PR 1129

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -21,6 +21,8 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.6.4]]
 == 1.6.4 (TBD)
 
+icon:plus[] Core: The link renderer now tries to use url fields to render the link if it cannot be constructed using segment fields.
+
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.4`.
 
 icon:check[] Clustering: The coordination feature will now be automatically disabled whenever clustering is disabled.

--- a/common/src/main/java/com/gentics/mesh/core/data/NodeGraphFieldContainer.java
+++ b/common/src/main/java/com/gentics/mesh/core/data/NodeGraphFieldContainer.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
@@ -481,11 +482,11 @@ public interface NodeGraphFieldContainer extends GraphFieldContainer, EditorTrac
 	void postfixSegmentFieldValue();
 
 	/**
-	 * Return the URL field values for the container.
+	 * Return the URL field values for the container. The order of fields returned is the same order defined in the schema.
 	 * 
 	 * @return
 	 */
-	Set<String> getUrlFieldValues();
+	Stream<String> getUrlFieldValues();
 
 	/**
 	 * Traverse to the base node and build up the path to this container.

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/RestructureWebrootIndex.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/RestructureWebrootIndex.java
@@ -4,6 +4,8 @@ import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_FIE
 import static com.gentics.mesh.core.rest.common.ContainerType.DRAFT;
 import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
 
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -67,7 +69,7 @@ public class RestructureWebrootIndex extends AbstractHighLevelChange {
 				if (container == null) {
 					continue;
 				}
-				edge.setUrlFieldInfo(container.getUrlFieldValues());
+				edge.setUrlFieldInfo(container.getUrlFieldValues().collect(Collectors.toSet()));
 				String segment = container.getSegmentFieldValue();
 				if (segment != null && !segment.trim().isEmpty()) {
 					Node node = container.getParentNode();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/migration/branch/BranchMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/migration/branch/BranchMigrationHandler.java
@@ -8,6 +8,7 @@ import static com.gentics.mesh.core.rest.job.JobStatus.RUNNING;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -139,7 +140,7 @@ public class BranchMigrationHandler extends AbstractMigrationHandler {
 					} else {
 						draftEdge.setSegmentInfo(null);
 					}
-					draftEdge.setUrlFieldInfo(container.getUrlFieldValues());
+					draftEdge.setUrlFieldInfo(container.getUrlFieldValues().collect(Collectors.toSet()));
 					batch.add(container.onUpdated(newBranch.getUuid(), DRAFT));
 				});
 
@@ -159,7 +160,7 @@ public class BranchMigrationHandler extends AbstractMigrationHandler {
 					} else {
 						publishEdge.setSegmentInfo(null);
 					}
-					publishEdge.setUrlFieldInfo(container.getUrlFieldValues());
+					publishEdge.setUrlFieldInfo(container.getUrlFieldValues().collect(Collectors.toSet()));
 					batch.add(container.onUpdated(newBranch.getUuid(), PUBLISHED));
 				});
 

--- a/core/src/test/java/com/gentics/mesh/linkrenderer/ResolveUrlFieldsTest.java
+++ b/core/src/test/java/com/gentics/mesh/linkrenderer/ResolveUrlFieldsTest.java
@@ -1,0 +1,185 @@
+package com.gentics.mesh.linkrenderer;
+
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gentics.mesh.core.rest.node.FieldMap;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.field.StringField;
+import com.gentics.mesh.core.rest.node.field.list.impl.StringFieldListImpl;
+import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.impl.ListFieldSchemaImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaReferenceImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
+import com.gentics.mesh.parameter.LinkType;
+import com.gentics.mesh.parameter.impl.NodeParametersImpl;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+@MeshTestSetting(testSize = FULL, startServer = true)
+public class ResolveUrlFieldsTest extends AbstractMeshTest {
+	public static final String SCHEMA_NAME = "urlFieldSchema";
+	private String parentNodeUuid;
+
+	@Before
+	public void setUp() {
+		parentNodeUuid = getProject().getRootNode().getUuid();
+	}
+
+	@Test
+	public void testSingleStringField() {
+		addSchema(new StringFieldSchemaImpl().setName("url"));
+		NodeResponse referencedNode = addNode(FieldMap.of("url", StringField.of("/some/test/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testMultipleStringFields() {
+		addSchema(new StringFieldSchemaImpl().setName("url"), new StringFieldSchemaImpl().setName("url2"));
+		NodeResponse referencedNode = addNode(FieldMap.of("url2", StringField.of("/some/test/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testStringListField() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"));
+		NodeResponse referencedNode = addNode(FieldMap.of("urls", StringFieldListImpl.of("/some/test/url", "/some/other/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testStringListFieldWithEmptyEntry() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"));
+		NodeResponse referencedNode = addNode(FieldMap.of("urls", StringFieldListImpl.of("", "/some/other/url")));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/other/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testMultipleStringListFields() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"), new ListFieldSchemaImpl().setListType("string").setName("urls2"));
+		NodeResponse referencedNode = addNode(FieldMap.of(
+			"urls", StringFieldListImpl.of("/some/test/url", "/some/other/url"),
+			"urls2", StringFieldListImpl.of("/some/test/url2", "/some/other/url2")
+		));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	@Test
+	public void testMixedFields() {
+		addSchema(new ListFieldSchemaImpl().setListType("string").setName("urls"), new StringFieldSchemaImpl().setName("url"));
+		NodeResponse referencedNode = addNode(FieldMap.of(
+			"url", StringField.of("/some/test/url")
+		));
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	/**
+	 * Tests a node that has a segment field set, but one of its ascendants misses a segment field.
+	 * In that case, a fallback to url fields is expected.
+	 */
+	@Test
+	public void testWithMissingParentSegment() {
+		// Create Schema
+		SchemaCreateRequest request = new SchemaCreateRequest();
+		request.setName(SCHEMA_NAME);
+		request.setFields(Arrays.asList(
+			new StringFieldSchemaImpl().setName("url"),
+			new StringFieldSchemaImpl().setName("slug")
+		));
+		request.setUrlFields("url");
+		request.setSegmentField("slug");
+		SchemaResponse schemaResponse = client().createSchema(request).blockingGet();
+		client().assignSchemaToProject(PROJECT_NAME, schemaResponse.getUuid()).blockingAwait();
+
+		// Create parent
+		NodeCreateRequest nodeCreateRequest = new NodeCreateRequest();
+		nodeCreateRequest.setLanguage("en");
+		nodeCreateRequest.setParentNodeUuid(parentNodeUuid);
+		nodeCreateRequest.setSchemaName("folder");
+		NodeResponse parentNode = client().createNode(PROJECT_NAME, nodeCreateRequest).blockingGet();
+
+		NodeResponse referencedNode = addNode(parentNode.getUuid(), FieldMap.of(
+			"url", StringField.of("/some/test/url"),
+			"slug", StringField.of("testSlug")
+		));
+
+		String result = resolveLink(referencedNode);
+		assertThat(result).isEqualTo("/some/test/url");
+		String resultUuid = client().webroot(PROJECT_NAME, result).blockingGet().getNodeUuid();
+		assertThat(referencedNode.getUuid()).isEqualTo(resultUuid);
+	}
+
+	private String resolveLink(NodeResponse referencedNode) {
+		return client().resolveLinks(
+			createLink(referencedNode.getUuid()),
+			new NodeParametersImpl().setResolveLinks(LinkType.SHORT)
+		).blockingGet();
+	}
+
+	private SchemaResponse addSchema(FieldSchema... fieldSchemas) {
+		SchemaCreateRequest request = new SchemaCreateRequest();
+		request.setName(SCHEMA_NAME);
+		request.setFields(Arrays.asList(fieldSchemas));
+		request.setUrlFields(Stream.of(fieldSchemas)
+			.map(FieldSchema::getName)
+			.collect(Collectors.toList()));
+		SchemaResponse schemaResponse = client().createSchema(request).blockingGet();
+		client().assignSchemaToProject(PROJECT_NAME, schemaResponse.getUuid()).blockingAwait();
+		return schemaResponse;
+	}
+
+	private NodeResponse addReferencingNode(NodeResponse referencedNode) {
+		NodeCreateRequest request = new NodeCreateRequest();
+		request.setParentNodeUuid(parentNodeUuid);
+		request.setSchema(new SchemaReferenceImpl().setName("content"));
+		request.setLanguage("en");
+		request.setFields(FieldMap.of("content", StringField.of(createLink(referencedNode.getUuid()))));
+		return client().createNode(PROJECT_NAME, request).blockingGet();
+	}
+
+	private NodeResponse addNode(String parentNodeUuid, FieldMap fields) {
+		NodeCreateRequest request = new NodeCreateRequest();
+		request.setParentNodeUuid(parentNodeUuid);
+		request.setSchema(new SchemaReferenceImpl().setName(SCHEMA_NAME));
+		request.setLanguage("en");
+		request.setFields(fields);
+		return client().createNode(PROJECT_NAME, request).blockingGet();
+	}
+
+	private NodeResponse addNode(FieldMap fields) {
+		return addNode(parentNodeUuid, fields);
+	}
+
+	private String createLink(String uuid) {
+		return String.format("{{mesh.link('%s')}}", uuid);
+	}
+}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/list/impl/StringFieldListImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/list/impl/StringFieldListImpl.java
@@ -1,4 +1,18 @@
 package com.gentics.mesh.core.rest.node.field.list.impl;
 
+import java.util.Arrays;
+
 public class StringFieldListImpl extends AbstractFieldList<String> {
+
+	/**
+	 * Creates a string field list.
+	 *
+	 * @param values
+	 * @return
+	 */
+	public static StringFieldListImpl of(String... values) {
+		StringFieldListImpl stringFieldList = new StringFieldListImpl();
+		stringFieldList.setItems(Arrays.asList(values));
+		return stringFieldList;
+	}
 }


### PR DESCRIPTION
## Abstract

Backports https://github.com/gentics/mesh/pull/1129 to hotfix-1.6.x

Java  9 specific API calls had to be changed in order to work with Java 8

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
