### PR TITLE
Bump OrientDB version to v3.1.10 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,11 @@ include::content/docs/variables.adoc-include[]
 
 * The support for the *embedded* version of Elasticsearch will be dropped in the future. It is highly recommended to link:{{< relref "elasticsearch.asciidoc" >}}#_dedicated_elasticsearch[setup Elasticsearch as a dedicated service].
 
+[[v1.7.8]]
+== 1.7.8 (TBD)
+
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.10`.
+
 [[v1.7.7]]
 == 1.7.7  (10.03.2021)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.10]]
+== 1.6.10 (TBD)
+
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.10`.
+
 [[v1.6.9]]
 == 1.6.9 (11.03.2021)
 
@@ -106,6 +111,11 @@ icon:check[] Clustering: The webroot handler no longer uses the cluster-wide wri
 
 icon:check[] Logging: Failing readiness checks are now logged using the `WARN` level.
 
+[[v1.5.10]]
+== 1.5.10 (TBD)
+
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.10`.
+
 [[v1.5.9]]
 == 1.5.9 (18.12.2020)
 
@@ -159,6 +169,11 @@ icon:plus[] Monitoring: The liveness probe will now check for plugin status. Fai
 icon:check[] Clustering: The webroot handler no longer uses the cluster-wide write lock.
 
 icon:check[] Logging: Failing readiness checks are now logged using the `WARN` level.
+
+[[v1.4.20]]
+== 1.4.20 (TBD)
+
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.10`.
 
 
 [[v1.4.19]]

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -24,7 +24,7 @@
 		<spring.security.version>4.2.13.RELEASE</spring.security.version>
 		<ferma.version>${project.version}</ferma.version>
 		<elasticsearch.client.version>1.1.1</elasticsearch.client.version>
-		<orientdb.version>3.1.6</orientdb.version>
+		<orientdb.version>3.1.10</orientdb.version>
 		<hazelcast.version>3.12.8</hazelcast.version>
 		<jackson.version>2.9.9</jackson.version>
 		<jackson-databind.version>2.9.10</jackson-databind.version>


### PR DESCRIPTION
## Abstract

Update OrientDB version to v3.1.10. https://github.com/gentics/mesh/pull/1173

## Checklist

* [x] Update bom/pom.xml

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
