### PR TITLE
Allow uploading of empty files

### DIFF
--- a/core/src/main/java/com/gentics/mesh/core/binary/DocumentTikaParser.java
+++ b/core/src/main/java/com/gentics/mesh/core/binary/DocumentTikaParser.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.exception.ZeroByteFileException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AutoDetectParser;
@@ -102,6 +103,8 @@ public class DocumentTikaParser {
 				throw (TikaException) cause;
 			} else if (cause instanceof IOException) {
 				throw (IOException) cause;
+			} else if (e instanceof ZeroByteFileException) {
+				return Optional.empty();
 			} else {
 				throw e;
 			}

--- a/core/src/test/java/com/gentics/mesh/core/binary/DocumentTikaParserTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/binary/DocumentTikaParserTest.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.core.binary;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
@@ -29,6 +30,15 @@ public class DocumentTikaParserTest {
 		String content = DocumentTikaParser.parse(new ByteArrayInputStream(data), metadata, LIMIT).get();
 		System.out.println(content);
 		System.out.println(metadata.toString());
+	}
+
+	@Test
+	public void testEmptyFile() throws TikaException, IOException {
+		Buffer buffer = getBuffer("/testfiles/empty.txt");
+		byte[] data = buffer.getBytes();
+		Metadata metadata = new Metadata();
+		Optional<String> maybeContent = DocumentTikaParser.parse(new ByteArrayInputStream(data), metadata, LIMIT);
+		assertFalse(maybeContent.isPresent());
 	}
 
 	protected Buffer getBuffer(String path) throws IOException {


### PR DESCRIPTION
## Abstract

Allow Mesh to upload and publish empty (size == 0 bytes) files. This feature is asked by the storage automation workflow.

## Checklist

* [ ] Correctly process ZeroByteFileException

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
