### PR TITLE
Change jobverticle to be no worker verticle, but to

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,14 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.21]]
+== 1.6.21 (TBD)
+
+icon:check[] Core: When eventbus messages where published during execution of a job (e.g. a node migration), the events were not published and handled immediately,
+but were queued in memory and eventually published after the job execution. This caused high memory consumption during a node migration and also the elasticsearch
+indexing of migrated nodes to be delayed until after all nodes had been migrated. Execution of the jobs has been changed now, so that events will be published
+immediately to fix those issues.
+
 [[v1.6.20]]
 == 1.6.20 (23.09.2021)
 

--- a/core/src/main/java/com/gentics/mesh/cli/CoreVerticleLoader.java
+++ b/core/src/main/java/com/gentics/mesh/cli/CoreVerticleLoader.java
@@ -92,9 +92,10 @@ public class CoreVerticleLoader {
 	}
 
 	private Completable deployJobWorkerVerticle() {
+		// the verticle is not deployed as worker verticle (any more). See comments of AbstractJobVerticle for details
 		return rxVertx.rxDeployVerticle(jobWorkerVerticle, new DeploymentOptions()
 			.setInstances(1)
-			.setWorker(true))
+			.setWorker(false))
 			.ignoreElement();
 	}
 


### PR DESCRIPTION
run jobs with executeBlocking (which enables immediate publishing of
events)

## Abstract

When the JobWorkerVerticle was deployed as worker verticle, eventbus messages published during the job execution were not published immediately. This seems to be caused by the fact, that the job execution itself is implemented in an event handler.

The JobWorkerVerticle is now no longer deployed as worker verticle, but job execution is now run as executeBlocking(), eventbus messages are now published immediately as expected.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
