### PR TITLE
The field restrictions cannot be unset

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.16]]
+== 1.6.16 (TBD)
+
+icon:check[] Core: A bug preventing the string schema field restrictions from being cleared, has been fixed.
+
 [[v1.6.15]]
 == 1.6.15 (21.06.2021)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateFieldChangeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateFieldChangeImpl.java
@@ -46,6 +46,9 @@ public class UpdateFieldChangeImpl extends AbstractSchemaFieldChange implements 
 
 	@Override
 	public void setRestProperty(String key, Object value) {
+		// What a restriction removal request comes from the REST API,
+		// it gives null instead of an empty array, so the request 
+		// gets eventually lost. In this case we give the empty array back.
 		if (SchemaChangeModel.ALLOW_KEY.equals(key) && value == null) {
 			value = new String[0];
 		}

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateFieldChangeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateFieldChangeImpl.java
@@ -45,6 +45,14 @@ public class UpdateFieldChangeImpl extends AbstractSchemaFieldChange implements 
 	}
 
 	@Override
+	public void setRestProperty(String key, Object value) {
+		if (SchemaChangeModel.ALLOW_KEY.equals(key) && value == null) {
+			value = new String[0];
+		}
+		super.setRestProperty(key, value);
+	}
+
+	@Override
 	public FieldSchemaContainer apply(FieldSchemaContainer container) {
 		FieldSchema fieldSchema = container.getField(getFieldName());
 

--- a/core/src/test/java/com/gentics/mesh/core/field/string/StringFieldEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/string/StringFieldEndpointTest.java
@@ -207,6 +207,26 @@ public class StringFieldEndpointTest extends AbstractFieldEndpointTest {
 				"node_error_invalid_string_field_value", "restrictedstringField", "invalid");
 		}
 	}
+	
+	@Test
+	public void testValueRemoveValueRestrictions() {
+		try (Tx tx = tx()) {
+			SchemaModel schema = schemaContainer("folder").getLatestVersion().getSchema();
+			
+			// unrestrict string field
+			StringFieldSchema restrictedStringFieldSchema = schema.getField("restrictedstringField", StringFieldSchema.class);
+			restrictedStringFieldSchema.setAllowedValues();
+			schema.addField(restrictedStringFieldSchema);
+
+			schemaContainer("folder").getLatestVersion().setSchema(schema);
+			tx.success();
+		}		
+		try (Tx tx = tx()) {
+			NodeResponse response = updateNode("restrictedstringField", new StringFieldImpl().setString("million"));
+			StringFieldImpl field = response.getFields().getStringField("restrictedstringField");
+			assertEquals("million", field.getString());
+		}
+	}
 
 	@Override
 	public NodeResponse createNodeWithField() {

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
@@ -472,8 +472,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 		
 		// 3. Unrestrict field
 		SchemaChangesListModel listOfChanges2 = new SchemaChangesListModel();
-		change = SchemaChangeModel.createUpdateSchemaChange();
-		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, null);
+		change = SchemaChangeModel.createFieldRestrictionChange("newField", null);
 		
 		listOfChanges2.getChanges().add(change);
 		

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
@@ -10,6 +10,7 @@ import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -20,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,6 +46,7 @@ import com.gentics.mesh.core.rest.node.field.impl.NumberFieldImpl;
 import com.gentics.mesh.core.rest.node.field.impl.StringFieldImpl;
 import com.gentics.mesh.core.rest.schema.ListFieldSchema;
 import com.gentics.mesh.core.rest.schema.Schema;
+import com.gentics.mesh.core.rest.schema.StringFieldSchema;
 import com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel;
 import com.gentics.mesh.core.rest.schema.change.impl.SchemaChangesListModel;
 import com.gentics.mesh.core.rest.schema.impl.ListFieldSchemaImpl;
