### PR TITLE
Implement plugin initialization retry if plugin init fails due to

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.12]]
+== 1.6.12 (TBD)
+
+icon:check[] Plugins: If plugin initialization fails due to topology changes (e.g. the OrientDB needs to be synchronized from another node), the plugin will be set to
+status FAILED_RETRY and initialization will be retried as soon as OrientDB becomes available again.
+
 [[v1.6.11]]
 == 1.6.11 (12.05.2021)
 

--- a/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
+++ b/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
@@ -54,4 +54,10 @@ public interface ClusterManager {
 	 */
 	Completable waitUntilWriteQuorumReached();
 
+	/**
+	 * Checks if the cluster storage is locked cluster-wide.
+	 * 
+	 * @return
+	 */
+	boolean isClusterTopologyLocked();
 }

--- a/common/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManager.java
+++ b/common/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManager.java
@@ -20,6 +20,10 @@ import io.reactivex.Single;
  * The plugin manager can be used to deploy plugins and register them in Gentics Mesh.
  */
 public interface MeshPluginManager {
+	/**
+	 * Initialize the internals after Vert.x is up.
+	 */
+	void init();
 
 	/**
 	 * Initialize the plugin manager.
@@ -145,6 +149,15 @@ public interface MeshPluginManager {
 	 * @return
 	 */
 	PluginStatus getStatus(String id);
+
+	/**
+	 * Set the plugin status to either {@link PluginStatus#FAILED} or {@link PluginStatus#FAILED_RETRY},
+	 * depending on whether the manager is aware of the reason, why the plugin initialization probably failed,
+	 * and will retry initialization, if possible.
+	 * 
+	 * @param id plugin ID
+	 */
+	void setPluginFailed(String id);
 
 	/**
 	 * Create a REST response for the given plugin.

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -327,6 +327,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				// Finally start ES integration
 				searchProvider.init();
 				searchProvider.start();
+				pluginManager.init();
 				if (flags.isReindex()) {
 					createSearchIndicesAndMappings();
 				}
@@ -348,6 +349,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 				// Finally start ES integration
 				searchProvider.init();
 				searchProvider.start();
+				pluginManager.init();
 				initLocalData(flags, options, true);
 			}
 
@@ -370,6 +372,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 			initVertx(options);
 			searchProvider.init();
 			searchProvider.start();
+			pluginManager.init();
 			initLocalData(flags, options, false);
 		}
 

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.plugin.manager;
 
+import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_DATABASE_CHANGE_STATUS;
 import static com.gentics.mesh.core.rest.error.Errors.error;
 import static com.gentics.mesh.core.rest.error.Errors.rxError;
 import static com.gentics.mesh.core.rest.plugin.PluginStatus.LOADED;
@@ -12,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -20,6 +22,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -56,6 +59,8 @@ import com.gentics.mesh.core.rest.error.GenericRestException;
 import com.gentics.mesh.core.rest.plugin.PluginResponse;
 import com.gentics.mesh.core.rest.plugin.PluginStatus;
 import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.graphdb.cluster.ClusterManager;
+import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.plugin.MeshPlugin;
 import com.gentics.mesh.plugin.MeshPluginDescriptor;
 import com.gentics.mesh.plugin.impl.MeshPluginDescriptorFinderImpl;
@@ -64,8 +69,13 @@ import com.gentics.mesh.plugin.pf4j.MeshPluginFactory;
 import com.gentics.mesh.plugin.registry.DelegatingPluginRegistry;
 import com.gentics.mesh.plugin.util.PluginUtils;
 
+import dagger.Lazy;
 import io.reactivex.Completable;
 import io.reactivex.Single;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -79,25 +89,81 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 
 	public static final String PLUGINS_DIR_CONFIG_PROPERTY_NAME = "pf4j.pluginsConfigDir";
 
+	private final Lazy<Vertx> vertx;
+
 	private final PluginFactory pluginFactory;
 
 	private final MeshOptions options;
 
 	// We track our own plugin status since the PF4J state is not extendible.
-	private final Map<String, PluginStatus> pluginStatusMap = new HashedMap<>();
+	private final Map<String, PluginStatus> pluginStatusMap = Collections.synchronizedMap(new HashedMap<>());
+
+	private final AtomicBoolean dbReady = new AtomicBoolean(true);
 
 	private final DelegatingPluginRegistry pluginRegistry;
 
+	private final ClusterManager clusterManager;
+
 	@Inject
-	public MeshPluginManagerImpl(MeshOptions options, MeshPluginFactory pluginFactory, DelegatingPluginRegistry pluginRegistry) {
+	public MeshPluginManagerImpl(MeshOptions options, MeshPluginFactory pluginFactory, DelegatingPluginRegistry pluginRegistry, Database database, Lazy<Vertx> vertx) {
 		this.pluginFactory = pluginFactory;
 		this.options = options;
 		this.pluginRegistry = pluginRegistry;
+		this.vertx = vertx;
+		this.clusterManager = database.clusterManager();
 		delayedInitialize();
 	}
 
 	protected void delayedInitialize() {
 		super.initialize();
+	}
+
+	/**
+	 * Register event handlers
+	 */
+	protected void registerEventListeners() {
+		if (options.getClusterOptions().isEnabled()) {
+			EventBus eb = vertx.get().eventBus();
+
+			eb.consumer(CLUSTER_DATABASE_CHANGE_STATUS.address, (Message<JsonObject> handler) -> {
+				// at least one database in the cluster changed its status
+				if (clusterManager != null) {
+					// we are interested in the cluster-wide locking of storages
+					handleDatabaseAvailability(!clusterManager.isClusterTopologyLocked());
+				}
+			});
+			log.info("Distributed DB status event listener registered.");
+		}
+	}
+
+	/**
+	 * Handle change in database availability in the cluster
+	 * @param available availability status
+	 */
+	protected synchronized void handleDatabaseAvailability(boolean available) {
+		if (available) {
+			boolean wasAvailable = dbReady.getAndSet(true);
+			if (!wasAvailable) {
+				log.info("Database changed to be available. Plugin stati are {}", pluginStatusMap);
+
+				List<String> failedPluginIds = pluginStatusMap.entrySet().stream().filter(entry -> entry.getValue() == PluginStatus.FAILED_RETRY)
+						.map(entry -> entry.getKey()).collect(Collectors.toList());
+
+				for (String id : failedPluginIds) {
+					preRegisterMeshPlugin(id);
+				}
+			}
+		} else {
+			boolean wasAvailable = dbReady.getAndSet(false);
+			if (wasAvailable) {
+				log.info("Database changed to be unavailable. Plugin stati are {}", pluginStatusMap);
+			}
+		}
+	}
+
+	@Override
+	public void init() {
+		registerEventListeners();
 	}
 
 	@Override
@@ -198,7 +264,7 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 		}
 		setStatus(id, LOADED);
 
