### PR TITLE
Hazelcast-Kubernetes -> v1.5.6

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.4.23]]
+== 1.4.23 (21.06.2021)
+
+icon:check[] Core: The included Hazelcast-Kubernetes library has been updated to version `1.5.6`, containing a DNS resolving fix.
+
 [[v1.4.22]]
 == 1.4.22 (02.06.2021)
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -194,7 +194,7 @@
 			<dependency>
 				<groupId>com.hazelcast</groupId>
 				<artifactId>hazelcast-kubernetes</artifactId>
-				<version>1.2.2</version>
+				<version>1.5.6</version>
 			</dependency>
 
 			<!-- Test dependencies -->

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,3 @@
 /elasticsearch
 /data*
+/bin/


### PR DESCRIPTION
## Abstract

The [update v1.5.6](https://github.com/hazelcast/hazelcast-kubernetes/releases/tag/v1.5.6) of Hazelcast-Kubernetes librtary contains an important fix for newer Hazelcast versions regarding DNS resolving within some cluster nodes.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
