### PR TITLE
Fix orientdb studio usage in non-clustered mode

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.4.19]]
+== 1.4.19 (TBD)
+
+icon:check[] OrientDB: A bug in the startup order has been fixed which prevented opening of databases via OrientDB Studio.
+
 [[v1.4.18]]
 == 1.4.18 (18.11.2020)
 

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -356,15 +356,15 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 			}
 			coordinatorMasterElector.start();
 		} else {
+			if (startOrientServer) {
+				db.clusterManager().startAndSync();
+			}
 			// No cluster mode - Just setup the connection pool and load or setup the local data
 			db.setupConnectionPool();
 			initVertx(options);
 			searchProvider.init();
 			searchProvider.start();
 			initLocalData(options, false);
-			if (startOrientServer) {
-				db.clusterManager().startAndSync();
-			}
 		}
 
 		eventManager.registerHandlers();


### PR DESCRIPTION
## Abstract

Fixes database already opened exception in OrientDB server

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
