### PR TITLE
CL-696: Split the BootstrapInitializer #4: unit tests adapt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ final def imagePrefix		   = "gtx-docker-releases-staging-mesh.docker.apa-it.at/"
 properties([
 	parameters([
 		booleanParam(name: 'runTests',            defaultValue: true,  description: "Whether to run the unit tests"),
-		booleanParam(name: 'splitTests',          defaultValue: true, description: "Whether to split tests or not"),
+		booleanParam(name: 'splitTests',          defaultValue: false, description: "Whether to split tests or not"),
 		booleanParam(name: 'runSonar',            defaultValue: false, description: "Whether to run the sonarqube checks"),
 		booleanParam(name: 'runPerformanceTests', defaultValue: false, description: "Whether to run performance tests."),
 		booleanParam(name: 'runClusterTests',     defaultValue: false, description: "Whether to run cluster tests."),

--- a/Jenkinsfile.split
+++ b/Jenkinsfile.split
@@ -8,7 +8,7 @@ JobContext.set(this)
 properties([
 	parameters([
 		booleanParam(name: 'runTests',            defaultValue: true,  description: "Whether to run the unit tests"),
-		booleanParam(name: 'splitTests',          defaultValue: true,  description: "Whether to split tests or not"),
+		booleanParam(name: 'splitTests',          defaultValue: false,  description: "Whether to split tests or not"),
 		booleanParam(name: 'skipSearchTests',     defaultValue: false, description: "Whether to skip search tests or not"),
 		booleanParam(name: 'runSonar',            defaultValue: false, description: "Whether to run the sonarqube checks"),
 		booleanParam(name: 'runUnstableTests',    defaultValue: true,  description: "Whether to run tests in failing group."),

--- a/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacerImpl.java
+++ b/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacerImpl.java
@@ -130,8 +130,7 @@ public class WebRootLinkReplacerImpl implements WebRootLinkReplacer {
 		String... languageTags) {
 		// Get rid of additional whitespaces
 		uuid = uuid.trim();
-		HibProject project = boot.projectDao().findByName(projectName);
-		HibNode node = boot.nodeDao().findByUuid(project, uuid);
+		HibNode node = boot.nodeDao().findByUuidGlobal(uuid);
 
 		// check for null
 		if (node == null) {

--- a/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacerImpl.java
+++ b/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacerImpl.java
@@ -130,7 +130,8 @@ public class WebRootLinkReplacerImpl implements WebRootLinkReplacer {
 		String... languageTags) {
 		// Get rid of additional whitespaces
 		uuid = uuid.trim();
-		HibNode node = boot.nodeDao().findByUuidGlobal(uuid);
+		HibProject project = boot.projectDao().findByName(projectName);
+		HibNode node = boot.nodeDao().findByUuid(project, uuid);
 
 		// check for null
 		if (node == null) {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<mesh.version>${project.version}</mesh.version>
-		<skip.test-plugins>true</skip.test-plugins>
 		<mesh.mdm.provider.groupId>${project.groupId}</mesh.mdm.provider.groupId>
 		<mesh.mdm.provider.artifactId>mesh-orientdb</mesh.mdm.provider.artifactId>
 		<mesh.mdm.provider.version>${project.version}</mesh.mdm.provider.version>

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/RootDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/RootDao.java
@@ -1,0 +1,332 @@
+package com.gentics.mesh.core.data.dao;
+
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+
+import java.util.Stack;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.gentics.mesh.context.BulkActionContext;
+import com.gentics.mesh.context.InternalActionContext;
+import com.gentics.mesh.core.data.HibBaseElement;
+import com.gentics.mesh.core.data.HibCoreElement;
+import com.gentics.mesh.core.data.page.Page;
+import com.gentics.mesh.core.data.perm.InternalPermission;
+import com.gentics.mesh.core.data.role.HibRole;
+import com.gentics.mesh.core.rest.common.PermissionInfo;
+import com.gentics.mesh.core.rest.common.RestModel;
+import com.gentics.mesh.core.result.Result;
+import com.gentics.mesh.event.EventQueueBatch;
+import com.gentics.mesh.parameter.PagingParameters;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public interface RootDao<R extends HibCoreElement<? extends RestModel>, L extends HibCoreElement<? extends RestModel>> {
+
+	public static final Logger log = LoggerFactory.getLogger(RootDao.class);
+
+	/**
+	 * Return a traversal of all elements. Only use this method if you know that the root->item relation only yields a specific kind of item.
+	 * 
+	 * @return
+	 */
+	Result<? extends L> findAll(R root);
+
+	/**
+	 * Return an iterator of all elements. Only use this method if you know that the root->item relation only yields a specific kind of item. This also checks
+	 * permissions.
+	 *
+	 * @param ac
+	 *            The context of the request
+	 * @param permission
+	 *            Needed permission
+	 */
+	Stream<? extends L> findAllStream(R root, InternalActionContext ac, InternalPermission permission);
+
+	/**
+	 * Return an traversal result of all elements and use the stored type information to load the items. The {@link #findAll()} will use explicit typing and
+	 * thus will be faster. Only use that method if you know that your relation only yields a specific kind of item.
+	 * 
+	 * @return
+	 */
+	Result<? extends L> findAllDynamic(R root);
+
+	/**
+	 * Find the visible elements and return a paged result.
+	 * 
+	 * @param ac
+	 *            action context
+	 * @param pagingInfo
+	 *            Paging information object that contains page options
+	 * 
+	 * @return
+	 */
+	Page<? extends L> findAll(R root, InternalActionContext ac, PagingParameters pagingInfo);
+
+	/**
+	 * Find the visible elements and return a paged result.
+	 *
+	 * @param ac
+	 *            action context
+	 * @param pagingInfo
+	 *            Paging information object that contains page options
+	 * @param extraFilter
+	 *            Additional filter to be applied
+	 * @return
+	 */
+	Page<? extends L> findAll(R root, InternalActionContext ac, PagingParameters pagingInfo, Predicate<L> extraFilter);
+
+	/**
+	 * Find all elements and return a paged result. No permission check will be performed.
+	 * 
+	 * @param ac
+	 *            action context
+	 * @param pagingInfo
+	 *            Paging information object that contains page options
+	 * @return
+	 */
+	Page<? extends L> findAllNoPerm(R root, InternalActionContext ac, PagingParameters pagingInfo);
+
+	/**
+	 * Find the element with the given name.
+	 * 
+	 * @param name
+	 * @return Found element or null if element with the name could not be found
+	 */
+	L findByName(R root, String name);
+
+	/**
+	 * Load the object by name and check the given permission.
+	 * 
+	 * @param ac
+	 *            Context to be used in order to check user permissions
+	 * @param name
+	 *            Name of the object that should be loaded
+	 * @param perm
+	 *            Permission that must be granted in order to load the object
+	 * @return
+	 */
+	L findByName(R root, InternalActionContext ac, String name, InternalPermission perm);
+
+	/**
+	 * Find the element with the given uuid.
+	 * 
+	 * @param uuid
+	 *            Uuid of the element to be located
+	 * @return Found element or null if the element could not be located
+	 */
+	L findByUuid(R root, String uuid);
+
+	/**
+	 * Load the object by uuid and check the given permission.
+	 * 
+	 * @param ac
+	 *            Context to be used in order to check user permissions
+	 * @param uuid
+	 *            Uuid of the object that should be loaded
+	 * @param perm
+	 *            Permission that must be granted in order to load the object
+	 * @return Loaded element. A not found error will be thrown if the element could not be found. Returned value will never be null.
+	 */
+	default L loadObjectByUuid(R root, InternalActionContext ac, String uuid, InternalPermission perm) {
+		return loadObjectByUuid(root, ac, uuid, perm, true);
+	}
+
+	/**
+	 * Load the object by uuid and check the given permission.
+	 * 
+	 * @param ac
+	 *            Context to be used in order to check user permissions
+	 * @param uuid
+	 *            Uuid of the object that should be loaded
+	 * @param perm
+	 *            Permission that must be granted in order to load the object
+	 * @param errorIfNotFound
+	 *            True if an error should be thrown, when the element could not be found
+	 * @return Loaded element. If errorIfNotFound is true, a not found error will be thrown if the element could not be found and the returned value will never
+	 *         be null.
+	 */
+	default L loadObjectByUuid(R root, InternalActionContext ac, String uuid, InternalPermission perm, boolean errorIfNotFound) {
+		L element = findByUuid(root, uuid);
+		return checkPerms(root, element, uuid, ac, perm, errorIfNotFound);
+	}
+
+	L checkPerms(R root, L element, String uuid, InternalActionContext ac, InternalPermission perm, boolean errorIfNotFound);
+// TODO get this back after Tx is generalized
+//	default L checkPerms(R root, L element, String uuid, InternalActionContext ac, InternalPermission perm, boolean errorIfNotFound) {
+//		if (element == null) {
+//			if (errorIfNotFound) {
+//				throw error(NOT_FOUND, "object_not_found_for_uuid", uuid);
+//			} else {
+//				return null;
+//			}
+//		}
+//
+//		HibUser requestUser = ac.getUser();
+//		String elementUuid = element.getUuid();
+//		UserDao userDao = Tx.get().userDao();
+//		if (userDao.hasPermission(requestUser, element, perm)) {
+//			return element;
+//		} else {
+//			throw error(FORBIDDEN, "error_missing_perm", elementUuid, perm.getRestPerm().getName());
+//		}
+//	}
+
+	/**
+	 * Load the object by uuid. No permission check will be performed.
+	 * 
+	 * @param uuid
+	 *            Uuid of the object that should be loaded
+	 * @param errorIfNotFound
+	 *            True if an error should be thrown, when the element could not be found
+	 * @return Loaded element. If errorIfNotFound is true, a not found error will be thrown if the element could not be found and the returned value will never
+	 *         be null.
+	 */
+	default L loadObjectByUuidNoPerm(R root, String uuid, boolean errorIfNotFound) {
+		L element = findByUuid(root, uuid);
+		if (element == null) {
+			if (errorIfNotFound) {
+				throw error(NOT_FOUND, "object_not_found_for_uuid", uuid);
+			} else {
+				return null;
+			}
+		}
+		return element;
+	}
+
+	/**
+	 * Resolve the given stack to the vertex.
+	 * 
+	 * @param stack
+	 *            Stack which contains the remaining path elements which should be resolved starting with the current graph element
+	 * @return
+	 */
+	default HibBaseElement resolveToElement(R root, Stack<String> stack) {
+		if (log.isDebugEnabled()) {
+			log.debug("Resolving for {" + getPersistenceClass(root).getSimpleName() + "}.");
+			if (stack.isEmpty()) {
+				log.debug("Stack: is empty");
+			} else {
+				log.debug("Stack: " + stack.peek());
+			}
+		}
+		if (stack.isEmpty()) {
+			return root;
+		} else {
+			String uuid = stack.pop();
+			if (stack.isEmpty()) {
+				return findByUuid(root, uuid);
+			} else {
+				throw error(BAD_REQUEST, "Can't resolve remaining segments. Next segment would be: " + stack.peek());
+			}
+		}
+	}
+
+	/**
+	 * Create a new object which is connected or directly related to this aggregation vertex.
+	 * 
+	 * @param ac
+	 *            Context which is used to load information needed for the object creation
+	 * @param batch
+	 */
+	default L create(R root, InternalActionContext ac, EventQueueBatch batch) {
+		return create(root, ac, batch, null);
+	}
+
+	/**
+	 * Create a new object which is connected or directly related to this aggregation vertex.
+	 * 
+	 * @param ac
+	 *            Context which is used to load information needed for the object creation
+	 * @param batch
+	 * @param uuid
+	 *            optional uuid to create the object with a given uuid (null to create a random uuid)
+	 */
+	L create(R root, InternalActionContext ac, EventQueueBatch batch, String uuid);
+
+	/**
+	 * Add the given item to the this root vertex.
+	 * 
+	 * @param item
+	 */
+	void addItem(R root, L item);
+
+	/**
+	 * Remove the given item from this root vertex.
+	 * 
+	 * @param item
+	 */
+	void removeItem(R root, L item);
+
+	/**
+	 * Return the label for the item edges.
+	 * 
+	 * @return
+	 */
+	String getRootLabel(R root);
+
+	/**
+	 * Return the ferma graph persistance class for the items of the root vertex. (eg. NodeImpl, TagImpl...)
+	 * 
+	 * @return
+	 */
+	Class<? extends L> getPersistenceClass(R root);
+
+	/**
+	 * Return the total count of all tracked elements.
+	 * 
+	 * @return
+	 */
+	default long computeCount(R root) {
+		return findAll(root).count();
+	}
+
+	/**
+	 * Return the global count for all elements of the type that are managed by the root vertex. The count will include all vertices in the graph of the
+	 * specific type.
+	 * 
+	 * @return
+	 */
+	long globalCount(R root);
+
+	/**
+	 * Get the permissions of a role for this element.
+	 *
+	 * @param element
+	 * @param ac
+	 * @param roleUuid
+	 * @return
+	 */
+	PermissionInfo getRolePermissions(R root, HibBaseElement element, InternalActionContext ac, String roleUuid);
+
+	/**
+	 * Return a traversal result for all roles which grant the permission to the element.
+	 *
+	 * @param vertex
+	 * @param perm
+	 * @return
+	 */
+	Result<? extends HibRole> getRolesWithPerm(R root, HibBaseElement vertex, InternalPermission perm);
+
+	/**
+	 * Delete the element. Additional entries will be added to the batch to keep the search index in sync.
+	 *
+	 * @param element
+	 * @param bac
+	 *            Deletion context which keeps track of the deletion process
+	 */
+	void delete(R root, L element, BulkActionContext bac);
+
+	/**
+	 * Update the vertex using the action context information.
+	 *
+	 * @param ac
+	 * @param batch
+	 *            Batch to which entries will be added in order to update the search index.
+	 * @return true if the element was updated. Otherwise false
+	 */
+	boolean update(R root, L element, InternalActionContext ac, EventQueueBatch batch);
+}

--- a/tests/common/src/main/java/com/gentics/mesh/test/category/ClusterTests.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/category/ClusterTests.java
@@ -1,0 +1,10 @@
+package com.gentics.mesh.test.category;
+
+/**
+ * A JUnit marker interface for cluster tests.
+ * 
+ * @author plyhun
+ *
+ */
+public interface ClusterTests {
+}

--- a/tests/common/src/main/java/com/gentics/mesh/test/category/PluginTests.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/category/PluginTests.java
@@ -1,0 +1,10 @@
+package com.gentics.mesh.test.category;
+
+/**
+ * A JUnit marker interface for plugin tests.
+ * 
+ * @author plyhun
+ *
+ */
+public interface PluginTests {
+}

--- a/tests/common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
@@ -331,10 +331,10 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 			classPathArg = classPathArg.substring(1);
 
 			// Add maven libs
-			File libFolder = new File("../server/target/mavendependencies-sharedlibs");
+			File libFolder = new File("../../server/target/mavendependencies-sharedlibs");
 			assertTrue("The library folder {" + libFolder + "} could not be found", libFolder.exists());
 			for (File lib : libFolder.listFiles()) {
-				String dockerPath = lib.getPath().replaceAll("\\.\\.\\/", "bin/");
+				String dockerPath = lib.getPath().replaceAll("\\.\\.\\/\\.\\.\\/", "bin/");
 				classPathArg += ":" + dockerPath;
 			}
 			dockerImage.withFileFromPath("bin/server/target/mavendependencies-sharedlibs", libFolder.toPath());

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/admin/AdminPluginEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/admin/AdminPluginEndpointTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNull;
 import java.io.IOException;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.core.rest.common.GenericMessageResponse;
 import com.gentics.mesh.core.rest.plugin.PluginDeploymentRequest;
@@ -28,10 +29,13 @@ import com.gentics.mesh.plugin.ClonePlugin;
 import com.gentics.mesh.plugin.ManifestInjectorPlugin;
 import com.gentics.mesh.plugin.PluginManifest;
 import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.test.category.ClusterTests;
+import com.gentics.mesh.test.category.PluginTests;
 
 /**
  * These tests require the test plugins to be build. You can build these plugins using the /core/build-test-plugins.sh script.
  */
+@Category(PluginTests.class)
 @MeshTestSetting(testSize = PROJECT, startServer = true, inMemoryDB = true)
 public class AdminPluginEndpointTest extends AbstractPluginTest {
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLPluginTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLPluginTest.java
@@ -8,15 +8,18 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import java.io.IOException;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.core.rest.graphql.GraphQLResponse;
 import com.gentics.mesh.plugin.AbstractPluginTest;
 import com.gentics.mesh.plugin.ClonePlugin;
 import com.gentics.mesh.test.MeshTestSetting;
 import com.gentics.mesh.test.TestSize;
+import com.gentics.mesh.test.category.PluginTests;
 
 import io.vertx.core.json.JsonObject;
 
+@Category(PluginTests.class)
 @MeshTestSetting(testSize = TestSize.FULL, startServer = true)
 public class GraphQLPluginTest extends AbstractPluginTest {
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/job/JobTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/job/JobTest.java
@@ -115,9 +115,9 @@ public class JobTest extends AbstractMeshTest {
 	public void testJobRootTypeHandling() {
 		try (Tx tx = tx()) {
 			JobDao dao = boot().jobDao();
-			dao.enqueueBranchMigration(user(), latestBranch());
-			dao.enqueueMicroschemaMigration(user(), latestBranch(), createMicroschemaVersion(tx), createMicroschemaVersion(tx));
 			dao.enqueueSchemaMigration(user(), latestBranch(), createSchemaVersion(tx), createSchemaVersion(tx));
+			dao.enqueueMicroschemaMigration(user(), latestBranch(), createMicroschemaVersion(tx), createMicroschemaVersion(tx));
+			dao.enqueueBranchMigration(user(), latestBranch());
 
 			List<String> list = TestUtils.toList(dao.findAll()).stream().map(i -> i.getClass().getName()).collect(Collectors.toList());
 			assertThat(list).containsExactly(NodeMigrationJobImpl.class.getName(), MicronodeMigrationJobImpl.class.getName(),

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -1299,7 +1299,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		container.setLatestVersion(versionA);
 		versionA.setSchemaContainer(container);
 		EventQueueBatch batch = createBatch();
-		boot().schemaDao().addSchema(container, project(), user(), batch);
+		boot().schemaDao().addSchema(container);
 
 		SchemaVersionModel schemaA = new SchemaModelImpl();
 		schemaA.setName("migratedSchema");

--- a/tests/tests-core/src/main/java/com/gentics/mesh/plugin/AbstractPluginTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/plugin/AbstractPluginTest.java
@@ -24,23 +24,23 @@ import io.netty.handler.codec.http.HttpResponseStatus;
  */
 public class AbstractPluginTest extends AbstractMeshTest {
 
-	public static final String BASIC_PATH = "target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String BASIC_PATH = "../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String BASIC2_PATH = "target/test-plugins/basic2/target/basic2-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String BASIC2_PATH = "../../core/target/test-plugins/basic2/target/basic2-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String FAILING_PATH = "target/test-plugins/failing/target/failing-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String FAILING_PATH = "../../core/target/test-plugins/failing/target/failing-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String NON_MESH_PATH = "target/test-plugins/non-mesh/target/non-mesh-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String NON_MESH_PATH = "../../core/target/test-plugins/non-mesh/target/non-mesh-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String CLASSLOADER_PATH = "target/test-plugins/classloader/target/classloader-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String CLASSLOADER_PATH = "../../core/target/test-plugins/classloader/target/classloader-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String EXTENSION_PROVIDER_PATH = "target/test-plugins/extension-provider/target/extension-provider-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String EXTENSION_PROVIDER_PATH = "../../core/target/test-plugins/extension-provider/target/extension-provider-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String EXTENSION_CONSUMER_PATH = "target/test-plugins/extension-consumer/target/extension-consumer-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String EXTENSION_CONSUMER_PATH = "../../core/target/test-plugins/extension-consumer/target/extension-consumer-plugin-0.0.1-SNAPSHOT.jar";
 
-	public static final String GRAPHQL_PATH = "target/test-plugins/graphql/target/graphql-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String GRAPHQL_PATH = "../../core/target/test-plugins/graphql/target/graphql-plugin-0.0.1-SNAPSHOT.jar";
 	
-	public static final String INVALID_GRAPHQL_PATH = "target/test-plugins/invalid-graphql/target/invalid-graphql-plugin-0.0.1-SNAPSHOT.jar";
+	public static final String INVALID_GRAPHQL_PATH = "../../core/target/test-plugins/invalid-graphql/target/invalid-graphql-plugin-0.0.1-SNAPSHOT.jar";
 
 	@Before
 	public void preparePluginDir() throws IOException {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/plugin/PluginManagerClusterTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/plugin/PluginManagerClusterTest.java
@@ -2,11 +2,15 @@ package com.gentics.mesh.plugin;
 
 import static com.gentics.mesh.test.TestSize.PROJECT;
 
+import org.junit.experimental.categories.Category;
+
 import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.test.category.PluginTests;
 
 /**
  * Run the plugin tests in clustered mode with a single instance.
  */
+@Category(PluginTests.class)
 @MeshTestSetting(testSize = PROJECT, startServer = true, inMemoryDB = false, clusterMode = true)
 public class PluginManagerClusterTest extends PluginManagerTest {
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/plugin/PluginManagerTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/plugin/PluginManagerTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.common.RestModel;
@@ -27,6 +28,7 @@ import com.gentics.mesh.core.rest.user.UserResponse;
 import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.plugin.manager.MeshPluginManager;
 import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.test.category.PluginTests;
 import com.twelvemonkeys.io.FileUtil;
 
 import io.vertx.core.http.HttpHeaders;
@@ -37,6 +39,7 @@ import okhttp3.Request;
 /**
  * In order to run the plugin tests you need to build the test plugins using the build-test-plugins.sh script. 
  */
+@Category(PluginTests.class)
 @MeshTestSetting(testSize = PROJECT, startServer = true, inMemoryDB = true)
 public class PluginManagerTest extends AbstractPluginTest {
 

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/BasicClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/BasicClusterTest.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.FieldUtil;
@@ -51,12 +52,14 @@ import com.gentics.mesh.core.rest.user.UserUpdateRequest;
 import com.gentics.mesh.parameter.client.NodeParametersImpl;
 import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
 import com.gentics.mesh.rest.client.MeshRestClient;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 import com.gentics.mesh.test.util.TestUtils;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+@Category(ClusterTests.class)
 public class BasicClusterTest extends AbstractClusterTest {
 
 	private static String clusterPostFix = randomUUID();

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ChaosClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ChaosClusterTest.java
@@ -10,15 +10,18 @@ import java.util.List;
 import java.util.Random;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.core.rest.user.UserCreateRequest;
 import com.gentics.mesh.core.rest.user.UserResponse;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 import com.gentics.mesh.test.docker.MeshContainer;
 
 /**
  * A test which will randomly add, remove, utilize and stop nodes in a mesh cluster.
  */
+@Category(ClusterTests.class)
 public class ChaosClusterTest extends AbstractClusterTest {
 
 	private static String clusterPostFix = randomUUID();

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterConcurrencyTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterConcurrencyTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.FieldUtil;
@@ -26,6 +27,7 @@ import com.gentics.mesh.core.rest.schema.SchemaListResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaUpdateRequest;
 import com.gentics.mesh.rest.client.MeshRestClient;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
 import io.reactivex.Completable;
@@ -33,6 +35,7 @@ import io.reactivex.Observable;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+@Category(ClusterTests.class)
 public class ClusterConcurrencyTest extends AbstractClusterTest {
 
 	private static final Logger log = LoggerFactory.getLogger(ClusterConcurrencyTest.class);

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterConfigEndpointTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterConfigEndpointTest.java
@@ -8,14 +8,17 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.core.rest.admin.cluster.ClusterConfigRequest;
 import com.gentics.mesh.core.rest.admin.cluster.ClusterConfigResponse;
 import com.gentics.mesh.core.rest.admin.cluster.ClusterServerConfig;
 import com.gentics.mesh.core.rest.admin.cluster.ServerRole;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
+@Category(ClusterTests.class)
 public class ClusterConfigEndpointTest extends AbstractClusterTest {
 
 	private static String clusterPostFix = randomUUID();

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterCoordinatorPlaneTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterCoordinatorPlaneTest.java
@@ -7,11 +7,14 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.core.rest.MeshServerInfoModel;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
+@Category(ClusterTests.class)
 public class ClusterCoordinatorPlaneTest extends AbstractClusterTest {
 
 	private static String coordinatorRegex = "nodeA";

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterCoordinatorTokenTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ClusterCoordinatorTokenTest.java
@@ -12,12 +12,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.event.impl.MeshElementEventModelImpl;
 import com.gentics.mesh.core.rest.user.UserResponse;
 import com.gentics.mesh.rest.client.MeshRestClient;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 import com.gentics.mesh.test.util.EventUtils;
 
@@ -28,6 +30,7 @@ import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 
+@Category(ClusterTests.class)
 public class ClusterCoordinatorTokenTest {
 	private static String clusterPostFix = randomUUID();
 	private static String coordinatorRegex = "nodeA";

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ErrorHandlingClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/ErrorHandlingClusterTest.java
@@ -12,14 +12,17 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.core.rest.project.ProjectCreateRequest;
 import com.gentics.mesh.core.rest.project.ProjectResponse;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
 /**
  * Tests various interacts with the cluster. (e.g.: Adding new nodes, Removing nodes)
  */
+@Category(ClusterTests.class)
 public class ErrorHandlingClusterTest extends AbstractClusterTest {
 
 	private static String clusterPostFix = randomUUID();

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/MultiNodeClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/MultiNodeClusterTest.java
@@ -7,15 +7,18 @@ import static com.gentics.mesh.util.UUIDUtil.randomUUID;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.core.rest.project.ProjectCreateRequest;
 import com.gentics.mesh.core.rest.project.ProjectResponse;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
 /**
  * Test how a cluster behaves with more than two nodes.
  */
+@Category(ClusterTests.class)
 public class MultiNodeClusterTest extends AbstractClusterTest {
 
 	private static final int STARTUP_TIMEOUT = 500;

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/NodeRejectionClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/NodeRejectionClusterTest.java
@@ -9,14 +9,17 @@ import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 import com.gentics.mesh.core.rest.admin.cluster.ClusterStatusResponse;
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
 /**
  * Assert that a node will not be able to join the cluster if the mesh versions and the database revision are not matching.
  */
+@Category(ClusterTests.class)
 public class NodeRejectionClusterTest extends AbstractClusterTest {
 
 	private static final int STARTUP_TIMEOUT = 110;

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/PluginClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/PluginClusterTest.java
@@ -15,12 +15,15 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.context.impl.LoggingConfigurator;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.plugin.PluginListResponse;
 import com.gentics.mesh.core.rest.plugin.PluginResponse;
 import com.gentics.mesh.rest.client.MeshWebsocket;
+import com.gentics.mesh.test.category.ClusterTests;
+import com.gentics.mesh.test.category.PluginTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 
 import io.vertx.core.logging.Logger;
@@ -29,6 +32,7 @@ import io.vertx.core.logging.LoggerFactory;
 /**
  * These tests require the test plugins to be build. You can build these plugins using the /core/build-test-plugins.sh script.
  */
+@Category({ClusterTests.class, PluginTests.class})
 public class PluginClusterTest extends AbstractClusterTest {
 
 	private static String clusterPostFix = randomUUID();
@@ -45,7 +49,7 @@ public class PluginClusterTest extends AbstractClusterTest {
 		.withInitCluster()
 		.waitForStartup()
 		.withWriteQuorum(2)
-		.withPlugin(new File("../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar"), "basic.jar")
+		.withPlugin(new File("../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar"), "basic.jar")
 		.withClearFolders();
 
 	@BeforeClass
@@ -88,7 +92,7 @@ public class PluginClusterTest extends AbstractClusterTest {
 
 	private MeshContainer addSlave(String nodeName) throws InterruptedException {
 		MeshContainer server = prepareSlave(clusterPostFix, nodeName, randomToken(), true, 2)
-			.withPlugin(new File("../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar"), "basic.jar");
+			.withPlugin(new File("../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar"), "basic.jar");
 		server.start();
 		server.awaitStartup(STARTUP_TIMEOUT);
 		login(server);

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/SplitBrainTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/SplitBrainTest.java
@@ -11,12 +11,15 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
+import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.docker.MeshContainer;
 import com.google.common.collect.Lists;
 
 @Ignore
+@Category(ClusterTests.class)
 public class SplitBrainTest {
 
 	private static final int STARTUP_TIMEOUT = 500;

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/coordinatortoken/ClusterCoordinatorTokenTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/coordinatortoken/ClusterCoordinatorTokenTest.java
@@ -24,7 +24,7 @@ public class ClusterCoordinatorTokenTest extends AbstractClusterCoordinatorToken
 		.withCoordinatorPlane(CoordinatorMode.CUD)
 		.withCoordinatorRegex(coordinatorRegex)
 		.withInitCluster()
-		.withPlugin(new File("../core/target/test-plugins/auth/target/auth-plugin-0.0.1-SNAPSHOT.jar"), "auth.jar")
+		.withPlugin(new File("../../core/target/test-plugins/auth/target/auth-plugin-0.0.1-SNAPSHOT.jar"), "auth.jar")
 		.withPublicKeys(getResourceAsFile("/public-keys/symmetric-key.json"))
 		.waitForStartup()
 		.withClearFolders();
@@ -35,7 +35,7 @@ public class ClusterCoordinatorTokenTest extends AbstractClusterCoordinatorToken
 		.withDataPathPostfix(randomToken())
 		.withCoordinatorPlane(CoordinatorMode.CUD)
 		.withCoordinatorRegex(coordinatorRegex)
-		.withPlugin(new File("../core/target/test-plugins/auth/target/auth-plugin-0.0.1-SNAPSHOT.jar"), "auth.jar")
+		.withPlugin(new File("../../core/target/test-plugins/auth/target/auth-plugin-0.0.1-SNAPSHOT.jar"), "auth.jar")
 		.withPublicKeys(getResourceAsFile("/public-keys/symmetric-key.json"))
 		.waitForStartup()
 		.withClearFolders();


### PR DESCRIPTION
## Abstract

Fixes to improve the unit tests' stability. Consist of
* categorizing the environment-dependent UTs (plugins, cluster)
* disabling test split run by default, because of the instability
* fixing the paths to the test plugins

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
