### PR TITLE
Fix Schema update api for elastic search settings

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,8 @@ include::content/docs/variables.adoc-include[]
 
 icon:check[] Server: added a health/writable monitoring and REST endpoint to check whether mesh is in a writable state (e.g. the topology lock is not hold).
 
+icon:check[] Server: when a schema was updated with a new field with elastic search properties, these were ignored. This has been fixed now.
+
 [[v1.7.19]]
 == 1.7.19 (12.10.2021)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/impl/AddFieldChangeImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/impl/AddFieldChangeImpl.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 import com.gentics.mesh.core.rest.schema.*;
 import com.gentics.mesh.core.rest.schema.impl.*;
+import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.BooleanUtils;
 
 import com.gentics.madl.index.IndexHandler;
@@ -173,12 +174,8 @@ public class AddFieldChangeImpl extends AbstractSchemaFieldChange implements Add
 			break;
 		default:
 			throw error(BAD_REQUEST, "Unknown type");
-		}field.setName(getFieldName());
-		field.setLabel(getLabel());
-		Boolean required = getRequired();
-		if (required != null) {
-			field.setRequired(required);
 		}
+		setCommonFieldProperties(field);
 		container.addField(field, position);
 		return container;
 	}
@@ -193,4 +190,16 @@ public class AddFieldChangeImpl extends AbstractSchemaFieldChange implements Add
 		getElement().remove();
 	}
 
+	private void setCommonFieldProperties(FieldSchema field) {
+		field.setName(getFieldName());
+		field.setLabel(getLabel());
+		Boolean required = getRequired();
+		if (required != null) {
+			field.setRequired(required);
+		}
+		JsonObject elasticSearch = getIndexOptions();
+		if (elasticSearch != null) {
+			field.setElasticsearch(elasticSearch);
+		}
+	}
 }

--- a/core/src/test/java/com/gentics/mesh/core/data/fieldhandler/AbstractSchemaComparatorTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/data/fieldhandler/AbstractSchemaComparatorTest.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperatio
 import java.io.IOException;
 import java.util.List;
 
