### PR TITLE
A routing strategy on the topology lock changes

### DIFF
--- a/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.doc.GenerateDocumentation;
 import com.gentics.mesh.etc.config.cluster.CoordinationTopology;
+import com.gentics.mesh.etc.config.cluster.CoordinationTopologyLockHeldStrategy;
 import com.gentics.mesh.etc.config.cluster.CoordinatorMode;
 import com.gentics.mesh.etc.config.env.EnvironmentVariable;
 import com.gentics.mesh.etc.config.env.Option;
@@ -33,6 +34,7 @@ public class ClusterOptions implements Option {
 	public static final String MESH_CLUSTER_TOPOLOGY_LOCK_TIMEOUT_ENV = "MESH_CLUSTER_TOPOLOGY_LOCK_TIMEOUT";
 	public static final String MESH_CLUSTER_TOPOLOGY_LOCK_DELAY_ENV = "MESH_CLUSTER_TOPOLOGY_LOCK_DELAY";
 	public static final String MESH_CLUSTER_COORDINATOR_TOPOLOGY_ENV = "MESH_CLUSTER_COORDINATOR_TOPOLOGY";
+	public static final String MESH_CLUSTER_COORDINATOR_TOPOLOGY_LOCK_HELD_STRATEGY_ENV = "MESH_CLUSTER_COORDINATOR_TOPOLOGY_LOCK_HELD_STRATEGY";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("IP or host which is used to announce and reach the instance in the cluster. Gentics Mesh will try to determine the IP automatically but you may use this setting to override this automatic IP handling.")
@@ -84,6 +86,20 @@ public class ClusterOptions implements Option {
 	@JsonPropertyDescription("The coordinator topology setting controls whether the coordinator should manage the cluster topology. By default no cluster topology management will be done.")
 	@EnvironmentVariable(name = MESH_CLUSTER_COORDINATOR_TOPOLOGY_ENV, description = "Override the cluster coordinator topology management mode.")
 	private CoordinationTopology coordinatorTopology = CoordinationTopology.UNMANAGED;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("The coordinator strategy controls the behavior of the DB access requests hit the held topology lock. By default all the requests wait for the topology lock being freed.")
+	@EnvironmentVariable(name = MESH_CLUSTER_COORDINATOR_TOPOLOGY_LOCK_HELD_STRATEGY_ENV, description = "Override the cluster coordinator strategy on topology lock being held.")
+	private CoordinationTopologyLockHeldStrategy coordinatorTopologyLockHeldStrategy = CoordinationTopologyLockHeldStrategy.PASS_AND_WAIT_ALL;
+
+	public CoordinationTopologyLockHeldStrategy getCoordinatorTopologyLockHeldStrategy() {
+		return coordinatorTopologyLockHeldStrategy;
+	}
+
+	public void setCoordinatorTopologyLockHeldStrategy(
+			CoordinationTopologyLockHeldStrategy coordinatorTopologyLockHeldStrategy) {
+		this.coordinatorTopologyLockHeldStrategy = coordinatorTopologyLockHeldStrategy;
+	}
 
 	public boolean isEnabled() {
 		return enabled;

--- a/api/src/main/java/com/gentics/mesh/etc/config/cluster/CoordinationTopologyLockHeldStrategy.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/cluster/CoordinationTopologyLockHeldStrategy.java
@@ -1,0 +1,14 @@
+package com.gentics.mesh.etc.config.cluster;
+
+public enum CoordinationTopologyLockHeldStrategy {
+
+	/**
+	 * On any DB transaction pass it further to wait until the topology lock is freed.
+	 */
+	PASS_AND_WAIT_ALL,
+	
+	/**
+	 * On mutating DB transactions fail on held topology lock immediately, and pass the reading DB transactions.
+	 */
+	DROP_CUD;
+}

--- a/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
+++ b/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
@@ -54,4 +54,10 @@ public interface ClusterManager {
 	 */
 	Completable waitUntilWriteQuorumReached();
 
+	/**
+	 * Checks if the cluster storage is locked cluster-wide.
+	 * 
+	 * @return
+	 */
+	default boolean isClusterTopologyLocked() { return false; }
 }

--- a/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
@@ -29,6 +29,8 @@ import com.gentics.mesh.distributed.coordinator.proxy.RequestDelegatorImpl;
 import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.event.impl.EventQueueBatchImpl;
 import com.gentics.mesh.graphdb.OrientDBDatabase;
+import com.gentics.mesh.graphdb.cluster.ClusterManager;
+import com.gentics.mesh.graphdb.cluster.OrientDBClusterManager;
 import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.handler.RangeRequestHandler;
 import com.gentics.mesh.handler.impl.RangeRequestHandlerImpl;
@@ -121,4 +123,7 @@ public abstract class BindModule {
 
 	@Binds
 	abstract BucketManager bindBucketManager(BucketManagerImpl e);
+
+	@Binds
+	abstract ClusterManager bindClusterManager(OrientDBClusterManager clusterManager);
 }

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
@@ -492,6 +492,7 @@ public class OrientDBClusterManager implements ClusterManager {
 	 * @see TopologyEventBridge#isClusterTopologyLocked()
 	 * @return
 	 */
+	@Override
 	public boolean isClusterTopologyLocked() {
 		if (topologyEventBridge == null) {
 			return false;

--- a/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/Coordinator.java
+++ b/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/Coordinator.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 
 import com.gentics.mesh.core.rest.admin.cluster.coordinator.CoordinatorConfig;
 import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.etc.config.cluster.CoordinationTopologyLockHeldStrategy;
 import com.gentics.mesh.etc.config.cluster.CoordinatorMode;
 
 /**
@@ -15,11 +16,13 @@ public class Coordinator {
 
 	private final MasterElector elector;
 	private CoordinatorMode mode = CoordinatorMode.DISABLED;
+	private CoordinationTopologyLockHeldStrategy topologyLockHeldStrategy = CoordinationTopologyLockHeldStrategy.PASS_AND_WAIT_ALL;
 
 	@Inject
 	public Coordinator(MasterElector elector, MeshOptions options) {
 		this.elector = elector;
 		this.mode = options.getClusterOptions().getCoordinatorMode();
+		this.setTopologyLockHeldStrategy(options.getClusterOptions().getCoordinatorTopologyLockHeldStrategy());
 	}
 
 	public MasterServer getMasterMember() {
@@ -33,6 +36,14 @@ public class Coordinator {
 	public Coordinator setCoordinatorMode(CoordinatorMode mode) {
 		this.mode = mode;
 		return this;
+	}
+
+	public CoordinationTopologyLockHeldStrategy getTopologyLockHeldStrategy() {
+		return topologyLockHeldStrategy;
+	}
+
+	public void setTopologyLockHeldStrategy(CoordinationTopologyLockHeldStrategy topologyLockHeldStrategy) {
+		this.topologyLockHeldStrategy = topologyLockHeldStrategy;
 	}
 
 	public void setMaster() {

--- a/distributed/src/test/java/com/gentics/mesh/distributed/coordinatortoken/ClusterTopologyLockedTest.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/coordinatortoken/ClusterTopologyLockedTest.java
@@ -1,0 +1,54 @@
+package com.gentics.mesh.distributed.coordinatortoken;
+
+import static com.gentics.mesh.util.TokenUtil.randomToken;
+import static com.gentics.mesh.util.UUIDUtil.randomUUID;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+
+import com.gentics.mesh.etc.config.cluster.CoordinationTopologyLockHeldStrategy;
+import com.gentics.mesh.rest.client.MeshRestClient;
+import com.gentics.mesh.test.docker.MeshContainer;
+
+public class ClusterTopologyLockedTest extends AbstractClusterCoordinatorTokenTest {
+	private static String clusterPostFix = randomUUID();
+	private static String coordinatorRegex = "nodeA";
+
+	public static MeshContainer serverA = new MeshContainer(MeshContainer.LOCAL_PROVIDER)
+		.withClusterName("dockerCluster" + clusterPostFix)
+		.withNodeName("nodeA")
+		.withDataPathPostfix(randomToken())
+		.withTopologyLockHeldStrategy(CoordinationTopologyLockHeldStrategy.DROP_CUD)
+		.withInitCluster()
+		.withPublicKeys(getResourceAsFile("/public-keys/symmetric-key.json"))
+		.waitForStartup()
+		.withClearFolders();
+
+	public static MeshContainer serverB = new MeshContainer(MeshContainer.LOCAL_PROVIDER)
+		.withClusterName("dockerCluster" + clusterPostFix)
+		.withNodeName("nodeB")
+		.withDataPathPostfix(randomToken())
+		.withTopologyLockHeldStrategy(CoordinationTopologyLockHeldStrategy.DROP_CUD)
+		.withPublicKeys(getResourceAsFile("/public-keys/symmetric-key.json"))
+		.waitForStartup()
+		.withClearFolders();
+
+	private static File getResourceAsFile(String name) {
+		try {
+			return new File(com.gentics.mesh.distributed.ClusterCoordinatorTokenTest.class.getResource(name).toURI());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@ClassRule
+	public static RuleChain chain = RuleChain.outerRule(serverA).around(serverB);
+
+	@Override
+	protected MeshRestClient getServerBClient() {
+		return serverB.client();
+	}
+}

--- a/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
+++ b/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
@@ -37,6 +37,7 @@ import com.gentics.mesh.OptionsLoader;
 import com.gentics.mesh.etc.config.ClusterOptions;
 import com.gentics.mesh.etc.config.GraphStorageOptions;
 import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.etc.config.cluster.CoordinationTopologyLockHeldStrategy;
 import com.gentics.mesh.etc.config.cluster.CoordinatorMode;
 import com.gentics.mesh.etc.config.search.ElasticSearchOptions;
 import com.gentics.mesh.rest.client.MeshRestClient;
@@ -117,6 +118,8 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 	private boolean startEmbeddedES = false;
 
 	private CoordinatorMode coordinatorMode = null;
+
+	private CoordinationTopologyLockHeldStrategy topologyHeldStrategy = null;
 
 	private String coordinatorPlaneRegex;
 
@@ -232,6 +235,10 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 
 		if (coordinatorMode != null) {
 			addEnv(ClusterOptions.MESH_CLUSTER_COORDINATOR_MODE_ENV, coordinatorMode.name());
+		}
+		
+		if (topologyHeldStrategy != null) {
+			addEnv(ClusterOptions.MESH_CLUSTER_COORDINATOR_TOPOLOGY_LOCK_HELD_STRATEGY_ENV, topologyHeldStrategy.name());
 		}
 
 		if (coordinatorPlaneRegex != null) {
@@ -615,6 +622,11 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 
 	public MeshContainer withCoordinatorPlane(CoordinatorMode coordinatorMode) {
 		this.coordinatorMode = coordinatorMode;
+		return this;
+	}
+
+	public MeshContainer withTopologyLockHeldStrategy(CoordinationTopologyLockHeldStrategy strategy) {
+		this.topologyHeldStrategy = strategy;
 		return this;
 	}
 


### PR DESCRIPTION
## Abstract

Introduce the handle to control over the strategy of incoming request processing. when the (distributed) storage is not available for whatever reason.

1. Default behavior: all the requests pass and wait for the DB is available again for the defined timeout, as before.
2. Drop the DB writing requests (create/update/delete) with HTTP 503, when the DB is not available.

## Checklist

### General

* [x] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
