### PR TITLE
Add configuration option for cluster join timeout

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,6 +26,9 @@ when the cluster topology changes, which will let reading requests pass and writ
 icon:check[] Plugins: If plugin initialization fails due to topology changes (e.g. the OrientDB needs to be synchronized from another node), the plugin will be set to
 status FAILED_RETRY and initialization will be retried as soon as OrientDB becomes available again.
 
+icon:plus[] Clustering: The timeout for waiting to join the cluster (which includes the time for synchronizing the graphdb storage), which was hardcoded to 500_000 milliseconds, can now be configured with the setting
+`storage.clusterJoinTimeout` or the environment variable `MESH_GRAPH_CLUSTER_JOIN_TIMEOUT`.
+
 [[v1.6.11]]
 == 1.6.11 (12.05.2021)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -18,7 +18,7 @@ The LTS changelog lists releases which are only accessible via a commercial subs
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
 [[v1.6.12]]
-== 1.6.12 (TBD)
+== 1.6.12 (02.06.2021)
 
 icon:plus[] Clustering: The `cluster.topologyChangeReadOnly` setting and `MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY` environment setting have been added. By enabling this flag, Mesh will be automatically set in `readOnly` mode,
 when the cluster topology changes, which will let reading requests pass and writing requests fail (immediately), instead of blocking all requests, which happens when the `cluster.topologyLockTimeout` is set to a positive value.
@@ -135,6 +135,17 @@ icon:check[] Clustering: The webroot handler no longer uses the cluster-wide wri
 
 icon:check[] Logging: Failing readiness checks are now logged using the `WARN` level.
 
+[[v1.5.12]]
+== 1.5.12 (02.06.2021)
+
+icon:plus[] Clustering: The `cluster.topologyChangeReadOnly` setting and `MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY` environment setting have been added. By enabling this flag, Mesh will be automatically set in `readOnly` mode,
+when the cluster topology changes, which will let reading requests pass and writing requests fail (immediately), instead of blocking all requests, which happens when the `cluster.topologyLockTimeout` is set to a positive value.
+
+icon:check[] Plugins: If plugin initialization fails due to topology changes (e.g. the OrientDB needs to be synchronized from another node), the plugin will be set to
+status FAILED_RETRY and initialization will be retried as soon as OrientDB becomes available again.
+
+icon:plus[] Clustering: The timeout for waiting to join the cluster (which includes the time for synchronizing the graphdb storage), which was hardcoded to 500_000 milliseconds, can now be configured with the setting `storage.clusterJoinTimeout` or the environment variable `MESH_GRAPH_CLUSTER_JOIN_TIMEOUT`.
+
 [[v1.5.11]]
 == 1.5.11 (12.05.2021)
 
@@ -216,6 +227,17 @@ icon:plus[] Monitoring: The liveness probe will now check for plugin status. Fai
 icon:check[] Clustering: The webroot handler no longer uses the cluster-wide write lock.
 
 icon:check[] Logging: Failing readiness checks are now logged using the `WARN` level.
+
+[[v1.4.22]]
+== 1.4.22 (02.06.2021)
+
+icon:plus[] Clustering: The `cluster.topologyChangeReadOnly` setting and `MESH_CLUSTER_TOPOLOGY_CHANGE_READONLY` environment setting have been added. By enabling this flag, Mesh will be automatically set in `readOnly` mode,
+when the cluster topology changes, which will let reading requests pass and writing requests fail (immediately), instead of blocking all requests, which happens when the `cluster.topologyLockTimeout` is set to a positive value.
+
+icon:check[] Plugins: If plugin initialization fails due to topology changes (e.g. the OrientDB needs to be synchronized from another node), the plugin will be set to
+status FAILED_RETRY and initialization will be retried as soon as OrientDB becomes available again.
+
+icon:plus[] Clustering: The timeout for waiting to join the cluster (which includes the time for synchronizing the graphdb storage), which was hardcoded to 500_000 milliseconds, can now be configured with the setting `storage.clusterJoinTimeout` or the environment variable `MESH_GRAPH_CLUSTER_JOIN_TIMEOUT`.
 
 [[v1.4.21]]
 == 1.4.21 (12.05.2021)

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,8 +26,7 @@ when the cluster topology changes, which will let reading requests pass and writ
 icon:check[] Plugins: If plugin initialization fails due to topology changes (e.g. the OrientDB needs to be synchronized from another node), the plugin will be set to
 status FAILED_RETRY and initialization will be retried as soon as OrientDB becomes available again.
 
