### PR TITLE
Fix mesh to change back to being "live" when failed plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ orientdb-plugins
 keystore.jceks
 /bower_components/
 mesh.lock
+mesh.live
 /build
 /dist
 /node

--- a/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/manager/MeshPluginManagerImpl.java
@@ -105,16 +105,13 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 
 	private final ClusterManager clusterManager;
 
-	private final LivenessManager liveness;
-
 	@Inject
-	public MeshPluginManagerImpl(MeshOptions options, MeshPluginFactory pluginFactory, DelegatingPluginRegistry pluginRegistry, Database database, Lazy<Vertx> vertx, LivenessManager liveness) {
+	public MeshPluginManagerImpl(MeshOptions options, MeshPluginFactory pluginFactory, DelegatingPluginRegistry pluginRegistry, Database database, Lazy<Vertx> vertx) {
 		this.pluginFactory = pluginFactory;
 		this.options = options;
 		this.pluginRegistry = pluginRegistry;
 		this.vertx = vertx;
 		this.clusterManager = database.clusterManager();
-		this.liveness = liveness;
 		delayedInitialize();
 	}
 
@@ -540,13 +537,6 @@ public class MeshPluginManagerImpl extends AbstractPluginManager implements Mesh
 	public void setStatus(String id, PluginStatus status) {
 		pluginStatusMap.put(id, status);
 		log.debug("Plugin {} changed to status {}", id , status);
-
-		// if initialization of a plugin failed, the "liveness" is false
-		if (status == PluginStatus.FAILED) {
-			// set liveness to false
-			log.error("Liveness of Mesh instance is set to false, because plugin {} failed to initialize", id);
-			liveness.setLive(false, String.format("Plugin %s failed to initialize", id));
-		}
 	}
 
 	@Override

--- a/core/src/test/java/com/gentics/mesh/core/monitoring/MonitoringServerEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/monitoring/MonitoringServerEndpointTest.java
@@ -82,7 +82,7 @@ public class MonitoringServerEndpointTest extends AbstractMeshTest {
 		}
 		manager.undeploy("failing").blockingAwait(2, TimeUnit.SECONDS);
 		assertEquals(0, manager.getPluginIds().size());
-		call(() -> monClient().ready());
+		call(() -> monClient().live());
 	}
 
 	@Test


### PR DESCRIPTION
is undeployed.

## Abstract

The LivenessManager would permanently switch to "not live", if the initialization for a plugin failed and not switch back to "live" if that plugin was undeployed (like the liveness probe before).
This has been changed so that the LivenessManager will only change the internal "live" flag to false in case of unrecoverable errors (OutOfMemory) and will additionally check for failed plugins before touching the mesh.live file.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
