### PR TITLE
Fix memory consumption during migrations

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.21]]
+== 1.6.21 (TBD)
+
+icon:check[] Core: The overall memory consumption during a migration job has been reduced.
+
 [[v1.6.20]]
 == 1.6.20 (23.09.2021)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/migration/AbstractMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/migration/AbstractMigrationHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -110,15 +111,26 @@ public abstract class AbstractMigrationHandler extends AbstractHandler implement
 		newContainer.updateFieldsFromRest(ac, fields);
 	}
 
+	/**
+	 * Migrate all elements in the given queue, by passing it to the migrator. The elements will be removed from the queue, before they are migrated,
+	 * in order to save memory (elements will be "enriched" with additional data during migration).
+	 * @param <T> type of migrated elements
+	 * @param containers queue of elements to be migrated
+	 * @param cause information about the cause
+	 * @param status migration status (will be updated during the migration)
+	 * @param migrator migrator
+	 * @return list of exceptions caught during the migration
+	 */
 	@ParametersAreNonnullByDefault
-	protected <T> List<Exception> migrateLoop(Iterable<T> containers, EventCauseInfo cause, MigrationStatusHandler status,
+	protected <T> List<Exception> migrateLoop(Queue<T> containers, EventCauseInfo cause, MigrationStatusHandler status,
 		TriConsumer<EventQueueBatch, T, List<Exception>> migrator) {
 		// Iterate over all containers and invoke a migration for each one
 		long count = 0;
 		List<Exception> errorsDetected = new ArrayList<>();
 		EventQueueBatch sqb = batchProvider.get();
 		sqb.setCause(cause);
-		for (T container : containers) {
+		while (!containers.isEmpty()) {
+			T container = containers.poll();
 			try {
 				// Each container migration has its own search queue batch which is then combined with other batch entries.
 				// This prevents adding partial entries from failed migrations.

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/migration/branch/BranchMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/migration/branch/BranchMigrationHandler.java
@@ -6,8 +6,10 @@ import static com.gentics.mesh.core.rest.common.ContainerType.INITIAL;
 import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
 import static com.gentics.mesh.core.rest.job.JobStatus.RUNNING;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -65,9 +67,9 @@ public class BranchMigrationHandler extends AbstractMigrationHandler {
 				}
 			});
 
-			List<? extends Node> nodes = db.tx(() -> {
+			Queue<? extends Node> nodes = db.tx(() -> {
 				Project project = oldBranch.getProject();
-				return project.findNodes().list();
+				return new ArrayDeque<>(project.findNodes().list());
 			});
 
 			List<Exception> errorsDetected = new ArrayList<>();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/migration/micronode/MicronodeMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/migration/micronode/MicronodeMigrationHandler.java
@@ -5,8 +5,10 @@ import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
 import static com.gentics.mesh.core.rest.job.JobStatus.COMPLETED;
 import static com.gentics.mesh.core.rest.job.JobStatus.RUNNING;
 
+import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Queue;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -86,8 +88,8 @@ public class MicronodeMigrationHandler extends AbstractMigrationHandler {
 			}
 
 			// Get the containers, that need to be transformed
-			List<? extends NodeGraphFieldContainer> fieldContainersResult = db.tx(() -> {
-				return fromVersion.getDraftFieldContainers(branch.getUuid()).list();
+			Queue<? extends NodeGraphFieldContainer> fieldContainersResult = db.tx(() -> {
+				return new ArrayDeque<>(fromVersion.getDraftFieldContainers(branch.getUuid()).list());
 			});
 
 			// No field containers, migration is done


### PR DESCRIPTION
by using a Queue instead of a List of objects to be migrated
and removing migrated objects from the Queue.

## Abstract

Migration Jobs used a List of the objects to be migrated. During the migration, the objects were "enriched" with additional data which had all to be kept in memory (because the objects were kept in the List).
This has been changed from a List to a Queue, from which the objects are removed before actually migrated.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
