### PR TITLE
Fix plugin parent

### DIFF
--- a/plugin-parent/pom.xml
+++ b/plugin-parent/pom.xml
@@ -42,11 +42,6 @@
 			<artifactId>mesh-plugin-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.gentics.mesh</groupId>
-			<artifactId>mesh-service-jwt-auth</artifactId>
-			<scope>provided</scope>
-		</dependency>
 
 		<!-- Logging -->
 		<dependency>


### PR DESCRIPTION
## Abstract

During building Maven complains that the dependency to `mesh-service-jwt-auth` is declared multiple times. This change removes the superfluous declaration.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
