### PR TITLE
Update OrientDB to v3.1.13

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.21]]
+== 1.6.21 (TBD)
+
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.13`.
+
 [[v1.6.20]]
 == 1.6.20 (23.09.2021)
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -23,7 +23,7 @@
 		<spring.security.version>4.2.13.RELEASE</spring.security.version>
 		<ferma.version>${project.version}</ferma.version>
 		<elasticsearch.client.version>1.1.1</elasticsearch.client.version>
-		<orientdb.version>3.1.11</orientdb.version>
+		<orientdb.version>3.1.13</orientdb.version>
 		<hazelcast.version>3.12.8</hazelcast.version>
 		<jackson.version>2.9.9</jackson.version>
 		<jackson-databind.version>2.9.10</jackson-databind.version>


### PR DESCRIPTION
## Abstract

Update OrientDB to v3.1.13. No extra data migration requirement is expected.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
