### PR TITLE
Implement topology change readonly behaviour

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.12]]
+== 1.6.12 (TBD)
+
+icon:plus[] Clustering: The `cluster.topologyChangeReadOnly` setting and `MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY` environment setting have been added. By enabling this flag, Mesh will be automatically set in `readOnly` mode,
+when the cluster topology changes, which will let reading requests pass and writing requests fail (immediately), instead of blocking all requests, which happens when the `cluster.topologyLockTimeout` is set to a positive value.
+
 [[v1.6.11]]
 == 1.6.11 (12.05.2021)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
@@ -200,6 +200,12 @@ public class ClusterOptions implements Option {
 		if (isEnabled()) {
 			Objects.requireNonNull(getClusterName(), "No cluster.clusterName was specified within mesh options.");
 			Objects.requireNonNull(meshOptions.getNodeName(), "No nodeName was specified within mesh options.");
+
+			if (getTopologyLockTimeout() > 0 && isTopologyChangeReadOnly()) {
+				log.warn(
+						"cluster.topologyLockTimeout has been set to {} and cluster.topologyChangeReadOnly to {}. It is recommended to either activate the lock or the read-only mode, but not both.",
+						getTopologyLockTimeout(), isTopologyChangeReadOnly());
+			}
 		}
 	}
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
@@ -23,6 +23,7 @@ public class ClusterOptions implements Option {
 	public static final int DEFAULT_VERTX_PORT = 4848;
 	public static final long DEFAULT_TOPOLOGY_LOCK_TIMEOUT = 0;
 	public static final long DEFAULT_TOPOLOGY_LOCK_DELAY = 20_000; // 20 seconds
+	public static final boolean DEFAULT_TOPOLOGY_CHANGE_READONLY = DISABLED;
 
 	public static final String MESH_CLUSTER_NETWORK_HOST_ENV = "MESH_CLUSTER_NETWORK_HOST";
 	public static final String MESH_CLUSTER_ENABLED_ENV = "MESH_CLUSTER_ENABLED";
@@ -33,6 +34,7 @@ public class ClusterOptions implements Option {
 	public static final String MESH_CLUSTER_TOPOLOGY_LOCK_TIMEOUT_ENV = "MESH_CLUSTER_TOPOLOGY_LOCK_TIMEOUT";
 	public static final String MESH_CLUSTER_TOPOLOGY_LOCK_DELAY_ENV = "MESH_CLUSTER_TOPOLOGY_LOCK_DELAY";
 	public static final String MESH_CLUSTER_COORDINATOR_TOPOLOGY_ENV = "MESH_CLUSTER_COORDINATOR_TOPOLOGY";
+	public static final String MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY_ENV = "MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("IP or host which is used to announce and reach the instance in the cluster. Gentics Mesh will try to determine the IP automatically but you may use this setting to override this automatic IP handling.")
@@ -84,6 +86,11 @@ public class ClusterOptions implements Option {
 	@JsonPropertyDescription("The coordinator topology setting controls whether the coordinator should manage the cluster topology. By default no cluster topology management will be done.")
 	@EnvironmentVariable(name = MESH_CLUSTER_COORDINATOR_TOPOLOGY_ENV, description = "Override the cluster coordinator topology management mode.")
 	private CoordinationTopology coordinatorTopology = CoordinationTopology.UNMANAGED;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag to enable or disable setting the cluster in readonly mode, when the topology changes.")
+	@EnvironmentVariable(name = MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY_ENV, description = "Override the topology change readonly flag.")
+	private boolean topologyChangeReadOnly = DEFAULT_TOPOLOGY_CHANGE_READONLY;
 
 	public boolean isEnabled() {
 		return enabled;
@@ -163,6 +170,24 @@ public class ClusterOptions implements Option {
 
 	public ClusterOptions setTopologyLockDelay(long topologyLockDelay) {
 		this.topologyLockDelay = topologyLockDelay;
+		return this;
+	}
+
+	/**
+	 * Set the topology change readonly flag
+	 * @return flag value
+	 */
+	public boolean isTopologyChangeReadOnly() {
+		return topologyChangeReadOnly;
+	}
+
+	/**
+	 * Get the topology change readonly flag
+	 * @param topologyChangeReadOnly flag
+	 * @return fluent API
+	 */
+	public ClusterOptions setTopologyChangeReadOnly(boolean topologyChangeReadOnly) {
+		this.topologyChangeReadOnly = topologyChangeReadOnly;
 		return this;
 	}
 

--- a/common/src/main/java/com/gentics/mesh/core/verticle/handler/WriteLockImpl.java
+++ b/common/src/main/java/com/gentics/mesh/core/verticle/handler/WriteLockImpl.java
@@ -1,5 +1,10 @@
 package com.gentics.mesh.core.verticle.handler;
 
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static com.gentics.mesh.metric.SimpleMetric.WRITE_LOCK_TIMEOUT_COUNT;
+import static com.gentics.mesh.metric.SimpleMetric.WRITE_LOCK_WAITING_TIME;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -8,11 +13,10 @@ import javax.inject.Singleton;
 
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.graphdb.cluster.ClusterManager;
 import com.gentics.mesh.metric.MetricsService;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
-import static com.gentics.mesh.metric.SimpleMetric.WRITE_LOCK_TIMEOUT_COUNT;
-import static com.gentics.mesh.metric.SimpleMetric.WRITE_LOCK_WAITING_TIME;
 
 import dagger.Lazy;
 import io.micrometer.core.instrument.Counter;
@@ -28,14 +32,16 @@ public class WriteLockImpl implements WriteLock {
 	private final boolean isClustered;
 	private final Timer writeLockTimer;
 	private final Counter timeoutCount;
+	private final ClusterManager clusterManager;
 
 	@Inject
-	public WriteLockImpl(MeshOptions options, Lazy<HazelcastInstance> hazelcast, MetricsService metricsService) {
+	public WriteLockImpl(MeshOptions options, Lazy<HazelcastInstance> hazelcast, MetricsService metricsService, ClusterManager clusterManager) {
 		this.options = options;
 		this.hazelcast = hazelcast;
 		this.isClustered = options.getClusterOptions().isEnabled();
 		this.writeLockTimer = metricsService.timer(WRITE_LOCK_WAITING_TIME);
 		this.timeoutCount = metricsService.counter(WRITE_LOCK_TIMEOUT_COUNT);
+		this.clusterManager = clusterManager;
 	}
 
 	@Override
@@ -57,6 +63,12 @@ public class WriteLockImpl implements WriteLock {
 		if (ac != null && ac.isSkipWriteLock()) {
 			return this;
 		} else {
+			// throw an error, if the cluster topology is currently locked and the option "topology change readonly" is activated
+			if (options.getClusterOptions().isTopologyChangeReadOnly() && clusterManager != null
+					&& clusterManager.isClusterTopologyLocked()) {
+				throw error(SERVICE_UNAVAILABLE, "error_cluster_topology_readonly").setLogStackTrace(false);
+			}
+
 			boolean syncWrites = options.getStorageOptions().isSynchronizeWrites();
 			if (syncWrites) {
 				Timer.Sample timer = Timer.start();

--- a/common/src/main/java/com/gentics/mesh/distributed/DistributionUtils.java
+++ b/common/src/main/java/com/gentics/mesh/distributed/DistributionUtils.java
@@ -9,6 +9,9 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+/**
+ * Utility methods for distributed computing
+ */
 public class DistributionUtils {
 	private static final Logger log = LoggerFactory.getLogger(DistributionUtils.class);
 
@@ -41,6 +44,11 @@ public class DistributionUtils {
 		}
 	}
 
+	/**
+	 * Check whether the given path matches one of the known read-only paths.
+	 * @param path path
+	 * @return true if the request to the given path is considered read-only
+	 */
 	public static boolean isReadOnly(String path) {
 		for (Pattern pattern : readOnlyPathPatternSet) {
 			Matcher m = pattern.matcher(path);
@@ -51,6 +59,10 @@ public class DistributionUtils {
 		return false;
 	}
 
+	/**
+	 * Create the set of read-only patterns
+	 * @return pattern set
+	 */
 	private static Set<Pattern> createReadOnlyPatternSet() {
 		Set<Pattern> patterns = new HashSet<>();
 		patterns.add(Pattern.compile("/api/v[0-9]+/auth/login/?"));

--- a/common/src/main/java/com/gentics/mesh/distributed/DistributionUtils.java
+++ b/common/src/main/java/com/gentics/mesh/distributed/DistributionUtils.java
@@ -1,0 +1,67 @@
+package com.gentics.mesh.distributed;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class DistributionUtils {
+	private static final Logger log = LoggerFactory.getLogger(DistributionUtils.class);
+
+	private static final Set<Pattern> readOnlyPathPatternSet = createReadOnlyPatternSet();
+
+	/**
+	 * Check whether the request is a read request.
+	 * 
+	 * @param method
+	 * @param path
+	 * @return
+	 */
+	public static boolean isReadRequest(HttpMethod method, String path) {
+		switch (method) {
+		case CONNECT:
+		case OPTIONS:
+		case GET:
+			return true;
+		case DELETE:
+		case PATCH:
+		case PUT:
+			return false;
+		case POST:
+			// Lets check whether the request is actually a read request.
+			// In this case we don't need to delegate it.
+			return isReadOnly(path);
+		default:
+			log.debug("Unhandled methd {" + method + "} in path {" + path + "}");
+			return false;
+		}
+	}
+
+	public static boolean isReadOnly(String path) {
+		for (Pattern pattern : readOnlyPathPatternSet) {
+			Matcher m = pattern.matcher(path);
+			if (m.matches()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static Set<Pattern> createReadOnlyPatternSet() {
+		Set<Pattern> patterns = new HashSet<>();
+		patterns.add(Pattern.compile("/api/v[0-9]+/auth/login/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/.*/graphql/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/search/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/rawSearch/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/.*/search/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/.*/rawSearch/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/utilities/linkResolver/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/utilities/validateSchema/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/utilities/validateMicroschema/?"));
+		return patterns;
+	}
+}

--- a/common/src/main/java/com/gentics/mesh/distributed/TopologyChangeReadonlyHandler.java
+++ b/common/src/main/java/com/gentics/mesh/distributed/TopologyChangeReadonlyHandler.java
@@ -1,0 +1,11 @@
+package com.gentics.mesh.distributed;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * The TopologyChangeReadonlyHandler will let all mutation requests fail immediately, while the cluster topology is changing
+ */
+public interface TopologyChangeReadonlyHandler extends Handler<RoutingContext> {
+
+}

--- a/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
+++ b/common/src/main/java/com/gentics/mesh/graphdb/cluster/ClusterManager.java
@@ -54,4 +54,10 @@ public interface ClusterManager {
 	 */
 	Completable waitUntilWriteQuorumReached();
 
+	/**
+	 * Checks if the cluster storage is locked cluster-wide.
+	 * 
+	 * @return
+	 */
+	boolean isClusterTopologyLocked();
 }

--- a/common/src/main/java/com/gentics/mesh/router/APIRouter.java
+++ b/common/src/main/java/com/gentics/mesh/router/APIRouter.java
@@ -55,6 +55,12 @@ public class APIRouter {
 	private void initHandlers(RouterStorage storage) {
 		// Add the coordinator delegator handler
 		ClusterOptions clusterOptions = options.getClusterOptions();
+
+		// add topology readonly handler
+		if (clusterOptions.isEnabled() && clusterOptions.isTopologyChangeReadOnly()) {
+			router.route().handler(root.getStorage().getTopologyChangeReadonlyHandler());
+		}
+
 		if (clusterOptions.isEnabled() && clusterOptions.getCoordinatorMode() != CoordinatorMode.DISABLED) {
 			router.route().handler(root.getStorage().getDelegator());
 		}

--- a/common/src/main/java/com/gentics/mesh/router/RouterStorage.java
+++ b/common/src/main/java/com/gentics/mesh/router/RouterStorage.java
@@ -176,6 +176,10 @@ public class RouterStorage {
 		return delegator;
 	}
 
+	/**
+	 * Get the topology change read-only handler
+	 * @return handler
+	 */
 	public TopologyChangeReadonlyHandler getTopologyChangeReadonlyHandler() {
 		return topologyChangeReadonlyHandler;
 	}

--- a/common/src/main/java/com/gentics/mesh/router/RouterStorage.java
+++ b/common/src/main/java/com/gentics/mesh/router/RouterStorage.java
@@ -12,6 +12,7 @@ import com.gentics.mesh.auth.MeshAuthChain;
 import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.core.data.Project;
 import com.gentics.mesh.distributed.RequestDelegator;
+import com.gentics.mesh.distributed.TopologyChangeReadonlyHandler;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.handler.VersionHandler;
@@ -69,12 +70,14 @@ public class RouterStorage {
 
 	private final RequestDelegator delegator;
 
+	private final TopologyChangeReadonlyHandler topologyChangeReadonlyHandler;
+
 	@Inject
 	public RouterStorage(Vertx vertx, MeshOptions options, MeshAuthChain authChain, CorsHandler corsHandler, BodyHandlerImpl bodyHandler,
 		Lazy<BootstrapInitializer> boot,
 		Lazy<Database> db, VersionHandler versionHandler,
 		RouterStorageRegistry routerStorageRegistry,
-		RequestDelegator delegator) {
+		RequestDelegator delegator, TopologyChangeReadonlyHandler topologyChangeReadonlyHandler) {
 		this.vertx = vertx;
 		this.options = options;
 		this.boot = boot;
@@ -85,6 +88,7 @@ public class RouterStorage {
 		this.versionHandler = versionHandler;
 		this.routerStorageRegistry = routerStorageRegistry;
 		this.delegator = delegator;
+		this.topologyChangeReadonlyHandler = topologyChangeReadonlyHandler;
 
 		// Initialize the router chain. The root router will create additional routers which will be mounted.
 		rootRouter = new RootRouter(vertx, this, options);
@@ -172,4 +176,7 @@ public class RouterStorage {
 		return delegator;
 	}
 
+	public TopologyChangeReadonlyHandler getTopologyChangeReadonlyHandler() {
+		return topologyChangeReadonlyHandler;
+	}
 }

--- a/common/src/main/java/com/gentics/mesh/router/route/FailureHandler.java
+++ b/common/src/main/java/com/gentics/mesh/router/route/FailureHandler.java
@@ -140,7 +140,15 @@ public class FailureHandler implements Handler<RoutingContext> {
 			default:
 				log.error("Error for request in path: " + toPath(rc));
 				if (failure != null) {
-					log.error("Error:", failure);
+					boolean logStackTrace = true;
+					if (failure instanceof AbstractRestException) {
+						logStackTrace = ((AbstractRestException) failure).isLogStackTrace();
+					}
+					if (logStackTrace) {
+						log.error("Error:", failure);
+					} else {
+						log.error("Error: {}", failure.toString());
+					}
 				}
 			}
 

--- a/common/src/main/java/com/gentics/mesh/router/route/FailureHandler.java
+++ b/common/src/main/java/com/gentics/mesh/router/route/FailureHandler.java
@@ -142,6 +142,7 @@ public class FailureHandler implements Handler<RoutingContext> {
 				if (failure != null) {
 					boolean logStackTrace = true;
 					if (failure instanceof AbstractRestException) {
+						// AbstractRestExceptions may suppress logging of the stack trace
 						logStackTrace = ((AbstractRestException) failure).isLogStackTrace();
 					}
 					if (logStackTrace) {

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -42,6 +42,7 @@ error_field_container_without_node=Für den angefragten Inhalt konnte kein Node 
 error_readonly_mode=Die Anfrage konnte nicht verarbeitet werden, da der Read-Only-Modus aktiv ist.
 error_readonly_mode_oauth=Die Anfrage konnte nicht verarbeitet werden, da die notwendige OAuth-Benutzer-Synchronisation nicht im Read-Only-Modus ausgeführt werden kann.
 error_cluster_coordination_master_not_found=Der Master Server konnte nicht bestimmt werden.
+error_cluster_topology_readonly=Die Anfrage konnte nicht verarbeitet werden, da Aufgrund einer Änderung in der Cluster-Topologie vorübergehend der Read-Only-Modus gesetzt ist.
 
 status_ready=Mesh ist bereit.
 status_starting=Mesh startet.

--- a/common/src/main/resources/i18n/translations_en.properties
+++ b/common/src/main/resources/i18n/translations_en.properties
@@ -42,6 +42,7 @@ error_field_container_without_node=No Node could be found for the requested cont
 error_readonly_mode=The request could not be processed because the read only mode is active.
 error_readonly_mode_oauth=The request could not be processed because the necessary OAuth user sync cannot be performed in read only mode.
 error_cluster_coordination_master_not_found=The coordination master could not be found.
+error_cluster_topology_readonly=The request could not be processed because read-only mode is temporarily set due to a change in the cluster topology.
 
 status_ready=Mesh is ready.
 status_starting=Mesh is starting up.

--- a/common/src/main/resources/i18n/translations_zh.properties
+++ b/common/src/main/resources/i18n/translations_zh.properties
@@ -39,6 +39,7 @@ error_date_format_invalid=无法解析提供的日期{0}。请以ISO8601格式�
 error_cluster_status_only_available_in_cluster_mode=仅在集群模式下运行时才能检索集群状态。
 error_field_container_without_node=找不到所请求内容的节点。
 error_readonly_mode=由于只读方式处于活动状态，因此无法处理该请求。
+error_cluster_topology_readonly=由于集群拓扑的更改而临时设置了只读模式，因此无法处理该请求。
 
 status_ready=Mesh准备就绪。
 status_starting=Mesh正在启动。

--- a/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
@@ -25,10 +25,14 @@ import com.gentics.mesh.core.data.service.WebRootServiceImpl;
 import com.gentics.mesh.core.verticle.handler.WriteLock;
 import com.gentics.mesh.core.verticle.handler.WriteLockImpl;
 import com.gentics.mesh.distributed.RequestDelegator;
+import com.gentics.mesh.distributed.TopologyChangeReadonlyHandler;
+import com.gentics.mesh.distributed.TopologyChangeReadonlyHandlerImpl;
 import com.gentics.mesh.distributed.coordinator.proxy.RequestDelegatorImpl;
 import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.event.impl.EventQueueBatchImpl;
 import com.gentics.mesh.graphdb.OrientDBDatabase;
+import com.gentics.mesh.graphdb.cluster.ClusterManager;
+import com.gentics.mesh.graphdb.cluster.OrientDBClusterManager;
 import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.handler.RangeRequestHandler;
 import com.gentics.mesh.handler.impl.RangeRequestHandlerImpl;
@@ -121,4 +125,10 @@ public abstract class BindModule {
 
 	@Binds
 	abstract BucketManager bindBucketManager(BucketManagerImpl e);
+
+	@Binds
+	abstract TopologyChangeReadonlyHandler bindTopologyChangeReadonlyHandler(TopologyChangeReadonlyHandlerImpl e);
+
+	@Binds
+	abstract ClusterManager bindClusterManager(OrientDBClusterManager e);
 }

--- a/core/src/test/java/com/gentics/mesh/distributed/TopologyChangeReadonlyTest.java
+++ b/core/src/test/java/com/gentics/mesh/distributed/TopologyChangeReadonlyTest.java
@@ -1,0 +1,132 @@
+package com.gentics.mesh.distributed;
+
+import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_DATABASE_CHANGE_STATUS;
+import static com.gentics.mesh.test.TestSize.PROJECT;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Test cases for the topology change readonly behavior
+ */
+@MeshTestSetting(testSize = PROJECT, startServer = true, inMemoryDB = false, clusterMode = true)
+public class TopologyChangeReadonlyTest extends AbstractMeshTest {
+	/**
+	 * Name of the project
+	 */
+	protected String projectName;
+
+	/**
+	 * UUID of the project's base node
+	 */
+	protected String projectBaseNodeUuid;
+
+	/**
+	 * Name of the base node's schema
+	 */
+	protected String schemaName;
+
+	/**
+	 * Read some data from the db
+	 */
+	@Before
+	public void setup() {
+		db().tx(() -> {
+			projectName = project().getName();
+			projectBaseNodeUuid = project().getBaseNode().getUuid();
+			schemaName = project().getBaseNode().getSchemaContainer().getName();
+		});
+	}
+
+	/**
+	 * Test that a change in the storage status (in this case to BACKUP) will cause writing requests to fail, while reading requests will still succeed.
+	 * @throws InterruptedException
+	 */
+	@Test
+	public void test() throws InterruptedException {
+		// enable the feature
+		options().getClusterOptions().setTopologyChangeReadOnly(true);
+		options().getClusterOptions().setTopologyLockDelay(1);
+
+		// current status of the topology lock
+		AtomicBoolean topoLocked = new AtomicBoolean(false);
+
+		// count down latches for topology lock changes
+		CountDownLatch lockLatch = new CountDownLatch(1);
+		CountDownLatch unlockLatch = new CountDownLatch(1);
+
+		// add event handler, which tracks the changes in topology lock
+		mesh().vertx().eventBus().consumer(CLUSTER_DATABASE_CHANGE_STATUS.address, (Message<JsonObject> handler) -> {
+			boolean locked = db().clusterManager().isClusterTopologyLocked();
+			boolean wasLocked = topoLocked.getAndSet(locked);
+			if (locked && !wasLocked) {
+				lockLatch.countDown();
+			} else if (!locked && wasLocked) {
+				unlockLatch.countDown();
+			}
+		});
+
+		// invoke the graphdb backup (asynchronously)
+		mesh().vertx().executeBlocking(bc -> {
+			try {
+				db().backupGraph(options().getStorageOptions().getBackupDirectory());
+				bc.complete();
+			} catch (IOException e) {
+				bc.fail(e);
+			}
+		}, rs -> {
+		});
+
+		// wait for the topology lock to be set
+		lockLatch.await(1, TimeUnit.MINUTES);
+
+		// reading nodes must succeed
+		read();
+		try {
+			// creating nodes must fail
+			create();
+			fail("Creating was expected to fail");
+		} catch (RuntimeException e) {
+		}
+
+		// wait for the topology lock to be cleared
+		unlockLatch.await(1, TimeUnit.MINUTES);
+
+		// reading nodes must succeed
+		read();
+		// creating nodes must succeed
+		create();
+	}
+
+	/**
+	 * Read a node (and wait for the response)
+	 */
+	protected void read() {
+		client().findNodeByUuid(projectName, projectBaseNodeUuid).blockingAwait();
+	}
+
+	/**
+	 * Create a node (and wait for the response)
+	 * @param client
+	 */
+	protected void create() {
+		NodeCreateRequest request = new NodeCreateRequest();
+		request.setParentNodeUuid(projectBaseNodeUuid);
+		request.setSchemaName(schemaName);
+		request.setLanguage("en");
+		client().createNode(projectName, request).blockingAwait();
+	}
+}

--- a/core/src/test/java/com/gentics/mesh/etc/RouterStorageTest.java
+++ b/core/src/test/java/com/gentics/mesh/etc/RouterStorageTest.java
@@ -30,7 +30,7 @@ public class RouterStorageTest {
 		RouterStorageRegistry routerStorageRegistry = mock(RouterStorageRegistry.class);
 		RouterStorage storage = new RouterStorage(Vertx.vertx(), new MeshOptions(), chain, null, null, null, () -> {
 			return Mockito.mock(Database.class);
-		}, null, routerStorageRegistry, null);
+		}, null, routerStorageRegistry, null, null);
 
 		RoutingContext rc = mock(RoutingContextImplBase.class);
 		Route currentRoute = mock(RouteImpl.class);

--- a/distributed-coordinator/src/test/java/com/gentics/mesh/distributed/coordinator/RequestDelegatorRegexTest.java
+++ b/distributed-coordinator/src/test/java/com/gentics/mesh/distributed/coordinator/RequestDelegatorRegexTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.gentics.mesh.distributed.DistributionUtils;
 import com.gentics.mesh.distributed.coordinator.proxy.RequestDelegatorImpl;
 
 public class RequestDelegatorRegexTest {
@@ -36,7 +37,7 @@ public class RequestDelegatorRegexTest {
 	}
 
 	private void assertReadOnly(String path) {
-		assertEquals("The path {" + path + "} is not read only.", true, RequestDelegatorImpl.isReadOnly(path));
+		assertEquals("The path {" + path + "} is not read only.", true, DistributionUtils.isReadOnly(path));
 	}
 
 }

--- a/distributed/src/main/java/com/gentics/mesh/distributed/TopologyChangeReadonlyHandlerImpl.java
+++ b/distributed/src/main/java/com/gentics/mesh/distributed/TopologyChangeReadonlyHandlerImpl.java
@@ -1,0 +1,37 @@
+package com.gentics.mesh.distributed;
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+
+import javax.inject.Inject;
+
+import com.gentics.mesh.graphdb.cluster.ClusterManager;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Implementation of {@link TopologyChangeReadonlyHandler} that will let mutating requests fail, if the cluster topology is changing
+ */
+public class TopologyChangeReadonlyHandlerImpl implements TopologyChangeReadonlyHandler {
+	private final ClusterManager clusterManager;
+
+	@Inject
+	public TopologyChangeReadonlyHandlerImpl(ClusterManager clusterManager) {
+		this.clusterManager = clusterManager;
+	}
+
+	@Override
+	public void handle(RoutingContext rc) {
+		HttpServerRequest request = rc.request();
+		String path = request.path();
+		HttpMethod method = request.method();
+
+		if (!DistributionUtils.isReadRequest(method, path) && clusterManager != null
+				&& clusterManager.isClusterTopologyLocked()) {
+			rc.fail(error(SERVICE_UNAVAILABLE, "error_cluster_topology_readonly").setLogStackTrace(false));
+		} else {
+			rc.next();
+		}
+	}
+}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/error/AbstractRestException.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/error/AbstractRestException.java
@@ -22,6 +22,8 @@ public abstract class AbstractRestException extends RuntimeException {
 	protected String translatedMessage;
 	protected Map<String, Object> properties = new HashMap<>();
 
+	protected boolean logStackTrace = true;
+
 	public AbstractRestException() {
 	}
 
@@ -186,4 +188,21 @@ public abstract class AbstractRestException extends RuntimeException {
 		this.properties.put(key, value);
 	}
 
+	/**
+	 * Check whether the stack trace shall be logged in the failure handler
+	 * @return true to log the stack trace
+	 */
+	public boolean isLogStackTrace() {
+		return logStackTrace;
+	}
+
+	/**
+	 * Set flag to log the stack trace
+	 * @param logStackTrace flag
+	 * @return fluent API
+	 */
+	public AbstractRestException setLogStackTrace(boolean logStackTrace) {
+		this.logStackTrace = logStackTrace;
+		return this;
+	}
 }


### PR DESCRIPTION
## Abstract

When using the topology lock, all requests will be blocked (at transaction commit) while e.g. a OrientDB sync is running to synchronize a new joining cluster node.
This leads to unavailability of Mesh during the sync (even for reading requests) and can further lead to OOM errors.

The new setting cluster.topologyChangeReadOnly is an alternative, which will let reading requests pass and will respond to writing requests with a 503 immediately.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
