### PR TITLE
Fix executing the changelog and storing Mesh version and DB revision

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -42,6 +42,10 @@ icon:check[] Core: When an OrientDB transaction repeatedly fails and runs into t
 
 icon:check[] Server: When an OutOfMemory was caught or one of the plugins (permanently) failed to initialize, mesh was still considered to be live. This has been fixed now.
 
+icon:check[] Clustering: When doing an offline update of Mesh in a cluster, the first instance of the cluster could not be started with the new Mesh version, because
+the new version should be written into OrientDB, which failed due to write quorum not reached. The initialization procedure has been changed now, so that executing the
+changelog and storing the Mesh version and DB revision will now only be started after the write quorum has been reached.
+
 [[v1.6.20]]
 == 1.6.20 (23.09.2021)
 

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -111,6 +111,7 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import ch.qos.logback.core.util.FileSize;
 import dagger.Lazy;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -130,6 +131,11 @@ import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 public class BootstrapInitializerImpl implements BootstrapInitializer {
 
 	private static Logger log = LoggerFactory.getLogger(BootstrapInitializer.class);
+
+	/**
+	 * Name of the global lock for executing the changelog in cluster mode
+	 */
+	public static final String GLOBAL_CHANGELOG_LOCK_KEY = "MESH_CHANGELOG_LOCK";
 
 	private static final String ADMIN_USERNAME = "admin";
 
@@ -766,11 +772,43 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 							+ MeshOptions.MESH_CLUSTER_INIT_ENV + " environment flag or the -" + MeshCLI.INIT_CLUSTER + " command line argument to migrate the database.");
 		}
 
-		// Now run the high level changelog entries, which are allowed to be executed in cluase mode
-		highlevelChangelogSystem.apply(flags, meshRoot, filter -> filter.isAllowedInCluster(configuration));
+		// wait for writeQuorum, then raise a global lock and execute changelog
+		db.clusterManager().waitUntilWriteQuorumReached()
+				.andThen(doWithLock(executeChangelog(flags, configuration), 60 * 1000)).subscribe();
+	}
 
-		log.info("Changelog completed.");
-		new ChangelogSystem(db, options).setCurrentVersionAndRev();
+	/**
+	 * Return a completable which will try to get a global lock with name {@link #GLOBAL_CHANGELOG_LOCK_KEY} and will then execute the locked action
+	 * @param lockedAction locked action
+	 * @param timeout timeout for waiting for the lock
+	 * @return completable
+	 */
+	protected Completable doWithLock(Completable lockedAction, long timeout) {
+		return mesh.getRxVertx().sharedData().rxGetLockWithTimeout(GLOBAL_CHANGELOG_LOCK_KEY, timeout).toMaybe()
+				.flatMapCompletable(lock -> {
+					log.debug("Acquired lock for executing changelog");
+					return lockedAction.doFinally(() -> {
+						log.debug("Releasing lock for executing changelog");
+						lock.release();
+					});
+				});
+	}
+
+	/**
+	 * Completable which will execute the highlevel changelog and will also store the (new) mesh version and DB revision to the DB
+	 * @param flags
+	 * @param configuration
+	 * @return
+	 */
+	protected Completable executeChangelog(PostProcessFlags flags, MeshOptions configuration) {
+		return Completable.defer(() -> {
+			// Now run the high level changelog entries, which are allowed to be executed in cluase mode
+			highlevelChangelogSystem.apply(flags, meshRoot, filter -> filter.isAllowedInCluster(configuration));
+
+			log.info("Changelog completed.");
+			new ChangelogSystem(db, options).setCurrentVersionAndRev();
+			return Completable.complete();
+		});
 	}
 
 	@Override


### PR DESCRIPTION
only when the write quorum has been reached and with a global lock.

## Abstract

When the first Mesh instance of a cluster was started with a new Mesh Version, executing the changelog and storing the Mesh version and DB revision in the DB would fail due to write quorum not reached.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
