### PR TITLE
Correctly message out empty file upload

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.10]]
+== 1.6.10 (TBD)
+
+icon:check[] Upload: More user-friendly message + HTTP 400 error on an attempt to upload an empty file.
+
 [[v1.6.9]]
 == 1.6.9 (11.03.2021)
 

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -125,7 +125,7 @@ branch_error_downgrade_schema_version=Die Version des Schemas {0} kann für den 
 
 field_list_error_null_not_allowed=Es befinden sich null Werte im List Feld {0}. Null Werte sind nicht erlaubt.
 field_binary_error_emptyfilename=Es ist nicht erlaubt den Dateinamen des Binärfeldes {0} auf einen leeren String zu setzten. Bitte den Dateinamen auslassen oder einen gültigen Wert wählen.
-field_binary_error_emptyfile=Es ist nicht erlaubt die leere Datei {1} in den Binärfeld {0} zu setzten. Bitte die andere Datei mit Inhalt wählen.
+field_binary_error_emptyfile=Es ist nicht erlaubt die Datei {1} im Binärfeld {0} zu verwenden. Die Datei ist leer und hat keinen Inhalt.
 field_binary_error_emptymimetype=Es ist nicht erlaubt den Mimetype des Binärfeldes {0} auf einen leeren String zu setzten. Bitte den Mimetype auslassen oder einen gültigen Wert wählen.
 field_binary_error_unable_to_set_before_upload=Es ist nicht möglich das Binärfeld {0} zu aktualisieren / zu erstellen bevor ein Daten mittels hochladen hinterlegt wurden.
 field_binary_error_image_focalpoint_out_of_bounds=Der angegebene Fokuspunkt {1} für das Binär Feld {0} ist ungültig. Der Punkt passt nicht in den Bildausschnitt {2}.

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -125,7 +125,7 @@ branch_error_downgrade_schema_version=Die Version des Schemas {0} kann für den 
 
 field_list_error_null_not_allowed=Es befinden sich null Werte im List Feld {0}. Null Werte sind nicht erlaubt.
 field_binary_error_emptyfilename=Es ist nicht erlaubt den Dateinamen des Binärfeldes {0} auf einen leeren String zu setzten. Bitte den Dateinamen auslassen oder einen gültigen Wert wählen.
-field_binary_error_emptyfile=Es ist nicht erlaubt die leere Datei {1} in den Binärfeldes {0} zu setzten. Bitte die andere Datei mit Inhalt wählen.
+field_binary_error_emptyfile=Es ist nicht erlaubt die leere Datei {1} in den Binärfeld {0} zu setzten. Bitte die andere Datei mit Inhalt wählen.
 field_binary_error_emptymimetype=Es ist nicht erlaubt den Mimetype des Binärfeldes {0} auf einen leeren String zu setzten. Bitte den Mimetype auslassen oder einen gültigen Wert wählen.
 field_binary_error_unable_to_set_before_upload=Es ist nicht möglich das Binärfeld {0} zu aktualisieren / zu erstellen bevor ein Daten mittels hochladen hinterlegt wurden.
 field_binary_error_image_focalpoint_out_of_bounds=Der angegebene Fokuspunkt {1} für das Binär Feld {0} ist ungültig. Der Punkt passt nicht in den Bildausschnitt {2}.

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -125,6 +125,7 @@ branch_error_downgrade_schema_version=Die Version des Schemas {0} kann für den 
 
 field_list_error_null_not_allowed=Es befinden sich null Werte im List Feld {0}. Null Werte sind nicht erlaubt.
 field_binary_error_emptyfilename=Es ist nicht erlaubt den Dateinamen des Binärfeldes {0} auf einen leeren String zu setzten. Bitte den Dateinamen auslassen oder einen gültigen Wert wählen.
