### PR TITLE
UVEK-455 Add versioning flag to schemas

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,7 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
-[[v1.4.17]] 
+[[v1.4.18]]
+== 1.4.18 (TBD)
+
+icon:plus[] Versioning: Versioning can now be disabled per Schema.
+
+[[v1.4.17]]
 == 1.4.17 (27.10.2020)
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.4`.

--- a/common/src/main/java/com/gentics/mesh/core/data/schema/SchemaContainerVersion.java
+++ b/common/src/main/java/com/gentics/mesh/core/data/schema/SchemaContainerVersion.java
@@ -60,9 +60,14 @@ public interface SchemaContainerVersion
 	TraversalResult<? extends Node> getNodes(String branchUuid, User user, ContainerType type);
 
 	/**
-	 * Check whether versioning is disabled by default or via the schema setting.
+	 * Check whether auto purge is enabled by default or via the schema setting.
 	 * @return
 	 */
 	boolean isAutoPurgeEnabled();
 
+	/**
+	 * Check whether versioning is enabled.
+	 * @return Whether versioning is enabled
+	 */
+	boolean isVersioning();
 }

--- a/common/src/main/java/com/gentics/mesh/core/data/schema/UpdateSchemaChange.java
+++ b/common/src/main/java/com/gentics/mesh/core/data/schema/UpdateSchemaChange.java
@@ -16,84 +16,98 @@ public interface UpdateSchemaChange extends FieldSchemaContainerUpdateChange<Sch
 
 	/**
 	 * Set the displayField name.
-	 * 
+	 *
 	 * @param fieldName
 	 */
 	void setDisplayField(String fieldName);
 
 	/**
 	 * Return the displayField name.
-	 * 
+	 *
 	 * @return
 	 */
 	String getDisplayField();
 
 	/**
 	 * Set the container flag.
-	 * 
+	 *
 	 * @param flag
 	 */
 	void setContainerFlag(Boolean flag);
 
 	/**
 	 * Return the container flag.
-	 * 
+	 *
 	 * @return
 	 */
 	Boolean getContainerFlag();
 
 	/**
 	 * Return the auto purge flag.
-	 * 
+	 *
 	 * @return
 	 */
 	Boolean getAutoPurgeFlag();
 
 	/**
 	 * Set the auto purge flag.
-	 * 
+	 *
 	 * @param flag
 	 */
 	void setAutoPurgeFlag(Boolean flag);
 
 	/**
+	 * Return the versioning flag.
+	 *
+	 * @return The versioning flag
+	 */
+	Boolean getVersioningFlag();
+
+	/**
+	 * Set the versioning flag.
+	 *
+	 * @param flag The value for the versioning flag
+	 */
+	void setVersioningFlag(Boolean flag);
+
+	/**
 	 * Set the segmentField name.
-	 * 
+	 *
 	 * @param fieldName
 	 */
 	void setSegmentField(String fieldName);
 
 	/**
 	 * Return the segmentField name.
-	 * 
+	 *
 	 * @return
 	 */
 	String getSegmentField();
 
 	/**
 	 * Set the url fields
-	 * 
+	 *
 	 * @param keys
 	 */
 	void setURLFields(String... keys);
 
 	/**
 	 * Return the list of url fields.
-	 * 
+	 *
 	 * @return
 	 */
 	List<String> getURLFields();
 
 	/**
 	 * Return the index options which were stored with this change.
-	 * 
+	 *
 	 * @return
 	 */
 	JsonObject getIndexOptions();
 
 	/**
 	 * Set the index options.
-	 * 
+	 *
 	 * @param indexOptions
 	 */
 	void setIndexOptions(JsonObject indexOptions);

--- a/core/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
@@ -74,7 +74,7 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 
 	/**
 	 * Return the parent node of the field container.
-	 * 
+	 *
 	 * @return
 	 */
 	abstract protected Node getParentNode();
@@ -292,7 +292,7 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 	/**
 	 * Create new list of the given type. If the container already has a list of given type, it will be "unattached" and removed, if this container was the only
 	 * parent
-	 * 
+	 *
 	 * @param classOfT
 	 *            Implementation/Type of list
 	 * @param fieldKey
@@ -300,6 +300,8 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 	 * @return
 	 */
 	private <T extends ListGraphField<?, ?, ?>> T createList(Class<T> classOfT, String fieldKey) {
+		// TODO Check if versioning is enabled, and if not do not create a new list.
+
 		T existing = getList(classOfT, fieldKey);
 		T list = getGraph().addFramedVertex(classOfT);
 		list.setFieldKey(fieldKey);
@@ -327,7 +329,7 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 
 	/**
 	 * Update or create the field using the given restField. The {@link FieldSchema} is used to determine the type of the field.
-	 * 
+	 *
 	 * @param ac
 	 *            Action context
 	 * @param fieldMap
@@ -418,7 +420,7 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 
 	/**
 	 * Gets the node from a node field.
-	 * 
+	 *
 	 * @param field
 	 *            The node field to get the node from
 	 * @return Gets the node as a stream or an empty stream if the node field is not set

--- a/core/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
@@ -418,19 +418,28 @@ public class NodeImpl extends AbstractGenericFieldContainerVertex<NodeResponse, 
 		}
 
 		// Create the new container
-		NodeGraphFieldContainerImpl newContainer = getGraph().addFramedVertex(NodeGraphFieldContainerImpl.class);
-		if (original != null) {
-			newContainer.setEditor(editor);
-			newContainer.setLastEditedTimestamp();
-			newContainer.setLanguageTag(languageTag);
-			newContainer.setSchemaContainerVersion(original.getSchemaContainerVersion());
-		} else {
-			newContainer.setEditor(editor);
-			newContainer.setLastEditedTimestamp();
-			newContainer.setLanguageTag(languageTag);
-			// We need create a new container with no reference. So use the latest version available to use.
-			newContainer.setSchemaContainerVersion(branch.findLatestSchemaVersion(getSchemaContainer()));
+		NodeGraphFieldContainer newContainer = null;
+		SchemaContainerVersion latestSchemaVersion = branch.findLatestSchemaVersion(getSchemaContainer());
+
+		if (original != null && !latestSchemaVersion.isVersioning()) {
+			newContainer = original;
 		}
+
+		if (newContainer == null) {
+			newContainer = getGraph().addFramedVertex(NodeGraphFieldContainerImpl.class);
+
+			if (original != null) {
+				newContainer.setSchemaContainerVersion(original.getSchemaContainerVersion());
+			} else {
+				// We need create a new container with no reference. So use the latest version available to use.
+				newContainer.setSchemaContainerVersion(branch.findLatestSchemaVersion(getSchemaContainer()));
+			}
+		}
+
+		newContainer.setEditor(editor);
+		newContainer.setLastEditedTimestamp();
+		newContainer.setLanguageTag(languageTag);
+
 		if (previous != null) {
 			// set the next version number
 			newContainer.setVersion(previous.getVersion().nextDraft());

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/handler/SchemaComparator.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/handler/SchemaComparator.java
@@ -1,6 +1,7 @@
 package com.gentics.mesh.core.data.schema.handler;
 
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.CONTAINER_FLAG_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.VERSIONING_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.DISPLAY_FIELD_NAME_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.ELASTICSEARCH_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.AUTO_PURGE_FLAG_KEY;
@@ -44,6 +45,9 @@ public class SchemaComparator extends AbstractFieldSchemaContainerComparator<Sch
 
 		// .autoPurge
 		compareAndAddSchemaProperty(changes, AUTO_PURGE_FLAG_KEY, schemaA.getAutoPurge(), schemaB.getAutoPurge(), Schema.class);
+
+		// .versioning
+		compareAndAddSchemaProperty(changes, VERSIONING_FLAG_KEY, schemaA.getVersioning(), schemaB.getVersioning(), Schema.class);
 
 		// .container
 		// Only diff the flag if a value has been set in the schemaB

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/impl/SchemaContainerVersionImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/impl/SchemaContainerVersionImpl.java
@@ -190,7 +190,7 @@ public class SchemaContainerVersionImpl extends
 
 	/**
 	 * Genereates branch unassign events for every assigned branch.
-	 * 
+	 *
 	 * @return
 	 */
 	private Stream<BranchSchemaAssignEventModel> generateUnassignEvents() {
@@ -226,4 +226,8 @@ public class SchemaContainerVersionImpl extends
 		}
 	}
 
+	@Override
+	public boolean isVersioning() {
+		return !Boolean.FALSE.equals(getSchema().getVersioning());
+	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateSchemaChangeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateSchemaChangeImpl.java
@@ -3,6 +3,7 @@ package com.gentics.mesh.core.data.schema.impl;
 import static com.gentics.mesh.core.rest.error.Errors.error;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.AUTO_PURGE_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.CONTAINER_FLAG_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.VERSIONING_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.DISPLAY_FIELD_NAME_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.SEGMENT_FIELD_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.URLFIELDS_KEY;
@@ -119,6 +120,16 @@ public class UpdateSchemaChangeImpl extends AbstractFieldSchemaContainerUpdateCh
 	@Override
 	public void setAutoPurgeFlag(Boolean flag) {
 		setRestProperty(AUTO_PURGE_FLAG_KEY, flag);
+	}
+
+	@Override
+	public Boolean getVersioningFlag() {
+		return getRestProperty(VERSIONING_FLAG_KEY);
+	}
+
+	@Override
+	public void setVersioningFlag(Boolean flag) {
+		setRestProperty(VERSIONING_FLAG_KEY, flag);
 	}
 
 	@Override

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryTransformHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryTransformHandler.java
@@ -83,7 +83,7 @@ public class BinaryTransformHandler extends AbstractHandler {
 	/**
 	 * Handle image transformation. This operation will utilize the binary data of the existing field and apply the transformation options. The new binary data
 	 * will be stored and the field will be updated accordingly.
-	 * 
+	 *
 	 * @param rc
 	 *            routing context
 	 * @param uuid
@@ -236,6 +236,7 @@ public class BinaryTransformHandler extends AbstractHandler {
 
 			// Now create the binary field in which we store the information about the file
 			BinaryGraphField oldField = newDraftVersion.getBinary(fieldName);
+			// TODO do not create new binary field when versioning is disabled.
 			BinaryGraphField field = newDraftVersion.createBinary(fieldName, binary);
 			if (oldField != null) {
 				oldField.copyTo(field);

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
@@ -132,7 +132,7 @@ public class BinaryUploadHandler extends AbstractHandler {
 
 	/**
 	 * Handle a request to create a new field.
-	 * 
+	 *
 	 * @param ac
 	 * @param nodeUuid
 	 *            UUID of the node which should be updated
@@ -331,6 +331,7 @@ public class BinaryUploadHandler extends AbstractHandler {
 				BinaryGraphField oldField = newDraftVersion.getBinary(fieldName);
 
 				// Create the new field
+				// TODO do not create new binary field when versioning is disabled.
 				BinaryGraphField field = newDraftVersion.createBinary(fieldName, binary);
 
 				// Reuse the existing properties
@@ -375,7 +376,7 @@ public class BinaryUploadHandler extends AbstractHandler {
 	/**
 	 * Processes the upload and set the binary information (e.g.: image dimensions) within the provided field. The binary data will be stored in the
 	 * {@link BinaryStorage} if desired.
-	 * 
+	 *
 	 * @param upload
 	 *            Upload to process
 	 * @param hash

--- a/core/src/test/java/com/gentics/mesh/core/data/fieldhandler/schema/SchemaComparatorSchemaTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/data/fieldhandler/schema/SchemaComparatorSchemaTest.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.FI
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.NAME_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.SEGMENT_FIELD_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.TYPE_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.VERSIONING_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperation.CHANGEFIELDTYPE;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperation.UPDATESCHEMA;
 import static com.gentics.mesh.test.TestSize.FULL;
@@ -227,6 +228,43 @@ public class SchemaComparatorSchemaTest extends AbstractMeshTest {
 		List<SchemaChangeModel> changes = comparator.diff(schemaA, schemaB);
 		assertThat(changes).hasSize(1);
 		assertThat(changes.get(0)).is(UPDATESCHEMA).hasProperty(AUTO_PURGE_FLAG_KEY, null);
+	}
+
+	@Test
+	public void testVersioningFlagUpdated() throws IOException {
+		Schema schemaA = FieldUtil.createMinimalValidSchema();
+		Schema schemaB = FieldUtil.createMinimalValidSchema();
+		schemaA.setVersioning(true);
+		schemaB.setVersioning(false);
+		List<SchemaChangeModel> changes = comparator.diff(schemaA, schemaB);
+		assertThat(changes).hasSize(1);
+		assertThat(changes.get(0)).is(UPDATESCHEMA).hasProperty(VERSIONING_FLAG_KEY, false);
+	}
+
+	@Test
+	public void testVersioningFlagSame() throws IOException {
+		Schema schemaA = FieldUtil.createMinimalValidSchema();
+		Schema schemaB = FieldUtil.createMinimalValidSchema();
+		schemaA.setVersioning(true);
+		schemaB.setVersioning(true);
+		List<SchemaChangeModel> changes = comparator.diff(schemaA, schemaB);
+		assertThat(changes).isEmpty();
+
+		schemaA.setVersioning(false);
+		schemaB.setVersioning(false);
+		changes = comparator.diff(schemaA, schemaB);
+		assertThat(changes).isEmpty();
+	}
+
+	@Test
+	public void testVersioningFlagNull() throws IOException {
+		Schema schemaA = FieldUtil.createMinimalValidSchema();
+		Schema schemaB = FieldUtil.createMinimalValidSchema();
+		schemaA.setVersioning(true);
+		schemaB.setVersioning(null);
+		List<SchemaChangeModel> changes = comparator.diff(schemaA, schemaB);
+		assertThat(changes).hasSize(1);
+		assertThat(changes.get(0)).is(UPDATESCHEMA).hasProperty(VERSIONING_FLAG_KEY, null);
 	}
 
 	@Test

--- a/core/src/test/java/com/gentics/mesh/core/node/NodeDisabledVersioningEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/node/NodeDisabledVersioningEndpointTest.java
@@ -1,0 +1,127 @@
+package com.gentics.mesh.core.node;
+
+import com.gentics.mesh.core.data.NodeGraphFieldContainer;
+import com.gentics.mesh.core.rest.common.ContainerType;
+import com.gentics.mesh.core.rest.node.FieldMap;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.NodeUpdateRequest;
+import com.gentics.mesh.core.rest.node.field.impl.StringFieldImpl;
+import com.gentics.mesh.core.rest.node.field.list.impl.StringFieldListImpl;
+import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.impl.ListFieldSchemaImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
+import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static com.gentics.mesh.test.context.ElasticsearchTestMode.TRACKING;
+
+@MeshTestSetting(elasticsearch = TRACKING, testSize = FULL, startServer = true)
+public class NodeDisabledVersioningEndpointTest extends AbstractMeshTest {
+
+	private static final String SCHEMA_NAME = "test_schema_no_versioning";
+	private static final String NODE_NAME = "test-node";
+	private static final String NODE_LANGUAGE = "en";
+	private static final List<String> STRING_LIST = Arrays.asList("foo", "bar", "doo");
+
+	private static boolean schemaCreated = false;
+
+	private String nodeUuid;
+	private String parentPath;
+
+	@Before
+	public void setup() {
+		if (!schemaCreated) {
+			SchemaCreateRequest rq = new SchemaCreateRequest()
+				.setName(SCHEMA_NAME)
+				.setDisplayField("name")
+				.setSegmentField("name")
+				.setVersioning(false);
+			List<FieldSchema> fields = rq.getFields();
+
+			fields.add(new StringFieldSchemaImpl().setName("name").setRequired(true));
+			fields.add(new ListFieldSchemaImpl().setListType("string").setName("list"));
+
+			client().createSchema(rq).toSingle()
+				.map(SchemaResponse::getUuid)
+				.flatMapCompletable(schemaUuid -> client().assignSchemaToProject(PROJECT_NAME, schemaUuid).toCompletable())
+				.blockingAwait();
+
+			schemaCreated = true;
+		}
+
+		parentPath = call(() -> client().findNodeByUuid(PROJECT_NAME, folderUuid())).getPath();
+
+		NodeCreateRequest rq = new NodeCreateRequest()
+			.setSchemaName(SCHEMA_NAME)
+			.setLanguage(NODE_LANGUAGE)
+			.setParentNodeUuid(folderUuid());
+		FieldMap fields = rq.getFields();
+
+		fields.put("name", new StringFieldImpl().setString(NODE_NAME));
+		fields.put("list", new StringFieldListImpl().setItems(STRING_LIST));
+
+		nodeUuid = call(() -> client().createNode(PROJECT_NAME, rq)).getUuid();
+		System.out.println("Created test node: " + nodeUuid);
+	}
+
+	@Test
+	public void testCreatedNodePublished() {
+		// No need for assertions, this call will fail if the node is not found.
+		call(() -> client().findNodeByUuid(
+			PROJECT_NAME,
+			nodeUuid,
+			new VersioningParametersImpl().setVersion("published")));
+	}
+
+	// WIP
+	@Test
+	public void testUpdateNode() {
+		NodeUpdateRequest rq = new NodeUpdateRequest()
+			.setLanguage(NODE_LANGUAGE);
+		FieldMap fields = rq.getFields();
+		List<String> list = new ArrayList<>(STRING_LIST);
+
+		for (int ii = 1; ii <= 10; ii++) {
+			list.add(String.format("item-%02d", ii));
+
+			fields.put("name", new StringFieldImpl().setString(String.format("%s-%02d", NODE_NAME, ii)));
+			fields.put("list", new StringFieldListImpl().setItems(list));
+
+			NodeResponse rs = call(() -> client().updateNode(PROJECT_NAME, nodeUuid, rq));
+
+			System.out.println(String.format("Update #%02d", ii));
+			System.out.println(rs.toJson());
+			System.out.println();
+
+			NodeGraphFieldContainer container = project().findNode(nodeUuid).getGraphFieldContainer("en", initialBranchUuid(), ContainerType.PUBLISHED);
+
+			rs = call(() -> client().findNodeByUuid(PROJECT_NAME, nodeUuid, new VersioningParametersImpl().setVersion("draft")));
+
+			assertThat(rs)
+				.as(String.format("Node after update #%02d", ii))
+				.hasVersion(String.format("%d.0", ii + 1));
+
+			String path = String.format("%s/%s-%02d", parentPath, NODE_NAME, ii);
+
+			rs = call(() -> client().webroot(PROJECT_NAME, path)).getNodeResponse();
+
+			System.out.println(String.format("Loaded via webroot #%02d", ii));
+			System.out.println(rs.toJson());
+			System.out.println();
+		}
+	}
+}

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaDiffEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaDiffEndpointTest.java
@@ -4,6 +4,7 @@ import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.AUTO_PURGE_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.CONTAINER_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.DISPLAY_FIELD_NAME_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.VERSIONING_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperation.ADDFIELD;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperation.REMOVEFIELD;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperation.UPDATEFIELD;
@@ -123,6 +124,28 @@ public class SchemaDiffEndpointTest extends AbstractMeshTest {
 		assertThat(changes.getChanges()).hasSize(1);
 		assertThat(changes.getChanges().get(0)).is(UPDATESCHEMA).hasProperty(AUTO_PURGE_FLAG_KEY, true);
 
+	}
+
+	@Test
+	public void testDiffVersioningFlag() {
+		String schemaUuid = tx(() -> schemaContainer("content").getUuid());
+		Schema request = getSchema();
+
+		// Flag not specified
+		request.setVersioning(null);
+		SchemaChangesListModel changes = call(() -> client().diffSchema(schemaUuid, request));
+		assertThat(changes.getChanges()).hasSize(0);
+
+		// Set to same value
+		request.setVersioning(false);
+		changes = call(() -> client().diffSchema(schemaUuid, request));
+		assertThat(changes.getChanges().get(0)).is(UPDATESCHEMA).hasProperty(VERSIONING_FLAG_KEY, false);
+
+		// Flag set to different value
+		request.setVersioning(true);
+		changes = call(() -> client().diffSchema(schemaUuid, request));
+		assertThat(changes.getChanges()).hasSize(1);
+		assertThat(changes.getChanges().get(0)).is(UPDATESCHEMA).hasProperty(VERSIONING_FLAG_KEY, true);
 	}
 
 	@Test

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/Schema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/Schema.java
@@ -16,14 +16,14 @@ public interface Schema extends FieldSchemaContainer {
 	/**
 	 * Return the display field of the schema which nodes will inherit in order. This is useful when you want to unify the name that should be displayed for
 	 * nodes of different types. Nodes that use the folder schema may use the display field name to display the name and blogpost nodes the field title.
-	 * 
+	 *
 	 * @return Display field of the schema
 	 */
 	String getDisplayField();
 
 	/**
 	 * Set the display field value.
-	 * 
+	 *
 	 * @param displayField
 	 *            Display field
 	 */
@@ -31,14 +31,14 @@ public interface Schema extends FieldSchemaContainer {
 
 	/**
 	 * Return the container flag.
-	 * 
+	 *
 	 * @return
 	 */
 	Boolean getContainer();
 
 	/**
 	 * Set the container flag for this schema. Nodes that are created using a schema which has an enabled container flag can be used as a parent for new nodes.
-	 * 
+	 *
 	 * @param flag
 	 *            Container flag value
 	 */
@@ -46,14 +46,14 @@ public interface Schema extends FieldSchemaContainer {
 
 	/**
 	 * Return the segment field name.
-	 * 
+	 *
 	 * @return
 	 */
 	String getSegmentField();
 
 	/**
 	 * Set the segment field name.
-	 * 
+	 *
 	 * @param segmentField
 	 */
 	Schema setSegmentField(String segmentField);
@@ -105,14 +105,14 @@ public interface Schema extends FieldSchemaContainer {
 
 	/**
 	 * Return the list of url fields.
-	 * 
+	 *
 	 * @return
 	 */
 	List<String> getUrlFields();
 
 	/**
 	 * Set the list of url field names.
-	 * 
+	 *
 	 * @param urlFields
 	 * @return Fluent API
 	 */
@@ -120,7 +120,7 @@ public interface Schema extends FieldSchemaContainer {
 
 	/**
 	 * Set the url field names.
-	 * 
+	 *
 	 * @param fieldNames
 	 * @return Fluent API
 	 */
@@ -131,16 +131,31 @@ public interface Schema extends FieldSchemaContainer {
 
 	/**
 	 * Return the auto purge flag for the schema.
-	 * 
+	 *
 	 * @return
 	 */
 	Boolean getAutoPurge();
 
 	/**
 	 * Set the auto purge flag.
-	 * 
+	 *
 	 * @param autoPurge
 	 * @return
 	 */
 	Schema setAutoPurge(Boolean autoPurge);
+
+	/**
+	 * Return the versioning flag for the schema.
+	 *
+	 * @return The versioning flag for the schema.
+	 */
+	Boolean getVersioning();
+
+	/**
+	 * Set the versioning flag for the schema.
+	 *
+	 * @param versioning Whether to disable versioning for this schema
+	 * @return Fluent API
+	 */
+	Schema setVersioning(Boolean versioning);
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
@@ -34,6 +34,8 @@ public class SchemaChangeModel implements RestModel {
 
 	public static final String AUTO_PURGE_FLAG_KEY = "autoPurge";
 
+	public static final String VERSIONING_FLAG_KEY = "versioning";
+
 	public static final String FIELD_ORDER_KEY = "order";
 
 	public static final String NAME_KEY = "name";
@@ -63,7 +65,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a new change.
-	 * 
+	 *
 	 * @param operation
 	 */
 	private SchemaChangeModel(SchemaChangeOperation operation) {
@@ -72,7 +74,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a new change that includes field name information.
-	 * 
+	 *
 	 * @param operation
 	 * @param fieldName
 	 */
@@ -83,7 +85,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Return the UUID of the change.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getUuid() {
@@ -92,7 +94,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Set the UUID of the change.
-	 * 
+	 *
 	 * @param uuid
 	 */
 	public void setUuid(String uuid) {
@@ -101,7 +103,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Return the operation for the change.
-	 * 
+	 *
 	 * @return
 	 */
 	public SchemaChangeOperation getOperation() {
@@ -110,7 +112,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Set the operation for this change.
-	 * 
+	 *
 	 * @param operation
 	 */
 	public SchemaChangeModel setOperation(SchemaChangeOperation operation) {
@@ -120,7 +122,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Return additional properties for the change.
-	 * 
+	 *
 	 * @return
 	 */
 	public Map<String, Object> getProperties() {
@@ -129,7 +131,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Set an additional property to the change.
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 */
@@ -139,7 +141,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a new update schema change.
-	 * 
+	 *
 	 * @return
 	 */
 	public static SchemaChangeModel createUpdateSchemaChange() {
@@ -148,7 +150,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a new update microschema change.
-	 * 
+	 *
 	 * @return
 	 */
 	public static SchemaChangeModel createUpdateMicroschemaChange() {
@@ -157,7 +159,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a new field removal change.
-	 * 
+	 *
 	 * @param name
 	 * @return
 	 */
@@ -167,7 +169,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a change field type change.
-	 * 
+	 *
 	 * @param fieldName
 	 * @param type
 	 * @return
@@ -180,7 +182,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create an update field change to rename a field.
-	 * 
+	 *
 	 * @param fieldName
 	 * @param newFieldName
 	 * @return
@@ -193,7 +195,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Create a add field change.
-	 * 
+	 *
 	 * @param fieldName
 	 *            Field key
 	 * @param type
@@ -216,7 +218,7 @@ public class SchemaChangeModel implements RestModel {
 
 	/**
 	 * Return the model property of the given key.
-	 * 
+	 *
 	 * @param key
 	 * @return
 	 */

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaCreateRequest.java
@@ -48,6 +48,10 @@ public class SchemaCreateRequest implements Schema {
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should create new versions.")
 	private Boolean autoPurge;
 
+	@JsonProperty
+	@JsonPropertyDescription("Versioning flag of the schema. Controls whether versioning is enabled for nodes of this schema.")
+	private Boolean versioning;
+
 	@Override
 	public String getDescription() {
 		return description;
@@ -147,4 +151,14 @@ public class SchemaCreateRequest implements Schema {
 		return this;
 	}
 
+	@Override
+	public Boolean getVersioning() {
+		return versioning;
+	}
+
+	@Override
+	public SchemaCreateRequest setVersioning(Boolean versioning) {
+		this.versioning = versioning;
+		return this;
+	}
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaModelImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaModelImpl.java
@@ -39,7 +39,7 @@ public class SchemaModelImpl implements SchemaModel {
 
 	/**
 	 * Create a new schema with the given name.
-	 * 
+	 *
 	 * @param name
 	 */
 	public SchemaModelImpl(String name) {
@@ -68,6 +68,10 @@ public class SchemaModelImpl implements SchemaModel {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should create new versions.")
 	private Boolean autoPurge;
+
+	@JsonProperty
+	@JsonPropertyDescription("Versioning flag of the schema. Controls whether versioning is enabled for nodes of this schema.")
+	private Boolean versioning;
 
 	@Override
 	public String getVersion() {
@@ -176,6 +180,17 @@ public class SchemaModelImpl implements SchemaModel {
 	@Override
 	public SchemaModelImpl setAutoPurge(Boolean autoPurge) {
 		this.autoPurge = autoPurge;
+		return this;
+	}
+
+	@Override
+	public Boolean getVersioning() {
+		return versioning;
+	}
+
+	@Override
+	public SchemaModelImpl setVersioning(Boolean versioning) {
+		this.versioning = versioning;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaResponse.java
@@ -54,6 +54,10 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should be automatically purged on update.")
 	private Boolean autoPurge;
 
+	@JsonProperty
+	@JsonPropertyDescription("Versioning flag of the schema. Controls whether versioning is enabled for nodes of this schema.")
+	private Boolean versioning;
+
 	@Override
 	public String getName() {
 		return name;
@@ -144,7 +148,7 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 
 	/**
 	 * Create a schema reference using the schema as source.
-	 * 
+	 *
 	 * @return
 	 */
 	public SchemaReferenceImpl toReference() {
@@ -188,6 +192,17 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 	@Override
 	public SchemaResponse setAutoPurge(Boolean autoPurge) {
 		this.autoPurge = autoPurge;
+		return this;
+	}
+
+	@Override
+	public Boolean getVersioning() {
+		return versioning;
+	}
+
+	@Override
+	public SchemaResponse setVersioning(Boolean versioning) {
+		this.versioning = versioning;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaUpdateRequest.java
@@ -53,6 +53,10 @@ public class SchemaUpdateRequest implements SchemaModel {
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should create new versions.")
 	private Boolean autoPurge;
 
+	@JsonProperty
+	@JsonPropertyDescription("Versioning flag of the schema. Controls whether versioning is enabled for nodes of this schema.")
+	private Boolean versioning;
+
 	@Override
 	public String getName() {
 		return name;
@@ -154,6 +158,17 @@ public class SchemaUpdateRequest implements SchemaModel {
 	@Override
 	public SchemaUpdateRequest setAutoPurge(Boolean autoPurge) {
 		this.autoPurge = autoPurge;
+		return this;
+	}
+
+	@Override
+	public Boolean getVersioning() {
+		return versioning;
+	}
+
+	@Override
+	public SchemaUpdateRequest setVersioning(Boolean versioning) {
+		this.versioning = versioning;
 		return this;
 	}
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/SchemaTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/SchemaTypeProvider.java
@@ -83,6 +83,12 @@ public class SchemaTypeProvider extends AbstractTypeProvider {
 			return model != null ? model.getAutoPurge() : null;
 		}));
 
+		// .isVersioning
+		schemaType.field(newFieldDefinition().name("isVersioning").type(GraphQLBoolean).dataFetcher((env) -> {
+			SchemaModel model = loadModelWithFallback(env);
+			return model != null ? model.getVersioning() : null;
+		}));
+
 		// .displayField
 		schemaType.field(newFieldDefinition().name("displayField").type(GraphQLString).dataFetcher((env) -> {
 			SchemaModel model = loadModelWithFallback(env);


### PR DESCRIPTION
## Abstract

Versioning can be disabled per Schema by setting the new versioning flag to false.

## Checklist

### General

* [x] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
