### PR TITLE
SUP-11538/fix for the update issue in the S3 field

### DIFF
--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryUploadHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryUploadHandlerImpl.java
@@ -130,7 +130,10 @@ public class S3BinaryUploadHandlerImpl extends AbstractHandler implements S3Bina
 			utils.eventAction(batch -> {
 
 				// We need to check whether someone else has stored the s3 binary in the meanwhile
-				S3HibBinary s3HibBinary = s3binaries.create(s3binaryUuid, s3ObjectKey, fileName).runInExistingTx(tx);
+				S3HibBinary s3HibBinary = s3binaries.findByS3ObjectKey(s3ObjectKey).runInExistingTx(tx);
+				if (s3HibBinary == null) {
+					s3HibBinary = s3binaries.create(s3binaryUuid, s3ObjectKey, fileName).runInExistingTx(tx);
+				}
 				HibLanguage language = tx.languageDao().findByLanguageTag(languageTag);
 				if (language == null) {
 					throw error(NOT_FOUND, "error_language_not_found", languageTag);


### PR DESCRIPTION
## Abstract
This is a bugfix for this bug: [c.g.m.g.OrientDBDatabase] - com.orientechnologies.orient.core.storage.ORecordDuplicatedException: Cannot index record #319:0: found duplicated key '39a8e51a10e24f36a288301162194040/file' in index 'S3BinaryImpl' previously assigned to the record #318:0
https://jira.gentics.com/browse/SUP-11538#