+field_binary_error_emptyfile=Es ist nicht erlaubt die leere Datei {1} in den Binärfeldes {0} zu setzten. Bitte die andere Datei mit Inhalt wählen.
 field_binary_error_emptymimetype=Es ist nicht erlaubt den Mimetype des Binärfeldes {0} auf einen leeren String zu setzten. Bitte den Mimetype auslassen oder einen gültigen Wert wählen.
 field_binary_error_unable_to_set_before_upload=Es ist nicht möglich das Binärfeld {0} zu aktualisieren / zu erstellen bevor ein Daten mittels hochladen hinterlegt wurden.
 field_binary_error_image_focalpoint_out_of_bounds=Der angegebene Fokuspunkt {1} für das Binär Feld {0} ist ungültig. Der Punkt passt nicht in den Bildausschnitt {2}.

--- a/common/src/main/resources/i18n/translations_en.properties
+++ b/common/src/main/resources/i18n/translations_en.properties
@@ -124,6 +124,7 @@ branch_error_downgrade_schema_version=The version of schema {0} cannot be downgr
 
 field_list_error_null_not_allowed=Detected null value within list field {0}. Null values are not allowed.
 field_binary_error_emptyfilename=It is not allowed to set the filename of binary field {0} to an empty string. Please use omit or select a valid filename.
+field_binary_error_emptyfile=It is not allowed to upload empty file {1} into the binary field {0}. Please select a non-empty file.
 field_binary_error_emptymimetype=It is not allowed to set the mimetype of binary field {0} to an empty string. Please use omit or select a valid mimetype.
 field_binary_error_unable_to_set_before_upload=It is not possible to update/create binary field {0} before an upload has been invoked for the field. 
 field_binary_error_image_focalpoint_out_of_bounds=The specified focal point {1} for binary field {0} does not fit within the bounds {2} of the image.

--- a/common/src/main/resources/i18n/translations_en.properties
+++ b/common/src/main/resources/i18n/translations_en.properties
@@ -124,7 +124,7 @@ branch_error_downgrade_schema_version=The version of schema {0} cannot be downgr
 
 field_list_error_null_not_allowed=Detected null value within list field {0}. Null values are not allowed.
 field_binary_error_emptyfilename=It is not allowed to set the filename of binary field {0} to an empty string. Please use omit or select a valid filename.
-field_binary_error_emptyfile=It is not allowed to upload empty file {1} into the binary field {0}. Please select a non-empty file.
+field_binary_error_emptyfile=It is not allowed to upload the file {1} into the binary field {0}. The file is empty and has no content.
 field_binary_error_emptymimetype=It is not allowed to set the mimetype of binary field {0} to an empty string. Please use omit or select a valid mimetype.
 field_binary_error_unable_to_set_before_upload=It is not possible to update/create binary field {0} before an upload has been invoked for the field. 
 field_binary_error_image_focalpoint_out_of_bounds=The specified focal point {1} for binary field {0} does not fit within the bounds {2} of the image.

--- a/common/src/main/resources/i18n/translations_zh.properties
+++ b/common/src/main/resources/i18n/translations_zh.properties
@@ -120,7 +120,7 @@ branch_error_downgrade_schema_version=数据模型{0}的版本不能从{1}降级
 
 field_list_error_null_not_allowed=列表字段{0}中检测到空值。不允许为空值。
 field_binary_error_emptyfilename=不允许将二进制字段{0}的文件名设置为空字符串。请使用忽略或选择有效的文件名。
-field_binary_error_emptyfile =不允许将文件{1}上传至二进制字段{0}。该文件为空，没有内容。
+field_binary_error_emptyfile=不允许将文件{1}上传至二进制字段{0}。该文件为空，没有内容。
 field_binary_error_emptymimetype=不允许将二进制字段{0}的MIME类型设置为空字符串。请使用忽略或选择有效的MIME类型。
 field_binary_error_unable_to_set_before_upload=在没有上传内容之前，无法更新/创建二进制字段{0}。
 field_binary_error_image_focalpoint_out_of_bounds=二进制字段{0}的指定焦点{1}不在图像的界限{2}内。

