### PR TITLE
Hotfix 1.4.x pdf metadata

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,6 +26,8 @@ icon:check[] OrientDB: A bug in the startup order has been fixed which prevented
 
 icon:check[] Core: An uploading of PDF binary files with complex metadata is improved.
 
+icon:check[] OrientDB: A bug in the startup order has been fixed which prevented opening of databases via OrientDB Studio.
+
 [[v1.4.18]]
 == 1.4.18 (18.11.2020)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,6 +26,8 @@ icon:check[] OrientDB: A bug in the startup order has been fixed which prevented
 
 icon:check[] Core: An uploading of PDF binary files with complex metadata is improved.
 
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.6`.
+
 icon:check[] OrientDB: A bug in the startup order has been fixed which prevented opening of databases via OrientDB Studio.
 
 [[v1.4.18]]

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,10 +26,6 @@ icon:check[] OrientDB: A bug in the startup order has been fixed which prevented
 
 icon:check[] Core: An uploading of PDF binary files with complex metadata is improved.
 
-icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.6`.
-
-icon:check[] OrientDB: A bug in the startup order has been fixed which prevented opening of databases via OrientDB Studio.
-
 [[v1.4.18]]
 == 1.4.18 (18.11.2020)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -24,6 +24,8 @@ icon:check[] OrientDB: The included OrientDB version has been updated to version
 
 icon:check[] OrientDB: A bug in the startup order has been fixed which prevented opening of databases via OrientDB Studio.
 
+icon:check[] Core: An uploading of PDF binary files with complex metadata is improved.
+
 [[v1.4.18]]
 == 1.4.18 (18.11.2020)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
@@ -14,8 +14,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
-
 import com.gentics.madl.index.IndexHandler;
 import com.gentics.madl.tx.Tx;
 import com.gentics.madl.type.TypeHandler;
@@ -333,17 +331,18 @@ public class BinaryGraphFieldImpl extends MeshEdgeImpl implements BinaryGraphFie
 	}
 
 	@Override
-	public Map<String, String> getMetadataProperties() {
-		List<String> keys = getPropertyKeys().stream().filter(k -> k.startsWith(META_DATA_PROPERTY_PREFIX)).collect(Collectors.toList());
-
-		Map<String, String> metadata = new HashMap<>();
-		for (String key : keys) {
-			String name = key.substring(META_DATA_PROPERTY_PREFIX.length());
-			String value = property(key);
-			metadata.put(name, value);
-		}
-		return metadata;
-	}
+    public Map<String, String> getMetadataProperties() {
+        List<String> keys = getPropertyKeys().stream().filter(k -> k.startsWith(META_DATA_PROPERTY_PREFIX)).collect(Collectors.toList());
+        Map<String, String> metadata = new HashMap<>();
+        for (String key : keys) {
+            String name = key.substring(META_DATA_PROPERTY_PREFIX.length());
+            name = key.replaceAll("%5B", "[");
+            name = key.replaceAll("%5D", "]");
+            String value = property(key);
+            metadata.put(name, value);
+        }
+        return metadata;
+    }
 
 	@Override
 	public BinaryMetadata getMetadata() {
@@ -366,12 +365,15 @@ public class BinaryGraphFieldImpl extends MeshEdgeImpl implements BinaryGraphFie
 	}
 
 	@Override
-	public void setMetadata(String key, String value) {
-		if (StringUtils.isNotBlank(key) && key.indexOf("[") > 0) {
-			key = key.substring(0, key.indexOf("["));
-		}
-		setProperty(META_DATA_PROPERTY_PREFIX + key, value);
-	}
+    public void setMetadata(String key, String value) {
+        key = key.replaceAll("\\[", "%5B");
+        key = key.replaceAll("\\]", "%5D");
+        if (value == null) {
+            removeProperty(META_DATA_PROPERTY_PREFIX + key);
+        } else {
+            setProperty(META_DATA_PROPERTY_PREFIX + key, value);
+        }
+    }
 
 	@Override
 	public String getPlainText() {

--- a/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
@@ -336,9 +336,9 @@ public class BinaryGraphFieldImpl extends MeshEdgeImpl implements BinaryGraphFie
         Map<String, String> metadata = new HashMap<>();
         for (String key : keys) {
             String name = key.substring(META_DATA_PROPERTY_PREFIX.length());
-            name = key.replaceAll("%5B", "[");
-            name = key.replaceAll("%5D", "]");
-            String value = property(key);
+            name = name.replaceAll("%5B", "[");
+            name = name.replaceAll("%5D", "]");
+            String value = property(name);
             metadata.put(name, value);
         }
         return metadata;

--- a/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
@@ -338,7 +338,7 @@ public class BinaryGraphFieldImpl extends MeshEdgeImpl implements BinaryGraphFie
             String name = key.substring(META_DATA_PROPERTY_PREFIX.length());
             name = name.replaceAll("%5B", "[");
             name = name.replaceAll("%5D", "]");
-            String value = property(name);
+            String value = property(key);
             metadata.put(name, value);
         }
         return metadata;

--- a/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/node/field/impl/BinaryGraphFieldImpl.java
@@ -14,6 +14,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.gentics.madl.index.IndexHandler;
 import com.gentics.madl.tx.Tx;
 import com.gentics.madl.type.TypeHandler;
@@ -365,6 +367,9 @@ public class BinaryGraphFieldImpl extends MeshEdgeImpl implements BinaryGraphFie
 
 	@Override
 	public void setMetadata(String key, String value) {
+		if (StringUtils.isNotBlank(key) && key.indexOf("[") > 0) {
+			key = key.substring(0, key.indexOf("["));
+		}
 		setProperty(META_DATA_PROPERTY_PREFIX + key, value);
 	}
 


### PR DESCRIPTION
## Abstract

The binary file with XML-based metadata (PDF) may be refused to upload into Mesh because of an array metadata field key. The provided fix allows such files for an upload. 

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