-		// 3. Invoke the loading of the plugin class
+		// 3. Invoke the validation of the plugin class
 		try {
 			PluginWrapper plugin = getPlugin(id);
 			if (plugin == null || plugin.getPlugin() == null) {
@@ -232,14 +298,9 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 			return rxError(INTERNAL_SERVER_ERROR, "admin_plugin_error_plugin_starting_failed", name);
 		}
 
-		// 5. Register the plugin
+		// 5. Pre-Register the plugin
 		try {
-			PluginWrapper wrapper = getPlugin(id);
-			Plugin plugin = wrapper.getPlugin();
-			if (plugin instanceof MeshPlugin) {
-				MeshPlugin meshPlugin = (MeshPlugin) plugin;
-				pluginRegistry.preRegister(meshPlugin);
-			}
+			preRegisterMeshPlugin(id);
 		} catch (Throwable e) {
 			log.error("Plugin registration failed with error", e);
 			rollback(id);
@@ -247,6 +308,20 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 		}
 
 		return Single.just(id);
+	}
+
+	/**
+	 * Pre-register the plugin with given ID (which will also start the initialization and registration)
+	 * @param id plugin ID
+	 */
+	private void preRegisterMeshPlugin(String id) {
+		PluginWrapper wrapper = getPlugin(id);
+		Plugin plugin = wrapper.getPlugin();
+
+		if (plugin instanceof MeshPlugin) {
+			MeshPlugin meshPlugin = (MeshPlugin) plugin;
+			pluginRegistry.preRegister(meshPlugin);
+		}
 	}
 
 	private void removePlugin(String id) {
@@ -438,14 +513,9 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 				return rxError(INTERNAL_SERVER_ERROR, "admin_plugin_error_plugin_starting_failed", name).ignoreElement();
 			}
 