--- a/common/src/main/resources/i18n/translations_zh.properties
+++ b/common/src/main/resources/i18n/translations_zh.properties
@@ -120,6 +120,7 @@ branch_error_downgrade_schema_version=数据模型{0}的版本不能从{1}降级
 
 field_list_error_null_not_allowed=列表字段{0}中检测到空值。不允许为空值。
 field_binary_error_emptyfilename=不允许将二进制字段{0}的文件名设置为空字符串。请使用忽略或选择有效的文件名。
+field_binary_error_emptyfile =不允许将空文件{1}上传到二进制字段{0}中。 请选择一个非空文件。
 field_binary_error_emptymimetype=不允许将二进制字段{0}的MIME类型设置为空字符串。请使用忽略或选择有效的MIME类型。
 field_binary_error_unable_to_set_before_upload=在没有上传内容之前，无法更新/创建二进制字段{0}。
 field_binary_error_image_focalpoint_out_of_bounds=二进制字段{0}的指定焦点{1}不在图像的界限{2}内。

--- a/common/src/main/resources/i18n/translations_zh.properties
+++ b/common/src/main/resources/i18n/translations_zh.properties
@@ -120,7 +120,7 @@ branch_error_downgrade_schema_version=数据模型{0}的版本不能从{1}降级
 
 field_list_error_null_not_allowed=列表字段{0}中检测到空值。不允许为空值。
 field_binary_error_emptyfilename=不允许将二进制字段{0}的文件名设置为空字符串。请使用忽略或选择有效的文件名。
-field_binary_error_emptyfile =不允许将空文件{1}上传到二进制字段{0}中。 请选择一个非空文件。
+field_binary_error_emptyfile =不允许将文件{1}上传至二进制字段{0}。该文件为空，没有内容。
 field_binary_error_emptymimetype=不允许将二进制字段{0}的MIME类型设置为空字符串。请使用忽略或选择有效的MIME类型。
 field_binary_error_unable_to_set_before_upload=在没有上传内容之前，无法更新/创建二进制字段{0}。
 field_binary_error_image_focalpoint_out_of_bounds=二进制字段{0}的指定焦点{1}不在图像的界限{2}内。

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
@@ -129,6 +129,9 @@ public class BinaryUploadHandler extends AbstractHandler {
 		if (isEmpty(ul.contentType())) {
 			throw error(BAD_REQUEST, "field_binary_error_emptymimetype", fieldName);
 		}
+		if (ul.size() < 1) {
+			throw error(BAD_REQUEST, "field_binary_error_emptyfile", fieldName, ul.fileName());
+		}
 	}
 
 	/**

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
@@ -8,6 +8,8 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -417,17 +419,22 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 			}
 		};
 
-		client().updateNodeBinaryField(
-			PROJECT_NAME,
-			binaryNode.getUuid(),
-			binaryNode.getLanguage(),
-			binaryNode.getVersion(),
-			"binary",
-			emptyStream,
-			0,
-			"emptyFile",
-			"application/binary"
-		).blockingAwait();
+		try {
+			client().updateNodeBinaryField(
+				PROJECT_NAME,
+				binaryNode.getUuid(),
+				binaryNode.getLanguage(),
+				binaryNode.getVersion(),
+				"binary",
+				emptyStream,
+				0,
+				"emptyFile",
+				"application/binary"
+			).blockingAwait();
+			fail("Empty file upload should not pass");
+		} catch (Exception e) {
+			assertTrue(e.getMessage().indexOf("Error:400 in POST") > -1);
+		}
 	}
 
 }


### PR DESCRIPTION
## Abstract

Currently Mesh API returns HTTP 500 error on an empty file upload attempt. We want to make this error more user friendly. 

## Checklist

* [x] Return HTTP 400 on empty file upload attempt.
* [x] Describe the error in details.

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
