### PR TITLE
Implement workaround for vert.x incorrectly handling non-local messages

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.21]]
+== 1.6.21 (TBD)
+
+icon:check[] Clustering: Due to a bug in the vert.x eventbus system, elasticsearch sync operations were not only performed in the Mesh instance, were the
+causing data change actually happened, but on all Mesh instances, which caused unnecessary high load on the elasticsearch. This has been fixed with a workaround.
+
 [[v1.6.20]]
 == 1.6.20 (23.09.2021)
 

--- a/common/src/main/java/com/gentics/mesh/event/EventQueueBatch.java
+++ b/common/src/main/java/com/gentics/mesh/event/EventQueueBatch.java
@@ -12,6 +12,10 @@ import com.gentics.mesh.core.rest.event.MeshEventModel;
  * A batch of event queue entries.
  */
 public interface EventQueueBatch {
+	/**
+	 * Name of the event header identifying the Mesh instance, which is sending the event
+	 */
+	public final static String SENDER_HEADER = "mesh.sender";
 
 	/**
 	 * Return the id of the batch.

--- a/common/src/main/java/com/gentics/mesh/event/impl/EventQueueBatchImpl.java
+++ b/common/src/main/java/com/gentics/mesh/event/impl/EventQueueBatchImpl.java
@@ -11,10 +11,12 @@ import com.gentics.mesh.core.rest.event.EventCauseAction;
 import com.gentics.mesh.core.rest.event.EventCauseInfo;
 import com.gentics.mesh.core.rest.event.EventCauseInfoImpl;
 import com.gentics.mesh.core.rest.event.MeshEventModel;
+import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.json.JsonUtil;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -37,9 +39,12 @@ public class EventQueueBatchImpl implements EventQueueBatch {
 
 	private final Vertx vertx;
 
+	private final MeshOptions options;
+
 	@Inject
-	public EventQueueBatchImpl(Vertx vertx) {
+	public EventQueueBatchImpl(Vertx vertx, MeshOptions options) {
 		this.vertx = vertx;
+		this.options = options;
 	}
 
 	@Override
@@ -86,7 +91,8 @@ public class EventQueueBatchImpl implements EventQueueBatch {
 			if (log.isTraceEnabled()) {
 				log.trace("Dispatching event '{}' with payload:\n{}", event, json);
 			}
-			eventbus.publish(event.getAddress(), new JsonObject(json));
+			eventbus.publish(event.getAddress(), new JsonObject(json),
+					new DeliveryOptions().addHeader(SENDER_HEADER, options.getNodeName()));
 		});
 		getEntries().clear();
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/ElasticsearchProcessVerticle.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/ElasticsearchProcessVerticle.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.search.verticle.eventhandler.Util.logElasticSearc
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,6 +23,7 @@ import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.event.MeshEventModel;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.etc.config.search.ElasticSearchOptions;
+import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.search.SearchProvider;
 import com.gentics.mesh.search.impl.ElasticsearchResponseErrorStreamable;
 import com.gentics.mesh.search.verticle.bulk.BulkOperator;
@@ -63,6 +65,7 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 	private final IdleChecker idleChecker;
 	private final SyncEventHandler syncEventHandler;
 	private final ElasticSearchOptions options;
+	private final String nodeName;
 
 	private FlowableProcessor<MessageEvent> requests = PublishProcessor.create();
 
@@ -82,6 +85,7 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 		this.idleChecker = idleChecker;
 		this.syncEventHandler = syncEventHandler;
 		this.options = options.getSearchOptions();
+		this.nodeName = options.getNodeName();
 	}
 
 	@Override
@@ -94,10 +98,14 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 				vertx.eventBus().publish(MeshEvent.SEARCH_IDLE.address, null);
 			});
 
+		// Note: although the handler is registered as localConsumer, there is no guarantee that it will really only handle local messages
+		// due to the vert.x bug https://github.com/eclipse-vertx/vert.x/issues/4116
+		// therefore the message is only handled, if it passes the check implemented in {@link #isLocal()}, which will check for an additional
+		// message header identifying the sender.
 		vertxHandlers = mainEventhandler.handledEvents()
 			.stream()
 			.map(event -> vertx.eventBus().<JsonObject>localConsumer(event.address, message -> {
-				if (!stopped.get() && !isDroppedEvent(message)) {
+				if (!stopped.get() && !isDroppedEvent(message) && isLocal(message)) {
 					idleChecker.incrementAndGetTransformations();
 					// Only continue processing the event if elasticsearch is available.
 					elasticsearchAvailable.filter(available -> available)
@@ -366,6 +374,23 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 			// For safety to keep the verticle always running
 			e.printStackTrace();
 			return Flowable.empty();
+		}
+	}
+
+	/**
+	 * Check whether the message is a local message.
+	 * The check will be done by comparing the message header {@link EventQueueBatch#SENDER_HEADER} with the node name
+	 * If the header is not found, the message is assumed to be local (i.e. will be handled)
+	 * @param message message to check
+	 * @return true if the message is assumed to be a local one
+	 */
+	private boolean isLocal(Message<JsonObject> message) {
+		if (message.headers().contains(EventQueueBatch.SENDER_HEADER)) {
+			// if the message contains the header, it is local if the value is equal to the name of this mesh instance
+			return Objects.equals(message.headers().get(EventQueueBatch.SENDER_HEADER), nodeName);
+		} else {
+			// if the message does not contain the header, it is assumed to be local
+			return true;
 		}
 	}
 


### PR DESCRIPTION
with localConsumer

## Abstract

A bug in vert.x causes the handler for eventbus messages to be called in all Mesh instances, even if the handler was registered with localConsumer(). This has been workarounded by adding a header to the message for identifying the sender and a check in the "local" consumer to ignore messages sent by other Mesh instances.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