@@ -391,6 +392,112 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 				!Objects.equals(currentVersion.getVersion(), node.getGraphFieldContainer("en").getSchemaContainerVersion().getVersion()));
 			assertEquals("label1234", node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField").getLabel());
 
+		}
+	}
+	
+	@Test
+	public void testAddRestrictedField() throws Exception {
+		SchemaContainer schemaContainer = schemaContainer("content");
+		String schemaUuid = tx(() -> schemaContainer.getUuid());
+		SchemaContainerVersion currentVersion = tx(() -> schemaContainer.getLatestVersion());
+		assertNull("The schema should not yet have any changes", tx(() -> currentVersion.getNextChange()));
+
+		// 1. Setup changes
+		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
+		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "string", "label1234");
+		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, new String[] {"5678"});
+		
+		listOfChanges.getChanges().add(change);
+
+		// 2. Invoke migration
+		GenericMessageResponse status = call(() -> client().applyChangesToSchema(schemaUuid, listOfChanges));
+		assertThat(status).matches("schema_changes_applied", "content");
+		SchemaResponse updatedSchema = call(() -> client().findSchemaByUuid(schemaUuid));
+
+		waitForJobs(() -> {
+			call(() -> client().assignBranchSchemaVersions(PROJECT_NAME, initialBranchUuid(),
+				new SchemaReferenceImpl().setName("content").setVersion(updatedSchema.getVersion())));
+		}, COMPLETED, 1);
+
+		try (Tx tx = tx()) {
+			assertNotNull("The change should have been added to the schema.", currentVersion.getNextChange());
+			assertNotEquals("The container should now have a new version", currentVersion.getUuid(), schemaContainer.getLatestVersion().getUuid());
+
+			// Assert that migration worked
+			Node node = content();
+			assertNotNull("The schema of the node should contain the new field schema",
+				node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField"));
+			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
+				!Objects.equals(currentVersion.getVersion(), node.getGraphFieldContainer("en").getSchemaContainerVersion().getVersion()));
+			assertArrayEquals(new String[] {"5678"}, node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
+		}
+	}
+	
+	@Test
+	public void testRemoveFieldRestriction() throws Exception {
+		SchemaContainer schemaContainer = schemaContainer("content");
+		String schemaUuid = tx(() -> schemaContainer.getUuid());
+		SchemaContainerVersion currentVersion = tx(() -> schemaContainer.getLatestVersion());
+		assertNull("The schema should not yet have any changes", tx(() -> currentVersion.getNextChange()));
+
+		// 1. Setup changes
+		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
+		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "string", "label1234");
+		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, new String[] {"5678"});
+		
+		listOfChanges.getChanges().add(change);
+
+		// 2. Invoke migration
+		GenericMessageResponse status = call(() -> client().applyChangesToSchema(schemaUuid, listOfChanges));
+		assertThat(status).matches("schema_changes_applied", "content");
+		SchemaResponse updatedSchema = call(() -> client().findSchemaByUuid(schemaUuid));
+
+		waitForJobs(() -> {
+			call(() -> client().assignBranchSchemaVersions(PROJECT_NAME, initialBranchUuid(),
+				new SchemaReferenceImpl().setName("content").setVersion(updatedSchema.getVersion())));
+		}, COMPLETED, 1);
+
+		try (Tx tx = tx()) {
+			assertNotNull("The change should have been added to the schema.", currentVersion.getNextChange());
+			assertNotEquals("The container should now have a new version", currentVersion.getUuid(), schemaContainer.getLatestVersion().getUuid());
+
+			// Assert that migration worked
+			Node node = content();
+			assertNotNull("The schema of the node should contain the new field schema",
+				node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField"));
+			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
+				!Objects.equals(currentVersion.getVersion(), node.getGraphFieldContainer("en").getSchemaContainerVersion().getVersion()));
+			assertArrayEquals(new String[] {"5678"}, node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
+		}
+		
+		// 3. Unrestrict field
+		SchemaChangesListModel listOfChanges2 = new SchemaChangesListModel();
+		change = SchemaChangeModel.createUpdateSchemaChange();
+		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, null);
+		
+		listOfChanges2.getChanges().add(change);
+		
+		// 4. Invoke migration again
+		status = call(() -> client().applyChangesToSchema(schemaUuid, listOfChanges2));
+		assertThat(status).matches("schema_changes_applied", "content");
+		SchemaResponse updatedSchema2 = call(() -> client().findSchemaByUuid(schemaUuid));
+
+		waitForJobs(() -> {
+			call(() -> client().assignBranchSchemaVersions(PROJECT_NAME, initialBranchUuid(),
+				new SchemaReferenceImpl().setName("content").setVersion(updatedSchema2.getVersion())));
+		}, COMPLETED, 1);
+
+		try (Tx tx = tx()) {
+			assertNotNull("The change should have been added to the schema.", currentVersion.getNextChange());
+			assertNotEquals("The container should now have a new version", currentVersion.getUuid(), schemaContainer.getLatestVersion().getUuid());
+
+			// Assert that migration worked
+			Node node = content();
+			assertNotNull("The schema of the node should contain the new field schema",
+				node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField"));
+			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
+				!Objects.equals(currentVersion.getVersion(), node.getGraphFieldContainer("en").getSchemaContainerVersion().getVersion()));
+			assertArrayEquals(new String[] {}, node.getGraphFieldContainer("en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
 		}
 	}
 

--- a/core/src/test/java/com/gentics/mesh/core/schema/change/AddFieldChangeTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/change/AddFieldChangeTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.assertj.core.api.AbstractObjectArrayAssert;
 import org.junit.Test;
 
 import com.gentics.madl.tx.Tx;
@@ -284,90 +285,57 @@ public class AddFieldChangeTest extends AbstractChangeTest {
 
 	@Test
 	public void testApplyStringFieldAllow() {
-		try (Tx tx = tx()) {
-			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
-			SchemaModelImpl schema = new SchemaModelImpl();
-			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
-			change.setFieldName("stringAllowField");
-			change.setType("string");
-			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, new String[] {"one", "two", "three"});
-			version.setSchema(schema);
-			version.setNextChange(change);
-			FieldSchemaContainer updatedSchema = mutator.apply(version);
-			assertThat(updatedSchema).hasField("stringAllowField");
-			assertThat(updatedSchema.getField("stringAllowField", StringFieldSchema.class).getAllowedValues()).as("Allowed values").containsExactly("one",
-					"two", "three");
-		}
+		testApplyStringFieldAllowance(true);
 	}
 
 	@Test
 	public void testApplyNodeFieldAllow() {
-		try (Tx tx = tx()) {
-			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
-			SchemaModelImpl schema = new SchemaModelImpl();
-			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
-			change.setFieldName("nodeAllowField");
-			change.setType("node");
-			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, new String[] {"content"});
-			version.setSchema(schema);
-			version.setNextChange(change);
-			FieldSchemaContainer updatedSchema = mutator.apply(version);
-			assertThat(updatedSchema).hasField("nodeAllowField");
-			assertThat(updatedSchema.getField("nodeAllowField", NodeFieldSchema.class).getAllowedSchemas()).as("Allowed schemas").containsExactly("content");
-		}
+		testApplyNodeFieldAllowance(true);
 	}
 
 	@Test
 	public void testApplyNodeListFieldAllow() {
-		try (Tx tx = tx()) {
-			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
-			SchemaModelImpl schema = new SchemaModelImpl();
-			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
-			change.setFieldName("nodeListFieldAllow");
-			change.setType("list");
-			change.setListType("node");
-			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, new String[] {"content"});
-			version.setSchema(schema);
-			version.setNextChange(change);
-			FieldSchemaContainer updatedSchema = mutator.apply(version);
-			assertThat(updatedSchema).hasField("nodeListFieldAllow");
-			assertThat(updatedSchema.getField("nodeListFieldAllow", ListFieldSchema.class).getAllowedSchemas()).as("Allowed schemas").containsExactly("content");
-		}
+		testApplyNodeListFieldAllowance(true);
 	}
 
 	@Test
 	public void testApplyMicronodeFieldAllow() {
-		try (Tx tx = tx()) {
-			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
-			SchemaModelImpl schema = new SchemaModelImpl();
-			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
-			change.setFieldName("micronodeAllowField");
-			change.setType("micronode");
-			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, new String[] {"content"});
-			version.setSchema(schema);
-			version.setNextChange(change);
-			FieldSchemaContainer updatedSchema = mutator.apply(version);
-			assertThat(updatedSchema).hasField("micronodeAllowField");
-			assertThat(updatedSchema.getField("micronodeAllowField", MicronodeFieldSchema.class).getAllowedMicroSchemas()).as("Allowed schemas").containsExactly("content");
-		}
+		testApplyMicronodeFieldAllowance(true);
 	}
 
 	@Test
 	public void testApplyMicronodeListFieldAllow() {
-		try (Tx tx = tx()) {
-			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
-			SchemaModelImpl schema = new SchemaModelImpl();
-			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
-			change.setFieldName("micronodeListFieldAllow");
-			change.setType("list");
-			change.setListType("micronode");
-			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, new String[] {"content"});
-			version.setSchema(schema);
-			version.setNextChange(change);
-			FieldSchemaContainer updatedSchema = mutator.apply(version);
-			assertThat(updatedSchema).hasField("micronodeListFieldAllow");
-			assertThat(updatedSchema.getField("micronodeListFieldAllow", ListFieldSchema.class).getAllowedSchemas()).as("Allowed schemas").containsExactly("content");
-		}
+		testApplyMicronodeListFieldAllowance(true);
+	}
+	
+	@Test
+	public void testApplyStringFieldDisallow() {
+		testApplyStringFieldAllowance(true);
+		testApplyStringFieldAllowance(false);
+	}
+
+	@Test
+	public void testApplyNodeFieldDisallow() {
+		testApplyNodeFieldAllowance(true);
+		testApplyNodeFieldAllowance(false);
+	}
+
+	@Test
+	public void testApplyNodeListFieldDisallow() {
+		testApplyNodeListFieldAllowance(true);
+		testApplyNodeListFieldAllowance(false);
+	}
+
+	@Test
+	public void testApplyMicronodeFieldDisallow() {
+		testApplyMicronodeFieldAllowance(true);
+		testApplyMicronodeFieldAllowance(false);
+	}
+
+	@Test
+	public void testApplyMicronodeListFieldDisallow() {
+		testApplyMicronodeListFieldAllowance(true);
+		testApplyMicronodeListFieldAllowance(false);
 	}
 
 	@Test