-icon:plus[] Clustering: The timeout for waiting to join the cluster (which includes the time for synchronizing the graphdb storage), which was hardcoded to 500_000 milliseconds, can now be configured with the setting
-`storage.clusterJoinTimeout` or the environment variable `MESH_GRAPH_CLUSTER_JOIN_TIMEOUT`.
+icon:plus[] Clustering: The timeout for waiting to join the cluster (which includes the time for synchronizing the graphdb storage), which was hardcoded to 500_000 milliseconds, can now be configured with the setting `storage.clusterJoinTimeout` or the environment variable `MESH_GRAPH_CLUSTER_JOIN_TIMEOUT`.
 
 [[v1.6.11]]
 == 1.6.11 (12.05.2021)

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphStorageOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphStorageOptions.java
@@ -25,6 +25,7 @@ public class GraphStorageOptions implements Option {
 	public static final int DEFAULT_TX_RETRY_DELAY = 10;
 	public static final int DEFAULT_TX_RETRY_LIMIT = 10;
 	public static final long DEFAULT_TX_COMMIT_TIMEOUT = 0;
+	public static final int DEFAULT_CLUSTER_JOIN_TIMEOUT = 500_000;
 
 	public static final String MESH_GRAPH_DB_DIRECTORY_ENV = "MESH_GRAPH_DB_DIRECTORY";
 	public static final String MESH_GRAPH_BACKUP_DIRECTORY_ENV = "MESH_GRAPH_BACKUP_DIRECTORY";
@@ -35,6 +36,7 @@ public class GraphStorageOptions implements Option {
 	public static final String MESH_GRAPH_TX_RETRY_DELAY_ENV = "MESH_GRAPH_TX_RETRY_DELAY";
 	public static final String MESH_GRAPH_TX_RETRY_LIMIT_ENV = "MESH_GRAPH_TX_RETRY_LIMIT";
 	public static final String MESH_GRAPH_TX_COMMIT_TIMEOUT_ENV = "MESH_GRAPH_TX_COMMIT_TIMEOUT";
+	public static final String MESH_GRAPH_CLUSTER_JOIN_TIMEOUT_ENV = "MESH_GRAPH_CLUSTER_JOIN_TIMEOUT";
 
 	@JsonProperty(required = true)
 	@JsonPropertyDescription("Path to the graph database data directory.")
@@ -87,6 +89,11 @@ public class GraphStorageOptions implements Option {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Additional set of graph database parameters.")
 	private Map<String, String> parameters = new HashMap<>();
+
+	@JsonProperty(defaultValue = DEFAULT_CLUSTER_JOIN_TIMEOUT + " ms")
+	@JsonPropertyDescription("The timeout for joining the graphdb cluster in milliseconds. This also includes the time it takes to synchronize the graphdb over the network.")
+	@EnvironmentVariable(name = MESH_GRAPH_CLUSTER_JOIN_TIMEOUT_ENV, description = "Override the graphdb cluster join timeout. Default: " + DEFAULT_CLUSTER_JOIN_TIMEOUT + " ms")
+	private int clusterJoinTimeout = DEFAULT_CLUSTER_JOIN_TIMEOUT;
 
 	public String getDirectory() {
 		return directory;
@@ -188,6 +195,24 @@ public class GraphStorageOptions implements Option {
 
 	public GraphStorageOptions setTxCommitTimeout(long txCommitTimeout) {
 		this.txCommitTimeout = txCommitTimeout;
+		return this;
+	}
+
+	/**
+	 * Get the cluster join timeout in ms
+	 * @return cluster join timeout
+	 */
+	public int getClusterJoinTimeout() {
+		return clusterJoinTimeout;
+	}
+
+	/**
+	 * Set the cluster join timeout in ms
+	 * @param clusterJoinTimeout timeout in ms
+	 * @return fluent API
+	 */
+	public GraphStorageOptions setClusterJoinTimeout(int clusterJoinTimeout) {
+		this.clusterJoinTimeout = clusterJoinTimeout;
 		return this;
 	}
 

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManager.java
@@ -1,7 +1,7 @@
 package com.gentics.mesh.graphdb.cluster;
 
 import static com.gentics.mesh.MeshEnv.CONFIG_FOLDERNAME;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.File;
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 import javax.inject.Inject;
@@ -439,10 +440,10 @@ public class OrientDBClusterManager implements ClusterManager {
 	 */
 	private void joinCluster() throws InterruptedException {
 		// Wait until another node joined the cluster
-		int timeout = 500;
-		log.info("Waiting {" + timeout + "} seconds for other nodes in the cluster.");
-		if (!topologyEventBridge.waitForMainGraphDB(timeout, SECONDS)) {
-			throw new RuntimeException("Waiting for cluster database source timed out after {" + timeout + "} seconds.");
+		int timeout = options.getStorageOptions().getClusterJoinTimeout();
+		log.info("Waiting {" + timeout + "} milliseconds for other nodes in the cluster.");
+		if (!topologyEventBridge.waitForMainGraphDB(timeout, MILLISECONDS)) {
+			throw new RuntimeException("Waiting for cluster database source timed out after {" + timeout + "} milliseconds.");
 		}
 	}
 


### PR DESCRIPTION
## Abstract

Timeout for joining the cluster was hardcoded to 500 seconds and can now be configured.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
