### PR TITLE
Make plugin startup aware of DB status + restart the init.

### DIFF
--- a/common/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManager.java
+++ b/common/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManager.java
@@ -20,6 +20,10 @@ import io.reactivex.Single;
  * The plugin manager can be used to deploy plugins and register them in Gentics Mesh.
  */
 public interface MeshPluginManager {
+	/**
+	 * Initialize the internals after Vert.x is up.
+	 */
+	default void init() {}
 
 	/**
 	 * Initialize the plugin manager.

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -327,6 +327,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				// Finally start ES integration
 				searchProvider.init();
 				searchProvider.start();
+				pluginManager.init();
 				if (flags.isReindex()) {
 					createSearchIndicesAndMappings();
 				}
@@ -348,6 +349,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				// Finally start ES integration
 				searchProvider.init();
 				searchProvider.start();
+				pluginManager.init();
 				initLocalData(flags, options, true);
 			}
 
@@ -370,6 +372,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 			initVertx(options);
 			searchProvider.init();
 			searchProvider.start();
+			pluginManager.init();
 			initLocalData(flags, options, false);
 		}
 

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -117,7 +117,6 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 
 	protected void delayedInitialize() {
 		super.initialize();
-		registerEventListeners();
 	}
 
 	protected void registerEventListeners() {
@@ -145,6 +144,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 					}
 				}
 			});
+			log.info("Distributed DB status event listener registered.");
 		}
 	}
 
@@ -165,6 +165,11 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 				startingPlugins.clear();
 			}
 		}
+	}
+	
+	@Override
+	public void init() {
+		registerEventListeners();
 	}
 
 	@Override

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -575,12 +575,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 
 			// 4. Register plugin
 			try {
-				PluginWrapper wrapper = getPlugin(id);
-				Plugin plugin = wrapper.getPlugin();
-				if (plugin instanceof MeshPlugin) {
-					MeshPlugin meshPlugin = (MeshPlugin) plugin;
-					pluginRegistry.preRegister(meshPlugin);
-				}
+				registerMeshPlugin(id);
 			} catch (Throwable e) {
 				log.error("Plugin registration failed with error", e);
 				try {

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -319,8 +319,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 			return rxError(INTERNAL_SERVER_ERROR, "admin_plugin_error_plugin_loading_failed", name);
 		}
 		if (id == null) {
-			log.warn(
-					"The plugin was not registered after deployment. Maybe the initialisation failed. Going to unload the plugin.");
+			log.warn("The plugin was not registered after deployment. Maybe the initialisation failed. Going to unload the plugin.");
 			return rxError(INTERNAL_SERVER_ERROR, "admin_plugin_error_plugin_did_not_register", name);
 		}
 		setStatus(id, LOADED);
@@ -359,7 +358,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 			return rxError(INTERNAL_SERVER_ERROR, "admin_plugin_error_plugin_starting_failed", name);
 		}
 
-		// 5. Pre-Register the plugin
+		// 5. Register the plugin
 		try {
 			registerMeshPlugin(id);
 		} catch (Throwable e) {

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -602,7 +602,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 
 						pluginRegistry.preRegister(meshPlugin);
 
-						// If the plugin has failed to init once
+						// If the plugin has failed to init once - 1st fail case.
 						if (getStatus(meshPlugin.id()) == PluginStatus.FAILED && source != failedPlugins) {
 							pluginWrapper.setPluginState(PluginState.RESOLVED);
 							setStatus(meshPlugin.id(), PluginStatus.LOADED);
@@ -622,6 +622,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 					if (source == failedPlugins) {
 						log.error("Error while starting plugin {" + pluginWrapper.getPluginId() + "}: " + e.getMessage(), e);
 					} else {
+						// If the plugin has thrown an exception without setting the FAILED status - 2nd fail case.
 						log.warn("First error while starting plugin {" + pluginWrapper.getPluginId() + "}: " + e.getMessage() + ", giving a retry...", e);
 						failedPlugins.add(pluginWrapper);
 						pluginWrapper.getPlugin().stop();

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -603,10 +603,13 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 						pluginRegistry.preRegister(meshPlugin);
 
 						// If the plugin has failed to init once - 1st fail case.
-						if (getStatus(meshPlugin.id()) == PluginStatus.FAILED && source != failedPlugins) {
-							pluginWrapper.setPluginState(PluginState.RESOLVED);
-							setStatus(meshPlugin.id(), PluginStatus.LOADED);
-							throw new IllegalStateException("Plugin " + meshPlugin.id() + " failed to initialize once!");
+						if (getStatus(meshPlugin.id()) == PluginStatus.FAILED) {
+							if (source != failedPlugins) {
+								// Plugin failed for the first time - give it another try
+								pluginWrapper.setPluginState(PluginState.RESOLVED);
+								setStatus(meshPlugin.id(), PluginStatus.LOADED);
+								throw new IllegalStateException("Plugin " + meshPlugin.id() + " failed to initialize once!");
+							}
 						} else {
 							setStatus(meshPlugin.id(), PluginStatus.STARTED);
 						}

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -156,7 +156,10 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 				for (PluginWrapper wrapper : startingPlugins) {
 					log.info("Restarting plugin {" + wrapper.getPluginId() + "} because of an unavailable database.");
 
-					// TODO stop the pf4j part?
+					if (wrapper.getPlugin() instanceof MeshPlugin) {
+						MeshPlugin meshPlugin = (MeshPlugin) wrapper.getPlugin();
+						meshPlugin.shutdown();
+					}
 					restartingPlugins.add(wrapper);
 				}
 				startingPlugins.clear();

--- a/core/src/test/plugins/failing-first/pom.xml
+++ b/core/src/test/plugins/failing-first/pom.xml
@@ -1,0 +1,88 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.gentics.mesh.plugin</groupId>
+	<artifactId>failing-first-plugin</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<plugin.id>failing-first</plugin.id>
+		<plugin.name>The failing-first plugin</plugin.name>
+		<plugin.class>com.gentics.mesh.plugin.FailingFirstPlugin</plugin.class>
+		<plugin.version>0.0.1</plugin.version>
+		<plugin.author>Serhii Plyhun</plugin.author>
+		<plugin.inception>2021-05-14</plugin.inception>
+		<plugin.description>Plugin, that fails on a first startup</plugin.description>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.gentics.mesh</groupId>
+				<artifactId>mesh-plugin-bom</artifactId>
+				<version>${mesh.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.gentics.mesh</groupId>
+			<artifactId>mesh-plugin-dep</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<verbose>false</verbose>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Plugin-Id>${plugin.id}</Plugin-Id>
+										<Plugin-Name>${plugin.name}</Plugin-Name>
+										<Plugin-Version>${plugin.version}</Plugin-Version>
+										<Plugin-Author>${plugin.author}</Plugin-Author>
+										<Plugin-Class>${plugin.class}</Plugin-Class>
+										<Plugin-Description>${plugin.description}</Plugin-Description>
+										<Plugin-License>Apache License 2.0</Plugin-License>
+										<Plugin-Inception>${plugin.inception}</Plugin-Inception>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-install-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+		</plugins>
+	</build>
+</project>

--- a/core/src/test/plugins/failing-first/src/main/java/com/gentics/mesh/plugin/FailingFirstPlugin.java
+++ b/core/src/test/plugins/failing-first/src/main/java/com/gentics/mesh/plugin/FailingFirstPlugin.java
@@ -27,6 +27,7 @@ public class FailingFirstPlugin extends AbstractPlugin implements RestPlugin {
 				return Completable.complete();
 			} catch (Exception e) {
 				log.error("Failing failed!", e);
+				Thread.sleep(1000 * 60 * 5);
 				environment().vertx().fileSystem().createFileBlocking(FILENAME);
 				return Completable.error(e);
 			}

--- a/core/src/test/plugins/failing-first/src/main/java/com/gentics/mesh/plugin/FailingFirstPlugin.java
+++ b/core/src/test/plugins/failing-first/src/main/java/com/gentics/mesh/plugin/FailingFirstPlugin.java
@@ -1,0 +1,35 @@
+package com.gentics.mesh.plugin;
+
+import org.pf4j.PluginWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gentics.mesh.plugin.env.PluginEnvironment;
+
+import io.reactivex.Completable;
+
+public class FailingFirstPlugin extends AbstractPlugin implements RestPlugin {
+	
+	private static final Logger log = LoggerFactory.getLogger(FailingFirstPlugin.class);
+	
+	private static final String FILENAME = "target/already-failed.bin";
+
+	public FailingFirstPlugin(PluginWrapper wrapper, PluginEnvironment env) {
+		super(wrapper, env);
+	}
+
+	@Override
+	public Completable initialize() {
+		return Completable.defer(() -> {
+			try {
+				log.info("Failing starts up!");
+				environment().vertx().fileSystem().readFileBlocking(FILENAME);
+				return Completable.complete();
+			} catch (Exception e) {
+				log.error("Failing failed!", e);
+				environment().vertx().fileSystem().createFileBlocking(FILENAME);
+				return Completable.error(e);
+			}
+		});
+	}
+}

--- a/core/src/test/plugins/pom.xml
+++ b/core/src/test/plugins/pom.xml
@@ -18,6 +18,7 @@
 		<module>client</module>
 		<module>non-mesh</module>
 		<module>failing</module>
+		<module>failing-first</module>
 		<module>classloader</module>
 		<module>common</module>
 		<module>extension-provider</module>

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/TopologyEventBridge.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/TopologyEventBridge.java
@@ -113,14 +113,16 @@ public class TopologyEventBridge implements ODistributedLifecycleListener {
 		}
 		databaseStatusMap.put(nodeName, iNewStatus);
 		log.info("Node {" + nodeName + "} Database {" + iDatabaseName + "} changed status {" + iNewStatus.name() + "}");
+		boolean isMe = "storage".equals(iDatabaseName) && nodeName.equals(manager.getNodeName());
 		if (isVertxReady()) {
 			JsonObject statusInfo = new JsonObject();
 			statusInfo.put("node", nodeName);
 			statusInfo.put("database", iDatabaseName);
 			statusInfo.put("status", iNewStatus.name());
+			statusInfo.put("isMe", isMe);
 			getEventBus().publish(CLUSTER_DATABASE_CHANGE_STATUS.address, statusInfo);
 		}
-		if ("storage".equals(iDatabaseName) && iNewStatus == DB_STATUS.ONLINE && nodeName.equals(manager.getNodeName())) {
+		if (isMe && iNewStatus == DB_STATUS.ONLINE) {
 			nodeJoinLatch.countDown();
 		}
 	}

--- a/distributed/src/test/java/com/gentics/mesh/distributed/AbstractClusterTest.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/AbstractClusterTest.java
@@ -100,5 +100,9 @@ public abstract class AbstractClusterTest {
 		}
 		return server;
 	}
-
+	
+	protected void login(MeshContainer server) {
+		server.client().setLogin("admin", "admin");
+		server.client().login().blockingGet();
+	}
 }

--- a/distributed/src/test/java/com/gentics/mesh/distributed/ClusterTorturePluginHoldsStartup.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/ClusterTorturePluginHoldsStartup.java
@@ -1,0 +1,25 @@
+package com.gentics.mesh.distributed;
+
+import static com.gentics.mesh.util.TokenUtil.randomToken;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.gentics.mesh.test.docker.MeshContainer;
+
+public class ClusterTorturePluginHoldsStartup extends AbstractClusterTortureTest {
+
+	private static final int STARTUP_TIMEOUT = 60 * 6;
+	
+	@Test
+	public void testSecondaryBackupCreated() throws Exception {
+		torture((a, b, c) -> {
+			MeshContainer serverB2 = prepareSlave("dockerCluster" + clusterPostFix, "nodeB2", randomToken(), true, true, 1)
+					.withPlugin(new File("../core/target/test-plugins/failing-first/target/failing-first-plugin-0.0.1-SNAPSHOT.jar"), "failing-first.jar");
+			serverB2.start();
+			serverB2.awaitStartup(STARTUP_TIMEOUT);
+			login(serverB2);
+		});
+	}	
+}

--- a/distributed/src/test/java/com/gentics/mesh/distributed/PluginClusterTest.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/PluginClusterTest.java
@@ -122,10 +122,4 @@ public class PluginClusterTest extends AbstractClusterTest {
 
 		latch.await(timeoutInMilliseconds, TimeUnit.MILLISECONDS);
 	}
-
-	private void login(MeshContainer server) {
-		server.client().setLogin("admin", "admin");
-		server.client().login().blockingGet();
-	}
-
 }


### PR DESCRIPTION
## Abstract

Mesh plugins are allowed to change the Mesh data over the MeshRestClient during the initialization. In the case of distributed database the DB availability has to be concerned during the plugin initialization. This MR applies a distributed DB topology lock listener, which triggers the currently initializing plugins to shutdown and restart once the DB is back again.

## Checklist

### General

* [x] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