-			// 4. Register plugin
+			// 4. Pre-Register plugin
 			try {
-				PluginWrapper wrapper = getPlugin(id);
-				Plugin plugin = wrapper.getPlugin();
-				if (plugin instanceof MeshPlugin) {
-					MeshPlugin meshPlugin = (MeshPlugin) plugin;
-					pluginRegistry.preRegister(meshPlugin);
-				}
+				preRegisterMeshPlugin(id);
 			} catch (Throwable e) {
 				log.error("Plugin registration failed with error", e);
 				try {
@@ -465,11 +535,21 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 	@Override
 	public void setStatus(String id, PluginStatus status) {
 		pluginStatusMap.put(id, status);
+		log.debug("Plugin {} changed to status {}", id , status);
 	}
 
 	@Override
 	public PluginStatus getStatus(String id) {
 		return pluginStatusMap.get(id);
+	}
+
+	@Override
+	public void setPluginFailed(String id) {
+		if (dbReady.get()) {
+			setStatus(id, PluginStatus.FAILED);
+		} else {
+			setStatus(id, PluginStatus.FAILED_RETRY);
+		}
 	}
 
 	private void withTimeout(String id, String operationName, Completable op) {

--- a/core/src/test/java/com/gentics/mesh/plugin/BackupPlugin.java
+++ b/core/src/test/java/com/gentics/mesh/plugin/BackupPlugin.java
@@ -1,0 +1,101 @@
+package com.gentics.mesh.plugin;
+
+import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_DATABASE_CHANGE_STATUS;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.pf4j.PluginWrapper;
+
+import com.gentics.mesh.RestAPIVersion;
+import com.gentics.mesh.plugin.env.PluginEnvironment;
+import com.gentics.mesh.rest.client.MeshRestClient;
+import com.gentics.mesh.rest.client.MeshRestClientConfig;
+
+import io.reactivex.Completable;
+import io.vertx.core.eventbus.MessageConsumer;
+import okhttp3.OkHttpClient;
+
+/**
+ * Test plugin which will
+ * <ol>
+ * <li>Invoke the OrientDB backup and fail immediately, when initialized the first time</li>
+ * <li>Succeed initialization for every further attempt</li>
+ * </ol>
+ */
+public class BackupPlugin extends AbstractPlugin {
+	protected static AtomicBoolean firstStart = new AtomicBoolean(true);
+
+	/**
+	 * Create instance
+	 * @param wrapper plugin wrapper
+	 * @param env environment
+	 */
+	public BackupPlugin(PluginWrapper wrapper, PluginEnvironment env) {
+		super(wrapper, env);
+	}
+
+	@Override
+	public Completable initialize() {
+		if (firstStart.getAndSet(false)) {
+			return invokeBackupAndFail();
+		} else {
+			return Completable.complete();
+		}
+	}
+
+	/**
+	 * Invoke the OrientDB back (using a client with timeout set to 1 ms), wait for the CLUSTER_DATABASE_CHANGE_STATUS event and then fail
+	 * @return failing completable
+	 */
+	protected Completable invokeBackupAndFail() {
+		OkHttpClient okHttpClient = new OkHttpClient.Builder()
+				.callTimeout(Duration.ofMillis(1))
+				.connectTimeout(Duration.ofMillis(1))
+				.writeTimeout(Duration.ofMillis(1))
+				.readTimeout(Duration.ofMillis(1))
+				.build();
+
+		int port = environment().options().getHttpServerOptions().getPort();
+		String host = "127.0.0.1";
+		MeshRestClient client = MeshRestClient.create(MeshRestClientConfig.newConfig()
+			.setPort(port)
+			.setHost(host)
+			.setBasePath(RestAPIVersion.V1.getBasePath())
+			.build(), okHttpClient);
+
+		client.setAPIKey(environment().adminToken());
+
+		return client.invokeBackup().toCompletable().onErrorResumeNext(t -> waitForEvent(10_000))
+				.andThen(Completable.error(new RuntimeException()));
+	}
+
+	/**
+	 * Wait for the event CLUSTER_DATABASE_CHANGE_STATUS
+	 * @param timeoutMs timeout
+	 * @return completable
+	 */
+	protected Completable waitForEvent(int timeoutMs) {
+		return Completable.fromAction(() -> {
+			CountDownLatch latch = new CountDownLatch(1);
+			MessageConsumer<Object> consumer = vertx().eventBus().consumer(CLUSTER_DATABASE_CHANGE_STATUS.address);
+			consumer.handler(msg -> latch.countDown());
+			// The completion handler will be invoked once the consumer has been registered
+			consumer.completionHandler(res -> {
+				if (res.failed()) {
+					throw new RuntimeException("Could not listen to event", res.cause());
+				}
+			});
+			try {
+				if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+					throw new RuntimeException("Timeout while waiting for event");
+				}
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+			consumer.unregister();
+		});
+	}
+}

--- a/core/src/test/java/com/gentics/mesh/plugin/PluginManagerClusterTest.java
+++ b/core/src/test/java/com/gentics/mesh/plugin/PluginManagerClusterTest.java
@@ -1,7 +1,15 @@
 package com.gentics.mesh.plugin;
 
+import static com.gentics.mesh.core.rest.plugin.PluginStatus.FAILED_RETRY;
+import static com.gentics.mesh.core.rest.plugin.PluginStatus.REGISTERED;
 import static com.gentics.mesh.test.TestSize.PROJECT;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
+
+import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.core.rest.plugin.PluginStatus;
+import com.gentics.mesh.plugin.manager.MeshPluginManager;
 import com.gentics.mesh.test.context.MeshTestSetting;
 
 /**
@@ -9,5 +17,27 @@ import com.gentics.mesh.test.context.MeshTestSetting;
  */
 @MeshTestSetting(testSize = PROJECT, startServer = true, inMemoryDB = false, clusterMode = true)
 public class PluginManagerClusterTest extends PluginManagerTest {
+	/**
+	 * Test initialization retry, if plugin fails due to topology change
+	 */
+	@Test
+	public void testRetry() {
+		MeshPluginManager manager = pluginManager();
+		// deploy the plugin
+		manager.deploy(BackupPlugin.class, "backup").blockingAwait();
 
+		// we expect the deployment to fail
+		waitForEvent(MeshEvent.PLUGIN_DEPLOY_FAILED);
+		assertEquals(1, manager.getPluginIds().size());
+		// plugin status is expected to be FAILED_RETRY, because the plugin invoked the OrientDB backup right before failing.
+		// this provoked the "cluster topology change"
+		PluginStatus status = manager.getStatus(manager.getPluginIds().iterator().next());
+		assertEquals(FAILED_RETRY, status);
+
+		// when the backup is finished, the OrientDB status should go ONLINE again and the PluginManager is
+		// expected to retry plugin initialization, which should succeed.
+		waitForEvent(MeshEvent.PLUGIN_REGISTERED, 60_000);
+		status = manager.getStatus(manager.getPluginIds().iterator().next());
+		assertEquals(REGISTERED, status);
+	}
 }

--- a/core/src/test/java/com/gentics/mesh/plugin/PluginManagerTest.java
+++ b/core/src/test/java/com/gentics/mesh/plugin/PluginManagerTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 
@@ -27,6 +28,7 @@ import com.gentics.mesh.core.rest.user.UserResponse;
 import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.plugin.manager.MeshPluginManager;
 import com.gentics.mesh.test.context.MeshTestSetting;
+import com.gentics.mesh.test.context.helper.ExpectedEvent;
 import com.twelvemonkeys.io.FileUtil;
 
 import io.vertx.core.http.HttpHeaders;
@@ -58,9 +60,10 @@ public class PluginManagerTest extends AbstractPluginTest {
 	@Test
 	public void testFilesystemDeployment() throws Exception {
 		setPluginBaseDir("abc");
-		String id = pluginManager().deploy(Paths.get(BASIC_PATH)).blockingGet();
-		assertEquals("basic", id);
-		waitForPluginRegistration();
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			String id = pluginManager().deploy(Paths.get(BASIC_PATH)).blockingGet();
+			assertEquals("basic", id);
+		}
 
 		for (int i = 0; i < 2; i++) {
 			ProjectCreateRequest request = new ProjectCreateRequest();
@@ -75,7 +78,7 @@ public class PluginManagerTest extends AbstractPluginTest {
 	}
 
 	@Test
-	public void testStartupDeployment() throws IOException {
+	public void testStartupDeployment() throws IOException, TimeoutException {
 		MeshPluginManager manager = pluginManager();
 		FileUtil.copy(new File(BASIC_PATH), new File(pluginDir(), "plugin.jar"));
 		FileUtil.copy(new File(BASIC_PATH), new File(pluginDir(), "duplicate-plugin.jar"));
@@ -96,9 +99,10 @@ public class PluginManagerTest extends AbstractPluginTest {
 		assertEquals(0, manager.getPluginIds().size());
 
 		manager.start();
-		manager.deployExistingPluginFiles().blockingAwait();
-		assertEquals(2, manager.getPluginIds().size());
-		waitForPluginRegistration();
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			manager.deployExistingPluginFiles().blockingAwait();
+			assertEquals(2, manager.getPluginIds().size());
+		}
 
 		// Assert that plugins were registered and initialized
 		String queryName = "plugin/graphql-plugin-query";
@@ -115,18 +119,20 @@ public class PluginManagerTest extends AbstractPluginTest {
 	 * @throws IOException
 	 */
 	@Test
-	public void testPluginAuth() throws IOException {
+	public void testPluginAuth() throws IOException, TimeoutException {
 		MeshPluginManager manager = pluginManager();
-		manager.deploy(ClientPlugin.class, "client").blockingAwait();
-		waitForPluginRegistration();
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			manager.deploy(ClientPlugin.class, "client").blockingAwait();
+		}
 		JsonObject json = new JsonObject(getJSONViaClient(CURRENT_API_BASE_PATH + "/plugins/client/user"));
 		assertNotNull(json.getString("uuid"));
 	}
 
 	@Test
-	public void testClientFlooding() throws GenericRestException, IOException {
-		pluginManager().deploy(ClientPlugin.class, "client").blockingAwait();
-		waitForPluginRegistration();
+	public void testClientFlooding() throws GenericRestException, IOException, TimeoutException {
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			pluginManager().deploy(ClientPlugin.class, "client").blockingAwait();
+		}
 
 		int before = threadCount();
 		for (int i = 0; i < 200; i++) {
@@ -145,9 +151,10 @@ public class PluginManagerTest extends AbstractPluginTest {
 	 * @throws IOException
 	 */
 	@Test
-	public void testClientAPI() throws IOException {
-		pluginManager().deploy(ClientPlugin.class, "client").blockingAwait();
-		waitForPluginRegistration();
+	public void testClientAPI() throws IOException, TimeoutException {
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			pluginManager().deploy(ClientPlugin.class, "client").blockingAwait();
+		}
 
 		ProjectCreateRequest request = new ProjectCreateRequest();
 		request.setName("testabc");
@@ -185,11 +192,12 @@ public class PluginManagerTest extends AbstractPluginTest {
 	}
 
 	@Test
-	public void testJavaDeployment() throws IOException {
+	public void testJavaDeployment() throws IOException, TimeoutException {
 		MeshPluginManager manager = pluginManager();
-		manager.deploy(DummyPlugin.class, "dummy").blockingAwait();
-		assertEquals(1, manager.getPluginIds().size());
-		waitForPluginRegistration();
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			manager.deploy(DummyPlugin.class, "dummy").blockingAwait();
+			assertEquals(1, manager.getPluginIds().size());
+		}
 
 		ProjectCreateRequest request = new ProjectCreateRequest();
 		request.setName("test");
@@ -222,29 +230,33 @@ public class PluginManagerTest extends AbstractPluginTest {
 	}
 
 	@Test
-	public void testInitializeTimeoutPlugin() {
+	public void testInitializeTimeoutPlugin() throws TimeoutException {
 		options().setPluginTimeout(1);
 		MeshPluginManager manager = pluginManager();
-		manager.deploy(InitializeTimeoutPlugin.class, "timeout").blockingAwait();
-		waitForEvent(MeshEvent.PLUGIN_DEPLOY_FAILED);
+		try (ExpectedEvent failed = expectEvent(MeshEvent.PLUGIN_DEPLOY_FAILED, 10_000)) {
+			manager.deploy(InitializeTimeoutPlugin.class, "timeout").blockingAwait();
+		}
 		assertEquals(1, manager.getPluginIds().size());
 		PluginStatus status = manager.getStatus(manager.getPluginIds().iterator().next());
 		assertEquals(FAILED, status);
 	}
 
 	@Test
-	public void testRedeployAfterInitFailure() {
+	public void testRedeployAfterInitFailure() throws TimeoutException {
 		MeshPluginManager manager = pluginManager();
-		manager.deploy(FailingInitializePlugin.class, "failing").blockingAwait();
-		waitForPluginRegistration();
+		try (ExpectedEvent failed = expectEvent(MeshEvent.PLUGIN_DEPLOY_FAILED, 10_000)) {
+			manager.deploy(FailingInitializePlugin.class, "failing").blockingAwait();
+		}
 		PluginStatus status = manager.getStatus(manager.getPluginIds().iterator().next());
 		assertEquals(FAILED, status);
 		assertEquals(1, manager.getPluginIds().size());
 		assertEquals(1, manager.getPluginsMap().size());
 
-		manager.deploy(SucceedingPlugin.class, "succeeding").blockingAwait();
-		assertEquals(2, manager.getPluginIds().size());
-		assertEquals(2, manager.getPluginsMap().size());
+		try (ExpectedEvent registration = expectEvent(MeshEvent.PLUGIN_REGISTERED, 20_000)) {
+			manager.deploy(SucceedingPlugin.class, "succeeding").blockingAwait();
+			assertEquals(2, manager.getPluginIds().size());
+			assertEquals(2, manager.getPluginsMap().size());
+		}
 	}
 
 }

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
@@ -11,12 +11,15 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import javax.jws.soap.SOAPBinding.Use;
+
 import com.gentics.mesh.cli.BootstrapInitializerImpl;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.job.JobListResponse;
 import com.gentics.mesh.core.rest.job.JobResponse;
 import com.gentics.mesh.core.rest.job.JobStatus;
 import com.gentics.mesh.parameter.client.PagingParametersImpl;
+import com.gentics.mesh.plugin.BackupPlugin;
 import com.gentics.mesh.search.verticle.ElasticsearchProcessVerticle;
 import com.gentics.mesh.search.verticle.eventhandler.SyncEventHandler;
 import com.gentics.mesh.test.context.ClientHandler;
@@ -49,17 +52,39 @@ public interface EventHelper extends BaseHelper {
 	 * 
 	 * @param address
 	 * @param code
-	 * @throws TimeoutException
+	 * @deprecated use {@link #expectEvent(String, Action, int)} instead
+	 * @see {@link #waitForEvent(String, Action, int)}
 	 */
 	default void waitForEvent(String address, Action code) {
 		waitForEvent(address, code, 10_000);
 	}
 
+	/**
+	 * Wait until the given event has been received.
+	 * 
+	 * @param event
+	 * @param timeoutMs
+	 * @deprecated use {@link #expectEvent(String, Action, int)} instead
+	 * @see {@link #waitForEvent(String, Action, int)}
+	 */
 	default void waitForEvent(MeshEvent event, int timeoutMs) {
 		waitForEvent(event.getAddress(), () -> {
 		}, timeoutMs);
 	}
 
+	/**
+	 * Wait for the event to be fired. Because this method has to first add the event handler
+	 * (which is done after the code, which will fire the event has been executed)
+	 * it may be, that the expected event has already been fired. In this case
+	 * (or when the event is never fired), this method will wait for the timeout and then succeed.<br>
+	 * It is therefore recommended to refactor all tests, which currently use this method to use {@link #expectEvent(String, Action, int)}
+	 * instead.
+	 * 
+	 * @param address event address
+	 * @param code code that is executed when the event has been fired
+	 * @param timeoutMs timeout in milliseconds
+	 * @deprecated use {@link #expectEvent(String, Action, int)} instead
+	 */
 	default void waitForEvent(String address, Action code, int timeoutMs) {
 		CountDownLatch latch = new CountDownLatch(1);
 		MessageConsumer<Object> consumer = vertx().eventBus().consumer(address);
@@ -76,13 +101,41 @@ public interface EventHelper extends BaseHelper {
 			}
 		});
 		try {
-			if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-				throw new RuntimeException("Timeout while waiting for event");
-			}
+			latch.await(timeoutMs, TimeUnit.MILLISECONDS);
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}
 		consumer.unregister();
+	}
+
+	/**
+	 * Variant of {@link #expectEvent(String, Action, int)}
+	 * @param event mesh event
+	 * @param timeoutMs timeout in milliseconds
+	 * @return AutoClosable instance
+	 */
+	default ExpectedEvent expectEvent(MeshEvent event, int timeoutMs) {
+		return expectEvent(event.getAddress(), () -> {
+		}, timeoutMs);
+	}
+
+	/**
+	 * Create an {@link AutoCloseable} which will register an event handler for the event with given address (when created) and
+	 * will wait for the event to be fired (at least once) in {@link AutoCloseable#close()}.<br>
+	 * This method should be used like this:
+	 * <blockquote><pre>
+	 * try (ExpectEvent ee = expectEvent(MeshEvent.PLUGIN_REGISTERED, 10_000)) {
+	 * 	// code, which is expected to fire the event
+	 * 	...
+	 * }
+	 * </pre></blockquote>
+	 * @param address event address
+	 * @param code action code, which is executed when the event was fired
+	 * @param timeoutMs timeout in milliseconds
+	 * @return AutoClosable instance
+	 */
+	default ExpectedEvent expectEvent(String address, Action code, int timeoutMs) {
+		return new ExpectedEvent(vertx(), address, code, timeoutMs);
 	}
 
 	default void waitForSearchIdleEvent() {
@@ -122,7 +175,8 @@ public interface EventHelper extends BaseHelper {
 	 *
 	 * @param event
 	 * @param code
-	 * @throws TimeoutException
+	 * @deprecated use {@link #expectEvent(String, Action, int)} instead
+	 * @see {@link #waitForEvent(String, Action, int)}
 	 */
 	default void waitForEvent(MeshEvent event, Action code) {
 		waitForEvent(event.address, code);
@@ -132,13 +186,18 @@ public interface EventHelper extends BaseHelper {
 	 * Wait until the given event has been received.
 	 *
 	 * @param event
-	 * @throws TimeoutException
+	 * @deprecated use {@link #expectEvent(String, Action, int)} instead
+	 * @see {@link #waitForEvent(String, Action, int)}
 	 */
 	default void waitForEvent(MeshEvent event) {
 		waitForEvent(event.address, () -> {
 		});
 	}
 
+	/**
+	 * @deprecated use {@link #expectEvent(String, Action, int)} instead
+	 * @see {@link #waitForEvent(String, Action, int)}
+	 */
 	default void waitForPluginRegistration() {
 		waitForEvent(MeshEvent.PLUGIN_REGISTERED, 20_000);
 	}

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
@@ -76,7 +76,9 @@ public interface EventHelper extends BaseHelper {
 			}
 		});
 		try {
-			latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+			if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+				throw new RuntimeException("Timeout while waiting for event");
+			}
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/ExpectedEvent.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/ExpectedEvent.java
@@ -1,0 +1,59 @@
+package com.gentics.mesh.test.context.helper;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.reactivex.functions.Action;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+
+/**
+ * AutoClosable implementation, which will register an event handler upon
+ * creation and will wait (up to the given timeout) in
+ * {@link ExpectedEvent#clone()} for the event to be fired at least once.
+ * See {@link EventHelper#expectEvent(com.gentics.mesh.core.rest.MeshEvent, int)} for usage.
+ */
+public class ExpectedEvent implements AutoCloseable {
+	protected CountDownLatch latch = new CountDownLatch(1);
+
+	protected int timeoutMs;
+
+	protected MessageConsumer<Object> consumer;
+
+	/**
+	 * Create an instance and register event handler
+	 * @param vertx vertx instance
+	 * @param address event address
+	 * @param code code to be executed when the event was fired
+	 * @param timeoutMs timeout in milliseconds
+	 */
+	public ExpectedEvent(Vertx vertx, String address, Action code, int timeoutMs) {
+		this.timeoutMs = timeoutMs;
+		consumer = vertx.eventBus().consumer(address);
+		consumer.handler(msg -> latch.countDown());
+		// The completion handler will be invoked once the consumer has been registered
+		consumer.completionHandler(res -> {
+			if (res.failed()) {
+				throw new RuntimeException("Could not listen to event", res.cause());
+			}
+			try {
+				code.run();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
+
+	@Override
+	public void close() throws TimeoutException {
+		try {
+			if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+				throw new TimeoutException("Timeout while waiting for event");
+			}
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		consumer.unregister();
+	}
+}

--- a/core/src/test/plugins/failing-first/pom.xml
+++ b/core/src/test/plugins/failing-first/pom.xml
@@ -1,0 +1,88 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.gentics.mesh.plugin</groupId>
+	<artifactId>failing-first-plugin</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<plugin.id>failing-first</plugin.id>
+		<plugin.name>The failing-first plugin</plugin.name>
+		<plugin.class>com.gentics.mesh.plugin.FailingFirstPlugin</plugin.class>
+		<plugin.version>0.0.1</plugin.version>
+		<plugin.author>Serhii Plyhun</plugin.author>
+		<plugin.inception>2021-05-14</plugin.inception>
+		<plugin.description>Plugin, that fails on a first startup</plugin.description>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.gentics.mesh</groupId>
+				<artifactId>mesh-plugin-bom</artifactId>
+				<version>${mesh.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.gentics.mesh</groupId>
+			<artifactId>mesh-plugin-dep</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<verbose>false</verbose>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Plugin-Id>${plugin.id}</Plugin-Id>
+										<Plugin-Name>${plugin.name}</Plugin-Name>
+										<Plugin-Version>${plugin.version}</Plugin-Version>
+										<Plugin-Author>${plugin.author}</Plugin-Author>
+										<Plugin-Class>${plugin.class}</Plugin-Class>
+										<Plugin-Description>${plugin.description}</Plugin-Description>
+										<Plugin-License>Apache License 2.0</Plugin-License>
+										<Plugin-Inception>${plugin.inception}</Plugin-Inception>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-install-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+		</plugins>
+	</build>
+</project>

--- a/core/src/test/plugins/failing-first/src/main/java/com/gentics/mesh/plugin/FailingFirstPlugin.java
+++ b/core/src/test/plugins/failing-first/src/main/java/com/gentics/mesh/plugin/FailingFirstPlugin.java
@@ -1,0 +1,35 @@
+package com.gentics.mesh.plugin;
+
+import org.pf4j.PluginWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gentics.mesh.plugin.env.PluginEnvironment;
+
+import io.reactivex.Completable;
+
+public class FailingFirstPlugin extends AbstractPlugin implements RestPlugin {
+	
+	private static final Logger log = LoggerFactory.getLogger(FailingFirstPlugin.class);
+	
+	private static final String FILENAME = "target/already-failed.bin";
+
+	public FailingFirstPlugin(PluginWrapper wrapper, PluginEnvironment env) {
+		super(wrapper, env);
+	}
+
+	@Override
+	public Completable initialize() {
+		return Completable.defer(() -> {
+			try {
+				log.info("Failing starts up!");
+				environment().vertx().fileSystem().readFileBlocking(FILENAME);
+				return Completable.complete();
+			} catch (Exception e) {
+				log.error("Failing failed!", e);
+				environment().vertx().fileSystem().createFileBlocking(FILENAME);
+				return Completable.error(e);
+			}
+		});
+	}
+}

--- a/core/src/test/plugins/init-mutating/pom.xml
+++ b/core/src/test/plugins/init-mutating/pom.xml
@@ -1,0 +1,88 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.gentics.mesh.plugin</groupId>
+  <artifactId>init-mutating</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  
+  <properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<plugin.id>init-mutating</plugin.id>
+		<plugin.name>The init-mutating plugin</plugin.name>
+		<plugin.class>com.gentics.mesh.plugin.InitMutatingPlugin</plugin.class>
+		<plugin.version>0.0.1</plugin.version>
+		<plugin.author>Serhii Plyhun</plugin.author>
+		<plugin.inception>2021-05-25</plugin.inception>
+		<plugin.description>Plugin, that mutates the Mesh data on initialization</plugin.description>
+		<mesh.version>1.6.5</mesh.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.gentics.mesh</groupId>
+				<artifactId>mesh-plugin-bom</artifactId>
+				<version>${mesh.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.gentics.mesh</groupId>
+			<artifactId>mesh-plugin-dep</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<verbose>false</verbose>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Plugin-Id>${plugin.id}</Plugin-Id>
+										<Plugin-Name>${plugin.name}</Plugin-Name>
+										<Plugin-Version>${plugin.version}</Plugin-Version>
+										<Plugin-Author>${plugin.author}</Plugin-Author>
+										<Plugin-Class>${plugin.class}</Plugin-Class>
+										<Plugin-Description>${plugin.description}</Plugin-Description>
+										<Plugin-License>Apache License 2.0</Plugin-License>
+										<Plugin-Inception>${plugin.inception}</Plugin-Inception>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-install-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+		</plugins>
+	</build>
+</project>

--- a/core/src/test/plugins/init-mutating/src/main/java/com/gentics/mesh/plugin/InitMutatingPlugin.java
+++ b/core/src/test/plugins/init-mutating/src/main/java/com/gentics/mesh/plugin/InitMutatingPlugin.java
@@ -1,0 +1,48 @@
+package com.gentics.mesh.plugin;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.pf4j.PluginWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gentics.mesh.RestAPIVersion;
+import com.gentics.mesh.core.rest.project.ProjectCreateRequest;
+import com.gentics.mesh.plugin.env.PluginEnvironment;
+import com.gentics.mesh.rest.client.MeshRestClient;
+
+import io.reactivex.Completable;
+
+public class InitMutatingPlugin extends AbstractPlugin implements RestPlugin {
+
+	private static final Logger log = LoggerFactory.getLogger(InitMutatingPlugin.class);
+	
+	public InitMutatingPlugin(PluginWrapper wrapper, PluginEnvironment env) {
+		super(wrapper, env);
+	}
+
+	@Override
+	public Completable initialize() {
+		return Completable.defer(() -> {
+			
+			MeshRestClient client = this.environment().createAdminClient(RestAPIVersion.V2);
+			
+			log.info("Mutate 'em all!");
+			
+			return Completable.merge(
+					IntStream.range(0, 100).mapToObj(
+							i -> {
+								String projectName = "prj" + System.currentTimeMillis();
+								log.info("Mutating " + projectName);
+								try {
+									Thread.sleep(2);
+								} catch (InterruptedException e) {
+									return Completable.error(e);
+								}
+								return client.createProject(new ProjectCreateRequest().setName(projectName).setSchemaRef("folder")).getResponse().toCompletable();
+							}
+						).collect(Collectors.toList()));
+		});
+	}
+}

--- a/core/src/test/plugins/pom.xml
+++ b/core/src/test/plugins/pom.xml
@@ -18,6 +18,8 @@
 		<module>client</module>
 		<module>non-mesh</module>
 		<module>failing</module>
+		<module>failing-first</module>
+		<module>init-mutating</module>
 		<module>classloader</module>
 		<module>common</module>
 		<module>extension-provider</module>

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
@@ -492,6 +492,7 @@ public class OrientDBClusterManager implements ClusterManager {
 	 * @see TopologyEventBridge#isClusterTopologyLocked()
 	 * @return
 	 */
+	@Override
 	public boolean isClusterTopologyLocked() {
 		if (topologyEventBridge == null) {
 			return false;

--- a/distributed/src/test/java/com/gentics/mesh/distributed/AbstractClusterTest.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/AbstractClusterTest.java
@@ -100,5 +100,9 @@ public abstract class AbstractClusterTest {
 		}
 		return server;
 	}
-
+	
+	protected void login(MeshContainer server) {
+		server.client().setLogin("admin", "admin");
+		server.client().login().blockingGet();
+	}
 }

--- a/distributed/src/test/java/com/gentics/mesh/distributed/ClusterTorturePluginHoldsStartup.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/ClusterTorturePluginHoldsStartup.java
@@ -1,0 +1,25 @@
+package com.gentics.mesh.distributed;
+
+import static com.gentics.mesh.util.TokenUtil.randomToken;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.gentics.mesh.test.docker.MeshContainer;
+
+public class ClusterTorturePluginHoldsStartup extends AbstractClusterTortureTest {
+
+	private static final int STARTUP_TIMEOUT = 60 * 6;
+	
+	@Test
+	public void testSecondaryBackupCreated() throws Exception {
+		torture((a, b, c) -> {
+			MeshContainer serverB2 = prepareSlave("dockerCluster" + clusterPostFix, "nodeB2", randomToken(), true, true, 1)
+					.withPlugin(new File("../core/target/test-plugins/failing-first/target/failing-first-plugin-0.0.1-SNAPSHOT.jar"), "failing-first.jar");
+			serverB2.start();
+			serverB2.awaitStartup(STARTUP_TIMEOUT);
+			login(serverB2);
+		});
+	}	
+}

--- a/distributed/src/test/java/com/gentics/mesh/distributed/PluginClusterTest.java
+++ b/distributed/src/test/java/com/gentics/mesh/distributed/PluginClusterTest.java
@@ -122,10 +122,4 @@ public class PluginClusterTest extends AbstractClusterTest {
 
 		latch.await(timeoutInMilliseconds, TimeUnit.MILLISECONDS);
 	}
-
-	private void login(MeshContainer server) {
-		server.client().setLogin("admin", "admin");
-		server.client().login().blockingGet();
-	}
-
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/plugin/PluginStatus.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/plugin/PluginStatus.java
@@ -35,6 +35,11 @@ public enum PluginStatus {
 	/**
 	 * The plugin is in a failed state.
 	 */
-	FAILED;
+	FAILED,
+
+	/**
+	 * The plugin is in a failed state, but will be retried when the storages become available again.
+	 */
+	FAILED_RETRY;
 
 }


### PR DESCRIPTION
## Abstract

Plugins are automatically initialized when a Mesh instance starts. If the initialization fails, because the cluster topology changes (which will cause DB storages to become unavailable), the plugins will now be marked as FAILED_RETRY (instead of FAILED), and plugin initialization of those plugins will be retried as soon as the DB storages are available again.
Additionally, plugins in state FAILED_RETRY will not cause the health check of the instance to fail.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