@@ -399,6 +367,113 @@ public class AddFieldChangeTest extends AbstractChangeTest {
 			assertEquals(change.getFieldName(), model.getProperty(SchemaChangeModel.FIELD_NAME_KEY));
 			assertEquals("The generic rest property from the change should have been set for the rest model.", "test",
 					change.getRestProperty("someProperty"));
+		}
+	}
+	
+	private void testApplyStringFieldAllowance(boolean allow) {
+		try (Tx tx = tx()) {
+			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
+			SchemaModelImpl schema = new SchemaModelImpl();
+			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
+			change.setFieldName("stringAllowField");
+			change.setType("string");
+			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, allow ? new String[] {"one", "two", "three"} : null);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("stringAllowField");
+			AbstractObjectArrayAssert<?, String> assertion = assertThat(updatedSchema.getField("stringAllowField", StringFieldSchema.class).getAllowedValues()).as("Allowed values");
+			if (allow) {
+				assertion.containsExactly("one", "two", "three");
+			} else {
+				assertion.isNullOrEmpty();
+			}
+		}
+	}
+
+	private void testApplyNodeFieldAllowance(boolean allow) {
+		try (Tx tx = tx()) {
+			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
+			SchemaModelImpl schema = new SchemaModelImpl();
+			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
+			change.setFieldName("nodeAllowField");
+			change.setType("node");
+			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, allow ? new String[] {"content"} : null);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("nodeAllowField");			
+			AbstractObjectArrayAssert<?, String> assertion = assertThat(updatedSchema.getField("nodeAllowField", NodeFieldSchema.class).getAllowedSchemas()).as("Allowed schemas");
+			if (allow) {
+				assertion.containsExactly("content");
+			} else {
+				assertion.isNullOrEmpty();
+			}
+		}
+	}
+
+	private void testApplyNodeListFieldAllowance(boolean allow) {
+		try (Tx tx = tx()) {
+			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
+			SchemaModelImpl schema = new SchemaModelImpl();
+			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
+			change.setFieldName("nodeListFieldAllow");
+			change.setType("list");
+			change.setListType("node");
+			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, allow ? new String[] {"content"} : null);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("nodeListFieldAllow");
+			AbstractObjectArrayAssert<?, String> assertion = assertThat(updatedSchema.getField("nodeListFieldAllow", ListFieldSchema.class).getAllowedSchemas()).as("Allowed schemas");
+			if (allow) {
+				assertion.containsExactly("content");
+			} else {
+				assertion.isNullOrEmpty();
+			}
+		}
+	}
+
+	private void testApplyMicronodeFieldAllowance(boolean allow) {
+		try (Tx tx = tx()) {
+			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
+			SchemaModelImpl schema = new SchemaModelImpl();
+			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
+			change.setFieldName("micronodeAllowField");
+			change.setType("micronode");
+			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, allow ? new String[] {"content"} : null);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("micronodeAllowField");
+			AbstractObjectArrayAssert<?, String> assertion = assertThat(updatedSchema.getField("micronodeAllowField", MicronodeFieldSchema.class).getAllowedMicroSchemas()).as("Allowed schemas");
+			if (allow) {
+				assertion.containsExactly("content");
+			} else {
+				assertion.isNullOrEmpty();
+			}
+		}
+	}
+
+	private void testApplyMicronodeListFieldAllowance(boolean allow) {
+		try (Tx tx = tx()) {
+			SchemaContainerVersion version = tx.getGraph().addFramedVertex(SchemaContainerVersionImpl.class);
+			SchemaModelImpl schema = new SchemaModelImpl();
+			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
+			change.setFieldName("micronodeListFieldAllow");
+			change.setType("list");
+			change.setListType("micronode");
+			change.setRestProperty(SchemaChangeModel.ALLOW_KEY, allow ? new String[] {"content"} : null);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("micronodeListFieldAllow");
+			AbstractObjectArrayAssert<?, String> assertion = assertThat(updatedSchema.getField("micronodeListFieldAllow", ListFieldSchema.class).getAllowedSchemas()).as("Allowed schemas");
+			if (allow) {
+				assertion.containsExactly("content");
+			} else {
+				assertion.isNullOrEmpty();
+			}
 		}
 	}
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
@@ -190,6 +190,19 @@ public class SchemaChangeModel implements RestModel {
 		change.getProperties().put(SchemaChangeModel.NAME_KEY, newFieldName);
 		return change;
 	}
+	
+	/**
+	 * Create an update field change to rename a field.
+	 * 
+	 * @param fieldName
+	 * @param newFieldName
+	 * @return
+	 */
+	public static SchemaChangeModel createFieldRestrictionChange(String fieldName, String[] restrictions) {
+		SchemaChangeModel change = new SchemaChangeModel(UPDATEFIELD, fieldName);
+		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, restrictions);
+		return change;
+	}
 
 	/**
 	 * Create a add field change.


### PR DESCRIPTION
## Abstract

A bug has appeared to ignore schema updates where the "allow" field restrictions are set to empty.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