+import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import com.gentics.mesh.FieldUtil;
@@ -47,11 +48,11 @@ public abstract class AbstractSchemaComparatorTest<T extends FieldSchema, C exte
 
 	/**
 	 * Test adding a field to a schema and assert that the expected change was generated.
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	@Test
-	public void testAddField() throws IOException {
+	public void testAddField() {
 		C containerA = createContainer();
 		containerA.setName("test");
 		containerA.addField(FieldUtil.createStringFieldSchema("first"));
@@ -62,14 +63,17 @@ public abstract class AbstractSchemaComparatorTest<T extends FieldSchema, C exte
 
 		// Add new field in B
 		T field = createField("test");
+		JsonObject indexSettings = new JsonObject().put("settings", "test");
+		field.setElasticsearch(indexSettings);
 		containerB.addField(field);
 
 		List<SchemaChangeModel> changes = getComparator().diff(containerA, containerB);
 		assertThat(changes).hasSize(2);
-		assertThat(changes.get(0)).is(ADDFIELD).forField("test").hasProperty("type", field.getType()).hasProperty("after", "first");
+		assertThat(changes.get(0)).is(ADDFIELD).forField("test")
+				.hasProperty("type", field.getType())
+				.hasProperty("after", "first")
+				.hasProperty("elasticsearch", indexSettings);
 		assertThat(changes.get(1)).isUpdateOperation(containerA);
-		//.hasProperty("order", new String[] { "first", "test" });
-
 	}
 
 	/**

--- a/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/MicroschemaChangesEndpointTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import io.vertx.core.json.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -96,7 +97,7 @@ public class MicroschemaChangesEndpointTest extends AbstractMeshTest {
 		String microschemaUuid = tx(() -> microschemaContainer.getUuid());
 
 		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
-		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "html", "fieldLabel");
+		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "html", "fieldLabel", new JsonObject().put("test", "test"));
 		listOfChanges.getChanges().add(change);
 
 		// 2. Invoke migration

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Objects;
 
+import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -375,7 +376,8 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 
 		// 1. Setup changes
 		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
-		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "html", "label1234");
+		JsonObject elasticSearch = new JsonObject().put("test", "test");
+		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "html", "label1234", elasticSearch);
 		listOfChanges.getChanges().add(change);
 
 		// 3. Invoke migration
@@ -401,7 +403,8 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 					boot().contentDao().getGraphFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
 			assertEquals("label1234",
 				boot().contentDao().getGraphFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField").getLabel());
-
+			assertEquals(elasticSearch,
+					boot().contentDao().getGraphFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField").getElasticsearch());
 		}
 	}
 	
@@ -414,7 +417,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 
 		// 1. Setup changes
 		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
-		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "string", "label1234");
+		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "string", "label1234", null);
 		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, new String[] {"5678"});
 		
 		listOfChanges.getChanges().add(change);
@@ -452,7 +455,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 
 		// 1. Setup changes
 		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
-		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "string", "label1234");
+		SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField", "string", "label1234", null);
 		change.getProperties().put(SchemaChangeModel.ALLOW_KEY, new String[] {"5678"});
 		
 		listOfChanges.getChanges().add(change);
@@ -528,7 +531,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 
 			// 1. Setup changes
 			SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
-			SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField_" + i, "html", null);
+			SchemaChangeModel change = SchemaChangeModel.createAddFieldChange("newField_" + i, "html", null, null);
 			listOfChanges.getChanges().add(change);
 
 			GenericMessageResponse status = call(() -> client().applyChangesToSchema(containerUuid, listOfChanges));

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaDiffEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaDiffEndpointTest.java
@@ -257,6 +257,23 @@ public class SchemaDiffEndpointTest extends AbstractMeshTest {
 		assertThat(change).is(UPDATEFIELD).forField("slug").hasProperty("elasticsearch", setting);
 	}
 
+	@Test
+	public void testESFieldDiffOnNewField() {
+		String schemaUuid = tx(() -> schemaContainer("content").getUuid());
+
+		SchemaModel request = getSchema();
+		StringFieldSchemaImpl testField = new StringFieldSchemaImpl();
+		testField.setName("test");
+		JsonObject setting = new JsonObject().put("test", "123");
+		testField.setElasticsearch(setting);
+		request.getFields().add(testField);
+
+		SchemaChangesListModel changes = call(() -> client().diffSchema(schemaUuid, request));
+		assertThat(changes.getChanges()).hasSize(2);
+		SchemaChangeModel change = changes.getChanges().get(0);
+		assertThat(change).is(ADDFIELD).forField("test").hasProperty("elasticsearch", setting);
+	}
+
 	/**
 	 * Diff the schema field with a schema field which sets the elasticsearch setting to null. Internally that should be transformed to set the setting to empty
 	 * json object.

--- a/core/src/test/java/com/gentics/mesh/core/schema/SchemaUpdateEndpointNewFieldsTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/SchemaUpdateEndpointNewFieldsTest.java
@@ -1,0 +1,63 @@
+package com.gentics.mesh.core.schema;
+
+import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.core.rest.schema.impl.SchemaUpdateRequest;
+import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.gentics.mesh.test.context.MeshTestSetting;
+import io.vertx.core.json.JsonObject;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestSize.FULL;
+
+@MeshTestSetting(testSize = FULL, startServer = true)
+public class SchemaUpdateEndpointNewFieldsTest extends AbstractMeshTest {
+
+    @Test
+    public void testCreateNewFieldWithElasticSearchProperties() {
+        // 1. create schema with single field
+        FieldSchema field1 = createFieldSchema("field1");
+        field1.setElasticsearch(new JsonObject().put("test", "123"));
+        SchemaResponse schema = createSchema(field1);
+
+        // 2. create a new field with elastic search properties
+        FieldSchema field2 = createFieldSchema("field2");
+        JsonObject elasticSearch = new JsonObject().put("test", "123");
+        field2.setElasticsearch(elasticSearch);
+
+        // 3. add the field to the update request
+        SchemaUpdateRequest schemaUpdateRequest = schema.toUpdateRequest();
+        schemaUpdateRequest.getFields().add(field2);
+
+        // 4. update the schema
+        call(() -> client().updateSchema(schema.getUuid(), schemaUpdateRequest));
+
+        // 5. make sure elastic search properties were saved
+        SchemaResponse response = call(() -> client().findSchemaByUuid(schema.getUuid()));
+        Assertions.assertThat(response.getField("field2", FieldSchema.class).getElasticsearch()).isEqualTo(elasticSearch);
+    }
+
+    private SchemaResponse createSchema(FieldSchema... schemas) {
+        SchemaCreateRequest request = new SchemaCreateRequest();
+        request.setName("test");
+        List<FieldSchema> fields = Arrays.stream(schemas).collect(Collectors.toList());
+        request.setFields(fields);
+
+        return client().createSchema(request).blockingGet();
+    }
+
+    private FieldSchema createFieldSchema(String name) {
+        FieldSchema schema = new StringFieldSchemaImpl();
+        schema.setName(name);
+        schema.setLabel(name);
+        return schema;
+    }
+}

--- a/core/src/test/java/com/gentics/mesh/core/schema/change/AddFieldChangeTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/schema/change/AddFieldChangeTest.java
@@ -2,13 +2,13 @@ package com.gentics.mesh.core.schema.change;
 
 import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
 import static com.gentics.mesh.test.TestSize.FULL;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import io.vertx.core.json.JsonObject;
 import org.assertj.core.api.AbstractObjectArrayAssert;
 import org.junit.Test;
 
@@ -448,7 +448,8 @@ public class AddFieldChangeTest extends AbstractChangeTest {
 	@Override
 	public void testUpdateFromRest() {
 		try (Tx tx = tx()) {
-			SchemaChangeModel model = SchemaChangeModel.createAddFieldChange("testField", "html", "test123");
+			JsonObject elasticSearch = new JsonObject().put("test", "test");
+			SchemaChangeModel model = SchemaChangeModel.createAddFieldChange("testField", "html", "test123", elasticSearch);
 
 			AddFieldChange change = tx.getGraph().addFramedVertex(AddFieldChangeImpl.class);
 			change.updateFromRest(model);

--- a/doc/src/main/java/com/gentics/mesh/generator/ModelExampleGenerator.java
+++ b/doc/src/main/java/com/gentics/mesh/generator/ModelExampleGenerator.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import io.vertx.core.json.JsonObject;
 import org.apache.commons.io.FileUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -56,7 +57,8 @@ public class ModelExampleGenerator extends AbstractGenerator {
 	 * @throws IOException
 	 */
 	private void writeChangeExamples() throws JsonProcessingException, IOException {
-		SchemaChangeModel addFieldChange = SchemaChangeModel.createAddFieldChange("fieldToBeAdded", "list", "Field Label Value");
+		JsonObject elasticSearchSettings = new JsonObject().put("settings", "value");
+		SchemaChangeModel addFieldChange = SchemaChangeModel.createAddFieldChange("fieldToBeAdded", "list", "Field Label Value", elasticSearchSettings);
 		addFieldChange.setProperty(ADD_FIELD_AFTER_KEY, "firstField");
 		addFieldChange.setProperty(LIST_TYPE_KEY, "html");
 		writeJson(addFieldChange, "addfield.json");

--- a/mdm/common/src/main/java/com/gentics/mesh/example/SchemaExamples.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/example/SchemaExamples.java
@@ -25,6 +25,7 @@ import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
 import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaUpdateRequest;
 import com.gentics.mesh.core.rest.schema.impl.StringFieldSchemaImpl;
+import io.vertx.core.json.JsonObject;
 
 public class SchemaExamples extends AbstractExamples {
 
@@ -121,7 +122,7 @@ public class SchemaExamples extends AbstractExamples {
 	public SchemaChangesListModel getSchemaChangesListModel() {
 		SchemaChangesListModel model = new SchemaChangesListModel();
 		// Add field
-		SchemaChangeModel addFieldChange = SchemaChangeModel.createAddFieldChange("listFieldToBeAddedField", "list", "Field Label Value");
+		SchemaChangeModel addFieldChange = SchemaChangeModel.createAddFieldChange("listFieldToBeAddedField", "list", "Field Label Value", new JsonObject().put("key", "value"));
 		addFieldChange.setProperty(SchemaChangeModel.LIST_TYPE_KEY, "html");
 		model.getChanges().add(addFieldChange);
 

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/schema/handler/AbstractFieldSchemaContainerComparator.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/schema/handler/AbstractFieldSchemaContainerComparator.java
@@ -87,7 +87,7 @@ public abstract class AbstractFieldSchemaContainerComparator<FC extends FieldSch
 				if (log.isDebugEnabled()) {
 					log.debug("Field " + fieldInB.getName() + " was added.");
 				}
-				SchemaChangeModel change = SchemaChangeModel.createAddFieldChange(fieldInB.getName(), fieldInB.getType(), fieldInB.getLabel());
+				SchemaChangeModel change = SchemaChangeModel.createAddFieldChange(fieldInB.getName(), fieldInB.getType(), fieldInB.getLabel(), fieldInB.getElasticsearch());
 				if (fieldInB instanceof ListFieldSchema) {
 					ListFieldSchema listFieldInB = (ListFieldSchema) fieldInB;
 					change.setProperty(SchemaChangeModel.LIST_TYPE_KEY, listFieldInB.getListType());

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/schema/handler/FieldSchemaComparator.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/schema/handler/FieldSchemaComparator.java
@@ -26,7 +26,7 @@ public class FieldSchemaComparator {
 			return change;
 		} else if (fieldSchemaA == null && fieldSchemaB != null) {
 			return SchemaChangeModel.createAddFieldChange(fieldSchemaB.getName(), fieldSchemaB.getType(),
-					fieldSchemaB.getLabel());
+					fieldSchemaB.getLabel(), fieldSchemaB.getElasticsearch());
 		}
 
 		return null;

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.common.RestModel;
+import io.vertx.core.json.JsonObject;
 
 /**
  * POJO for a schema change.
@@ -207,18 +208,19 @@ public class SchemaChangeModel implements RestModel {
 	/**
 	 * Create a add field change.
 	 * 
-	 * @param fieldName
-	 *            Field key
-	 * @param type
-	 *            Field type
-	 * @param label
-	 *            Field label
+	 * @param fieldName Field key
+	 * @param type Field type
+	 * @param label Field label
+	 * @param elasticSearch Field elastic search properties
 	 * @return
 	 */
-	public static SchemaChangeModel createAddFieldChange(String fieldName, String type, String label) {
+	public static SchemaChangeModel createAddFieldChange(String fieldName, String type, String label, JsonObject elasticSearch) {
 		SchemaChangeModel change = new SchemaChangeModel(ADDFIELD, fieldName);
 		change.getProperties().put(SchemaChangeModel.TYPE_KEY, type);
 		change.getProperties().put(SchemaChangeModel.LABEL_KEY, label);
+		if (elasticSearch != null) {
+			change.getProperties().put(SchemaChangeModel.ELASTICSEARCH_KEY, elasticSearch.encode());
+		}
 		return change;
 	}
 

--- a/test-common/src/main/java/com/gentics/mesh/assertj/impl/SchemaChangeModelAssert.java
+++ b/test-common/src/main/java/com/gentics/mesh/assertj/impl/SchemaChangeModelAssert.java
@@ -73,6 +73,9 @@ public class SchemaChangeModelAssert extends AbstractAssert<SchemaChangeModelAss
 			assertArrayEquals("The value for the given property did not match the expected one." + values, (Object[]) value, (Object[]) actualValue);
 		} else if (value instanceof JsonObject) {
 			Object current = actual.getProperties().get(key);
+			if (current instanceof String) {
+				current = new JsonObject((String) current);;
+			}
 			if (current instanceof LinkedHashMap) {
 				current = new JsonObject((Map) current);
 			}


### PR DESCRIPTION
## Abstract
At the moment, the schema update REST api is omitting elastic search properties of new fields.
This fix the problem. The main changes were done in **SchemaChangeModel#createAddFieldChange()** and in **AddFieldChangeImpl#apply()**.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
