### PR TITLE
SUP-10440 GraphQL: Add lang parameter to breadcrumb

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.6]]
+== 1.6.6 (11.11.2020)
+
+icon:plus[] GraphQL: The `breadcrumb` field now accepts the `lang` parameter which will be used for additional fallback languages.
+
 [[v1.6.5]]
 == 1.6.5 (04.11.2020)
 
@@ -92,7 +97,7 @@ icon:check[] Clustering: An additional check has been added which will prevent n
 
 
 [[v1.5.5]]
-== 1.5.5 (06.10.2020) 
+== 1.5.5 (06.10.2020)
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.0.34`.
 

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
@@ -151,6 +151,7 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 			Arrays.asList("nodes-query", true, "draft"),
 			Arrays.asList("nodes-query-by-uuids", true, "draft"),
 			Arrays.asList("node-breadcrumb-query", true, "draft"),
+			Arrays.asList("node-breadcrumb-query-with-lang", true, "draft"),
 			Arrays.asList("node-language-fallback-query", true, "draft"),
 			Arrays.asList("node-languages-query", true, "draft", (Consumer<JsonObject>) GraphQLEndpointTest::checkNodeLanguageContent),
 			Arrays.asList("node-not-found-webroot-query", true, "draft"),

--- a/core/src/test/resources/graphql/node-breadcrumb-query-with-lang
+++ b/core/src/test/resources/graphql/node-breadcrumb-query-with-lang
@@ -1,0 +1,26 @@
+{
+	node(path:"/Neuigkeiten/2015/News_2015.de.html") {
+		path
+		# [$.data.node.breadcrumb[0].path=/]
+		# [$.data.node.breadcrumb[1].language=de]
+		# [$.data.node.breadcrumb[1].path=/Neuigkeiten]
+		### The language for this entry is english because the node 2015 is only
+		### available in english, and when its path is resolved that is the
+		### used fallback instead of the language of the originally requested
+		### node (News_2015.de.html).
+		# [$.data.node.breadcrumb[2].path=/News/2015]
+		# [$.data.node.breadcrumb[2].language=en]
+		# [$.data.node.breadcrumb[3].path=/Neuigkeiten/2015/News_2015.de.html]
+		breadcrumb(lang: ["de", "en"]) {
+			language
+			path
+			... on content {
+				fields { slug }
+			}
+			... on folder {
+				fields { slug }
+			}
+		}
+	}
+}
+# [$.errors=<is-undefined>]

--- a/core/src/test/resources/graphql/node-breadcrumb-query-with-lang.v1
+++ b/core/src/test/resources/graphql/node-breadcrumb-query-with-lang.v1
@@ -1,0 +1,24 @@
+{
+	node(path:"/Neuigkeiten/2015/News_2015.de.html") {
+		path
+		# [$.data.node.breadcrumb[0].path=/]
+		# [$.data.node.breadcrumb[1].language=de]
+		# [$.data.node.breadcrumb[1].path=/Neuigkeiten]
+		### The language for this entry is english because the node 2015 is only
+		### available in english, and when its path is resolved that is the
+		### used fallback instead of the language of the originally requested
+		### node (News_2015.de.html).
+		# [$.data.node.breadcrumb[2].path=/News/2015]
+		# [$.data.node.breadcrumb[2].language=en]
+		# [$.data.node.breadcrumb[3].path=/Neuigkeiten/2015/News_2015.de.html]
+		breadcrumb(lang: ["de", "en"]) {
+			language
+			path
+			fields {
+				... on content { slug }
+				... on folder { slug }
+			}
+		}
+	}
+}
+# [$.errors=<is-undefined>]

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
@@ -106,7 +106,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 
 	/**
 	 * Fetcher for the parent node reference of a node.
-	 * 
+	 *
 	 * @param env
 	 * @return
 	 */
@@ -158,6 +158,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 		ContainerType type = getNodeVersion(env);
 		return content.getNode().getBreadcrumbNodes(gc).stream().map(node -> {
 			List<String> languageTags = getLanguageArgument(env, content);
+
 			NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
 			return new NodeContent(node, container, languageTags, type);
 		})
@@ -232,6 +233,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 				.description("Breadcrumb of the node")
 				.type(new GraphQLList(new GraphQLTypeReference(NODE_TYPE_NAME)))
 				.argument(createNodeVersionArg())
+				.argument(createLanguageTagArg(false))
 				.dataFetcher(this::breadcrumbFetcher).build(),
 
 			// .availableLanguages


### PR DESCRIPTION
## Abstract

Add the `lang` parameter to `breadcrumb` fields for easier language fallback (e.g. when the loaded node itself is german, but all containing folders are english).

This is a pure GraphQL change.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
