### PR TITLE
Properly fetch bucket-id

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,8 @@ icon:check[] Jobs: A race condition within the job processing mechanism has been
 
 icon:check[] Jobs: New jobs will now set the correct start date and time.
 
+icon:check[] Changelog: Fix the failing on-the-fly migration introduced in 1.7.5. The migration was producing `ClassCastExceptions`.
+
 [[v1.7.5]]
 == 1.7.5 (09.11.2020)
 

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/search/BucketableElementHelper.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/search/BucketableElementHelper.java
@@ -16,7 +16,7 @@ public final class BucketableElementHelper {
 		Long bucketId = e.property(BUCKET_ID_KEY);
 		if (bucketId == null) {
 			e.generateBucketId();
-			return e.getProperty(BUCKET_ID_KEY);
+			return e.<Long>getProperty(BUCKET_ID_KEY).intValue();
 		} else {
 			return bucketId.intValue();
 		}


### PR DESCRIPTION
## Abstract
The bucket-id-property is stored as a long wrapper-type.
This leads to a ClassCastException if just the plain getProperty is returned.

Fetch the property as long and then manually convert to an Integer to avoid ClassCastExceptions.
## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs
