### PR TITLE
SUP-12285 return live member variable

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -40,6 +40,8 @@ icon:check[] Core: When deleting old versions of nodes, the related binaries wer
 
 icon:check[] Core: When an OrientDB transaction repeatedly fails and runs into the retry limit, the original cause will now also be logged.
 
+icon:check[] Server: When an OutOfMemory was caught or one of the plugins (permanently) failed to initialize, mesh was still considered to be live. This has been fixed now.
+
 [[v1.6.20]]
 == 1.6.20 (23.09.2021)
 

--- a/core/src/main/java/com/gentics/mesh/monitor/liveness/LivenessManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/monitor/liveness/LivenessManagerImpl.java
@@ -56,7 +56,7 @@ public class LivenessManagerImpl implements LivenessManager {
 
 	@Override
 	public boolean isLive() {
-		return true;
+		return live;
 	}
 
 	@Override


### PR DESCRIPTION
## Abstract
The **LivenessManagerImpl** was always returning true when **isLive()** was called.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
