### PR TITLE
Add periodic check for elasticsearch indices.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,19 @@ icon:check[] Server: added a health/writable monitoring and REST endpoint to che
 
 icon:check[] Server: when a schema was updated with a new field with elastic search properties, these were ignored. This has been fixed now.
 
+icon:check[] Search: If ElasticSearch indices, which were originally created by Mesh were dropped, they would probably be re-created with the default mapping when Mesh
+stored a document in the index. This could cause the index to be not completely filled and also the mapping to be incorrect, so that search queries would fail to find
+documents. In order to detect and repair such situations, a periodic check has been added to Mesh, which will check existence and correctness of all required ElasticSearch
+indices. Missing indices will be created and incorrect indices will be dropped and re-created. Afterwards a full sync for the affected indices will be triggered. The check
+period can be configured with the new configuration setting `search.indexCheckInterval`, which defaults to 60_000 milliseconds. Setting the interval to 0 will disable the
+periodic check (not recommended).
+
+icon:plus[] Search: The index maintenance endpoints `/api/v1/search/sync` and `/api/v1/search/clear` have been extended with the query parameter `index`, which can be used
+to restrict the synchronized/cleared indices by a regular expression.
+
+icon:check[] Search: The index maintenance actions triggered via `/api/v1/search/sync` and `/api/v1/search/clear` will now be redirected to the current master instance,
+if the cluster coordinator is used.
+
 [[v1.7.19]]
 == 1.7.19 (12.10.2021)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -19,8 +19,20 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 [[v1.6.22]]
 == 1.6.22 (TBD)
-
 icon:check[] Server: when a schema was updated with a new field with elastic search properties, these were ignored. This has been fixed now.
+
+icon:check[] Search: If ElasticSearch indices, which were originally created by Mesh were dropped, they would probably be re-created with the default mapping when Mesh
+stored a document in the index. This could cause the index to be not completely filled and also the mapping to be incorrect, so that search queries would fail to find
+documents. In order to detect and repair such situations, a periodic check has been added to Mesh, which will check existence and correctness of all required ElasticSearch
+indices. Missing indices will be created and incorrect indices will be dropped and re-created. Afterwards a full sync for the affected indices will be triggered. The check
+period can be configured with the new configuration setting `search.indexCheckInterval`, which defaults to 60_000 milliseconds. Setting the interval to 0 will disable the
+periodic check (not recommended).
+
+icon:plus[] Search: The index maintenance endpoints `/api/v1/search/sync` and `/api/v1/search/clear` have been extended with the query parameter `index`, which can be used
+to restrict the synchronized/cleared indices by a regular expression.
+
+icon:check[] Search: The index maintenance actions triggered via `/api/v1/search/sync` and `/api/v1/search/clear` will now be redirected to the current master instance,
+if the cluster coordinator is used.
 
 [[v1.6.21]]
 == 1.6.21 (12.10.2021)

--- a/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
@@ -43,6 +43,9 @@ public class ElasticSearchOptions implements Option {
 
 	public static final boolean DEFAULT_HOSTNAME_VERIFICATION = true;
 
+	public static final long DEFAULT_INDEX_CHECK_INTERVAL = 60 * 1000;
+	public static final long DEFAULT_INDEX_MAPPING_CACHE_TIMEOUT = 60 * 60 * 1000;
+
 	public static final String MESH_ELASTICSEARCH_URL_ENV = "MESH_ELASTICSEARCH_URL";
 	public static final String MESH_ELASTICSEARCH_USERNAME_ENV = "MESH_ELASTICSEARCH_USERNAME";
 	public static final String MESH_ELASTICSEARCH_PASSWORD_ENV = "MESH_ELASTICSEARCH_PASSWORD";
@@ -66,6 +69,9 @@ public class ElasticSearchOptions implements Option {
 	public static final String MESH_ELASTICSEARCH_SYNC_BATCH_SIZE_ENV = "MESH_ELASTICSEARCH_SYNC_BATCH_SIZE";
 	public static final String MESH_ELASTICSEARCH_HOSTNAME_VERIFICATION_ENV = "MESH_ELASTICSEARCH_HOSTNAME_VERIFICATION";
 	public static final String MESH_ELASTICSEARCH_INCLUDE_BINARY_FIELDS_ENV = "MESH_ELASTICSEARCH_INCLUDE_BINARY_FIELDS";
+
+	public static final String MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL_ENV = "MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL";
+	public static final String MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT_ENV = "MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Elasticsearch connection url to be used. Set this setting to null will disable the Elasticsearch support.")
@@ -189,6 +195,16 @@ public class ElasticSearchOptions implements Option {
 	@JsonPropertyDescription("Configure the index sync batch size. Default: " + DEFAULT_SYNC_BATCH_SIZE)
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_SYNC_BATCH_SIZE_ENV, description = "Override the search sync batch size")
 	private int syncBatchSize = DEFAULT_SYNC_BATCH_SIZE;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Set the interval of index checks in ms. Default: " + DEFAULT_INDEX_CHECK_INTERVAL)
+	@EnvironmentVariable(name = MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL_ENV, description = "Override the interval for index checks")
+	private long indexCheckInterval = DEFAULT_INDEX_CHECK_INTERVAL;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Set the timeout for the cache of index mappings in ms. Default: " + DEFAULT_INDEX_MAPPING_CACHE_TIMEOUT)
+	@EnvironmentVariable(name = MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT_ENV, description = "Override the timeout for the cache if index mappings")
+	private long indexMappingCacheTimeout = DEFAULT_INDEX_MAPPING_CACHE_TIMEOUT;
 
 	public ElasticSearchOptions() {
 
@@ -479,5 +495,37 @@ public class ElasticSearchOptions implements Option {
 
 	public void setSyncBatchSize(int batchSize) {
 		this.syncBatchSize = batchSize;
+	}
+
+	/**
+	 * Index check interval in ms
+	 * @return interval
+	 */
+	public long getIndexCheckInterval() {
+		return indexCheckInterval;
+	}
+
+	/**
+	 * Set the index check interval in ms
+	 * @param indexCheckInterval interval
+	 */
+	public void setIndexCheckInterval(long indexCheckInterval) {
+		this.indexCheckInterval = indexCheckInterval;
+	}
+
+	/**
+	 * Timeout for the cache of index mappings in ms
+	 * @return timeout
+	 */
+	public long getIndexMappingCacheTimeout() {
+		return indexMappingCacheTimeout;
+	}
+
+	/**
+	 * Set the timeout for the cache of index mappings
+	 * @param indexMappingCacheTimeout timeout
+	 */
+	public void setIndexMappingCacheTimeout(long indexMappingCacheTimeout) {
+		this.indexMappingCacheTimeout = indexMappingCacheTimeout;
 	}
 }

--- a/common-api/src/main/java/com/gentics/mesh/search/SearchProvider.java
+++ b/common-api/src/main/java/com/gentics/mesh/search/SearchProvider.java
@@ -150,7 +150,16 @@ public interface SearchProvider {
 	 * 
 	 * @return Completable for the clear action
 	 */
-	Completable clear();
+	default Completable clear() {
+		return clear(null);
+	}
+
+	/**
+	 * Delete all indices which are managed by mesh and match the optionally provided index pattern (clear all, if pattern is null)
+	 * @param indexPattern optional index pattern
+	 * @return Completable for the clear action
+	 */
+	Completable clear(String indexPattern);
 
 	/**
 	 * Delete the given index and don't fail if the index is not existing.
@@ -258,4 +267,13 @@ public interface SearchProvider {
 	 * @return
 	 */
 	boolean isActive();
+
+	/**
+	 * Check existence and correctness the given index
+	 * @param info index info
+	 * @return completable
+	 */
+	default Completable check(IndexInfo info) {
+		return Completable.complete();
+	}
 }

--- a/common/src/main/java/com/gentics/mesh/search/DevNullSearchProvider.java
+++ b/common/src/main/java/com/gentics/mesh/search/DevNullSearchProvider.java
@@ -121,7 +121,7 @@ public class DevNullSearchProvider implements SearchProvider {
 	}
 
 	@Override
-	public Completable clear() {
+	public Completable clear(String indexPattern) {
 		return Completable.complete();
 	}
 

--- a/common/src/main/java/com/gentics/mesh/search/SearchMappingsCache.java
+++ b/common/src/main/java/com/gentics/mesh/search/SearchMappingsCache.java
@@ -1,0 +1,17 @@
+package com.gentics.mesh.search;
+
+import com.gentics.mesh.cache.MeshCache;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Interface for the cache of expected search mappings
+ */
+public interface SearchMappingsCache extends MeshCache<String, JsonObject> {
+	/**
+	 * Put the value into the cache
+	 * @param key cache key
+	 * @param value cached value
+	 */
+	void put(String key, JsonObject value);
+}

--- a/common/src/main/java/com/gentics/mesh/search/TrackingSearchProviderImpl.java
+++ b/common/src/main/java/com/gentics/mesh/search/TrackingSearchProviderImpl.java
@@ -198,7 +198,7 @@ public class TrackingSearchProviderImpl implements TrackingSearchProvider {
 	}
 
 	@Override
-	public Completable clear() {
+	public Completable clear(String indexPattern) {
 		updateEvents.clear();
 		deleteEvents.clear();
 		storeEvents.clear();

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -664,7 +664,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 		}
 
 		if (isSearchEnabled && (flags.isReindex() || flags.isResync())) {
-			SyncEventHandler.invokeSync(vertx);
+			SyncEventHandler.invokeSync(vertx, null);
 		}
 
 		// Handle admin password reset

--- a/core/src/main/java/com/gentics/mesh/dagger/module/CommonBindModule.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/module/CommonBindModule.java
@@ -111,6 +111,8 @@ import com.gentics.mesh.router.RouterStorageRegistry;
 import com.gentics.mesh.router.RouterStorageRegistryImpl;
 import com.gentics.mesh.search.IndexHandlerRegistry;
 import com.gentics.mesh.search.IndexHandlerRegistryImpl;
+import com.gentics.mesh.search.SearchMappingsCache;
+import com.gentics.mesh.search.impl.SearchMappingsCacheImpl;
 import com.gentics.mesh.search.index.common.DropIndexHandler;
 import com.gentics.mesh.search.index.common.DropIndexHandlerImpl;
 import com.gentics.mesh.search.index.group.GroupIndexHandler;
@@ -343,4 +345,7 @@ public abstract class CommonBindModule {
 
 	@Binds
 	abstract LivenessManager bindLivenessManager(LivenessManagerImpl e);
+
+	@Binds
+	abstract SearchMappingsCache searchMappingsCache(SearchMappingsCacheImpl e);
 }

--- a/core/src/main/java/com/gentics/mesh/rest/MeshLocalClientImpl.java
+++ b/core/src/main/java/com/gentics/mesh/rest/MeshLocalClientImpl.java
@@ -1053,15 +1053,15 @@ public class MeshLocalClientImpl implements MeshLocalClient {
 	}
 
 	@Override
-	public MeshRequest<GenericMessageResponse> invokeIndexClear() {
-		LocalActionContextImpl<GenericMessageResponse> ac = createContext(GenericMessageResponse.class);
+	public MeshRequest<GenericMessageResponse> invokeIndexClear(ParameterProvider... parameters) {
+		LocalActionContextImpl<GenericMessageResponse> ac = createContext(GenericMessageResponse.class, parameters);
 		adminIndexHandler.handleClear(ac);
 		return new MeshLocalRequestImpl<>(ac.getFuture());
 	}
 
 	@Override
-	public MeshRequest<GenericMessageResponse> invokeIndexSync() {
-		LocalActionContextImpl<GenericMessageResponse> ac = createContext(GenericMessageResponse.class);
+	public MeshRequest<GenericMessageResponse> invokeIndexSync(ParameterProvider... parameters) {
+		LocalActionContextImpl<GenericMessageResponse> ac = createContext(GenericMessageResponse.class, parameters);
 		adminIndexHandler.handleSync(ac);
 		return new MeshLocalRequestImpl<>(ac.getFuture());
 	}

--- a/core/src/main/java/com/gentics/mesh/search/SearchEndpointImpl.java
+++ b/core/src/main/java/com/gentics/mesh/search/SearchEndpointImpl.java
@@ -27,6 +27,7 @@ import com.gentics.mesh.core.rest.tag.TagFamilyListResponse;
 import com.gentics.mesh.core.rest.tag.TagListResponse;
 import com.gentics.mesh.core.rest.user.UserListResponse;
 import com.gentics.mesh.graphdb.spi.Database;
+import com.gentics.mesh.parameter.impl.IndexMaintenanceParametersImpl;
 import com.gentics.mesh.parameter.impl.PagingParametersImpl;
 import com.gentics.mesh.parameter.impl.SearchParametersImpl;
 import com.gentics.mesh.rest.InternalEndpointRoute;
@@ -167,6 +168,7 @@ public class SearchEndpointImpl extends AbstractInternalEndpoint implements Sear
 		indexClearEndpoint.path("/clear");
 		indexClearEndpoint.method(POST);
 		indexClearEndpoint.produces(APPLICATION_JSON);
+		indexClearEndpoint.addQueryParameters(IndexMaintenanceParametersImpl.class);
 		indexClearEndpoint.description("Drops all indices and recreates them. The index sync is not invoked automatically.");
 		indexClearEndpoint.exampleResponse(OK, miscExamples.createMessageResponse(), "Recreated all indices.");
 		indexClearEndpoint.handler(rc -> {
@@ -178,6 +180,7 @@ public class SearchEndpointImpl extends AbstractInternalEndpoint implements Sear
 		indexSyncEndpoint.path("/sync");
 		indexSyncEndpoint.method(POST);
 		indexSyncEndpoint.produces(APPLICATION_JSON);
+		indexSyncEndpoint.addQueryParameters(IndexMaintenanceParametersImpl.class);
 		indexSyncEndpoint.description(
 			"Invokes the manual synchronisation of the search indices. This operation may take some time to complete and is performed asynchronously. When clustering is enabled it will be executed on any free instance.");
 		indexSyncEndpoint.exampleResponse(OK, miscExamples.createMessageResponse(), "Invoked index synchronisation on all indices.");

--- a/core/src/test/java/com/gentics/mesh/search/index/IndexClearTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/IndexClearTest.java
@@ -5,24 +5,31 @@ import static com.gentics.mesh.core.rest.MeshEvent.INDEX_SYNC_FINISHED;
 import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.context.ElasticsearchTestMode.CONTAINER_ES6;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
+import org.junit.Before;
 import org.junit.Test;
 
-import com.gentics.elasticsearch.client.HttpErrorException;
+import com.gentics.mesh.core.data.Project;
 import com.gentics.mesh.core.data.User;
 import com.gentics.mesh.core.rest.common.GenericMessageResponse;
+import com.gentics.mesh.parameter.client.IndexMaintenanceParametersImpl;
 import com.gentics.mesh.search.verticle.eventhandler.SyncEventHandler;
 import com.gentics.mesh.test.TestSize;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
+
 @MeshTestSetting(elasticsearch = CONTAINER_ES6, testSize = TestSize.FULL, startServer = true)
 public class IndexClearTest extends AbstractMeshTest {
+	@Before
+	public void setup() throws Exception {
+		getProvider().clear().blockingAwait();
+		syncIndex();
+		revokeAdmin();
+	}
 
 	@Test
 	public void testClear() throws Exception {
-		waitForEvent(INDEX_SYNC_FINISHED, () -> SyncEventHandler.invokeSync(vertx()));
+		waitForEvent(INDEX_SYNC_FINISHED, () -> SyncEventHandler.invokeSync(vertx(), null));
 
 		call(() -> client().invokeIndexClear(), FORBIDDEN, "error_admin_permission_required");
 		grantAdmin();
@@ -30,13 +37,47 @@ public class IndexClearTest extends AbstractMeshTest {
 		GenericMessageResponse message = call(() -> client().invokeIndexClear());
 		assertThat(message).matches("search_admin_index_clear");
 
-		try {
-			getProvider().getDocument(User.composeIndexName(), userUuid()).blockingGet();
-			fail("An error should occur");
-		} catch (Exception e) {
-			HttpErrorException error = (HttpErrorException) e.getCause();
-			assertEquals(404, error.getStatusCode());
-		}
+		assertDocumentDoesNotExist(User.composeIndexName(), User.composeDocumentId(userUuid()));
 
+	}
+
+	/**
+	 * Test that clearing the index restricted by name only clears the specified index
+	 * @throws Exception
+	 */
+	@Test
+	public void testClearWithName() throws Exception {
+		runClearTest(false);
+	}
+
+	/**
+	 * Test that clearing indices can also be done with the full name (including the installation prefix)
+	 * @throws Exception
+	 */
+	@Test
+	public void testClearWithFullName() throws Exception {
+		runClearTest(true);
+	}
+
+	/**
+	 * Run the clear test
+	 * @param prefix true to use the prefixed index name, false to use the bare index name
+	 * @throws Exception
+	 */
+	protected void runClearTest(boolean prefix) throws Exception {
+		String index = prefix ? "mesh-user" : "user";
+		grantAdmin();
+
+		// check that the project is found in index
+		assertDocumentExists(Project.composeIndexName(), Project.composeDocumentId(projectUuid()));
+		// check that the user is found in index
+		assertDocumentExists(User.composeIndexName(), User.composeDocumentId(userUuid()));
+
+		call(() -> client().invokeIndexClear(new IndexMaintenanceParametersImpl().setIndex(index)));
+
+		// check that the project is still found in index
+		assertDocumentExists(Project.composeIndexName(), Project.composeDocumentId(projectUuid()));
+		// check that the user is no longer found in index
+		assertDocumentDoesNotExist(User.composeIndexName(), User.composeDocumentId(userUuid()));
 	}
 }

--- a/core/src/test/java/com/gentics/mesh/search/index/IndexSyncCleanupTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/index/IndexSyncCleanupTest.java
@@ -25,9 +25,12 @@ import com.gentics.mesh.core.data.User;
 import com.gentics.mesh.core.data.schema.Microschema;
 import com.gentics.mesh.core.data.schema.Schema;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
+import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.parameter.client.IndexMaintenanceParametersImpl;
 import com.gentics.mesh.test.TestSize;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
+import com.gentics.mesh.test.context.helper.ExpectedEvent;
 
 import io.vertx.core.json.JsonObject;
 
@@ -35,7 +38,9 @@ import io.vertx.core.json.JsonObject;
 public class IndexSyncCleanupTest extends AbstractMeshTest {
 
 	@Before
-	public void setup() {
+	public void setup() throws Exception {
+		getProvider().clear().blockingAwait();
+		syncIndex();
 		grantAdmin();
 	}
 
@@ -92,6 +97,49 @@ public class IndexSyncCleanupTest extends AbstractMeshTest {
 
 	}
 
+	/**
+	 * Test that synchronizing indices restricted to name only synchronizes the specified index
+	 * @throws Exception
+	 */
+	@Test
+	public void testSyncWithName() throws Exception {
+		runSyncTest(false);
+	}
+
+	/**
+	 * Test that synchronizing indices restricted to name only synchronizes the specified index
+	 * @throws Exception
+	 */
+	@Test
+	public void testSyncWithFullName() throws Exception {
+		runSyncTest(true);
+	}
+
+	/**
+	 * Run the sync test
+	 * @param prefix true to use the prefixed index name, false to use the bare index name
+	 * @throws Exception
+	 */
+	protected void runSyncTest(boolean prefix) throws Exception {
+		int timeout = 10_000;
+		String index = prefix ? "mesh-user" : "user";
+
+		// drop indices for user and project
+		deleteIndex("mesh-user", "mesh-project");
+		// recreate invalid indices for user and project
+		createThirdPartyIndex("mesh-" + User.composeIndexName());
+		createThirdPartyIndex("mesh-" + Project.composeIndexName());
+
+		try (ExpectedEvent syncFinished = expectEvent(MeshEvent.INDEX_SYNC_FINISHED, timeout)) {
+			call(() -> client().invokeIndexSync(new IndexMaintenanceParametersImpl().setIndex(index)));
+		}
+
+		// check that the project is not found in index
+		assertDocumentDoesNotExist(Project.composeIndexName(), Project.composeDocumentId(projectUuid()));
+		// check that the user is found in index
+		assertDocumentExists(User.composeIndexName(), User.composeDocumentId(userUuid()));
+	}
+
 	private void createThirdPartyIndex(String name) throws HttpErrorException {
 		ElasticsearchClient<JsonObject> searchClient = searchProvider().getClient();
 		JsonObject response = searchClient.createIndex(name, new JsonObject()).sync();
@@ -100,6 +148,11 @@ public class IndexSyncCleanupTest extends AbstractMeshTest {
 
 	private void createIndex(String name) {
 		searchProvider().createIndex(new IndexInfo(name, new JsonObject(), new JsonObject(), "")).blockingAwait();
+	}
+
+	private void deleteIndex(String...indexNames) throws HttpErrorException {
+		ElasticsearchClient<JsonObject> searchClient = searchProvider().getClient();
+		searchClient.deleteIndex(indexNames).sync();
 	}
 
 	public Set<String> indices() throws HttpErrorException {

--- a/core/src/test/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -479,6 +479,10 @@ public class MeshTestContext extends TestWatcher {
 		if (settings == null) {
 			throw new RuntimeException("Settings could not be found. Did you forgot to add the @MeshTestSetting annotation to your test?");
 		}
+
+		// disable periodic index check
+		meshOptions.getSearchOptions().setIndexCheckInterval(0);
+
 		// Clustering options
 		if (settings.clusterMode()) {
 			meshOptions.getClusterOptions().setEnabled(true);

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/ExpectedEvent.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/ExpectedEvent.java
@@ -11,7 +11,7 @@ import io.vertx.core.eventbus.MessageConsumer;
 /**
  * AutoClosable implementation, which will register an event handler upon
  * creation and will wait (up to the given timeout) in
- * {@link ExpectedEvent#clone()} for the event to be fired at least once.
+ * {@link ExpectedEvent#close()} for the event to be fired at least once.
  * See {@link EventHelper#expectEvent(com.gentics.mesh.core.rest.MeshEvent, int)} for usage.
  */
 public class ExpectedEvent implements AutoCloseable {
@@ -53,7 +53,8 @@ public class ExpectedEvent implements AutoCloseable {
 			}
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
+		} finally {
+			consumer.unregister();
 		}
-		consumer.unregister();
 	}
 }

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/UnexpectedEvent.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/UnexpectedEvent.java
@@ -1,0 +1,52 @@
+package com.gentics.mesh.test.context.helper;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+
+/**
+ * AutoClosable implementation, which will register an event handler upon
+ * creation and will wait (up to the given timeout) in
+ * {@link UnexpectedEvent#close()} for the event to be fired. If the event was fired, an exception is thrown.
+ * See {@link EventHelper#notExpectEvent(com.gentics.mesh.core.rest.MeshEvent, int)} for usage.
+ */
+
+public class UnexpectedEvent implements AutoCloseable {
+	protected CountDownLatch latch = new CountDownLatch(1);
+
+	protected String address;
+
+	protected int timeoutMs;
+
+	protected MessageConsumer<Object> consumer;
+
+	/**
+	 * Create an instance and register the event handler
+	 * @param vertx vertx instance
+	 * @param address event address
+	 * @param timeoutMs timeout in milliseconds
+	 */
+	public UnexpectedEvent(Vertx vertx, String address, int timeoutMs) {
+		this.address = address;
+		this.timeoutMs = timeoutMs;
+		consumer = vertx.eventBus().consumer(address);
+		consumer.handler(msg -> latch.countDown());
+	}
+
+	@Override
+	public void close() {
+		try {
+			if (latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+				fail("Event " + address + " was handled at least once within timeout");
+			}
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} finally {
+			consumer.unregister();
+		}
+	}
+}

--- a/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/Coordinator.java
+++ b/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/Coordinator.java
@@ -24,6 +24,10 @@ public class Coordinator {
 		this.mode = options.getClusterOptions().getCoordinatorMode();
 	}
 
+	/**
+	 * Get the current master server, may be null
+	 * @return current master, may be null
+	 */
 	public MasterServer getMasterMember() {
 		return elector.getMasterMember();
 	}
@@ -75,6 +79,11 @@ public class Coordinator {
 	 * @return
 	 */
 	public boolean isMaster() {
-		return getMasterMember().isSelf();
+		MasterServer masterMember = getMasterMember();
+		if (masterMember != null) {
+			return masterMember.isSelf();
+		} else {
+			return false;
+		}
 	}
 }

--- a/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/MasterElector.java
+++ b/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/MasterElector.java
@@ -325,9 +325,8 @@ public class MasterElector {
 	}
 
 	/**
-	 * Return the master server information.
-	 * 
-	 * @return
+	 * Get the server, which is currently the master, may be null
+	 * @return current master, may be null
 	 */
 	public MasterServer getMasterMember() {
 		if (masterMember == null) {

--- a/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/proxy/RequestDelegatorImpl.java
+++ b/distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/proxy/RequestDelegatorImpl.java
@@ -173,6 +173,11 @@ public class RequestDelegatorImpl implements RequestDelegator {
 		}
 	}
 
+	@Override
+	public boolean isMaster() {
+		return coordinator.isMaster();
+	}
+
 	/**
 	 * Log the given messages with loglevel <code>TRACE</code>.
 	 *

--- a/doc/src/main/docs/generated/tables/IndexMaintenanceParametersImpl.adoc-include
+++ b/doc/src/main/docs/generated/tables/IndexMaintenanceParametersImpl.adoc-include
@@ -1,0 +1,15 @@
+[options="header",cols="10%,20%,10%,60%"]
+|======
+
+| Name
+| Type
+| Mandatory
+| Description
+
+
+| index
+| string 
+| false
+| Index pattern to handle
+
+|======

--- a/doc/src/main/docs/generated/tables/SearchIndexSyncEventModel.adoc-include
+++ b/doc/src/main/docs/generated/tables/SearchIndexSyncEventModel.adoc-include
@@ -1,0 +1,25 @@
+[options="header",cols="10%,10%,10%,70%"]
+|======
+
+| Property
+| Mandatory 
+| Type
+| Description
+
+
+| cause
+| true
+| object
+| Some events will be caused by another action. This object contains information about the cause of the event.
+
+| indexPattern
+| true
+| string
+| Index pattern
+
+| origin
+| true
+| string
+| Name of the mesh node from which the event originates.
+
+|======

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
@@ -11,17 +11,25 @@ import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERR
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.gentics.elasticsearch.client.ElasticsearchClient;
 import com.gentics.elasticsearch.client.HttpErrorException;
+import com.gentics.mesh.core.data.search.IndexHandler;
 import com.gentics.mesh.core.data.search.bulk.BulkEntry;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
 import com.gentics.mesh.core.data.search.request.Bulkable;
@@ -29,7 +37,9 @@ import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.etc.config.search.ComplianceMode;
 import com.gentics.mesh.etc.config.search.ElasticSearchOptions;
 import com.gentics.mesh.search.ElasticsearchProcessManager;
+import com.gentics.mesh.search.SearchMappingsCache;
 import com.gentics.mesh.search.SearchProvider;
+import com.gentics.mesh.search.verticle.eventhandler.SyncEventHandler;
 import com.gentics.mesh.util.UUIDUtil;
 
 import dagger.Lazy;
@@ -70,12 +80,15 @@ public class ElasticSearchProvider implements SearchProvider {
 
 	private final ComplianceMode complianceMode;
 
+	private final Lazy<SearchMappingsCache> searchMappingsCache;
+
 	@Inject
-	public ElasticSearchProvider(Lazy<Vertx> vertx, MeshOptions options, ElasticsearchClient<JsonObject> client) {
+	public ElasticSearchProvider(Lazy<Vertx> vertx, MeshOptions options, ElasticsearchClient<JsonObject> client, Lazy<SearchMappingsCache> searchMappingsCache) {
 		this.vertx = vertx;
 		this.options = options;
 		this.client = client;
 		this.complianceMode = options.getSearchOptions().getComplianceMode();
+		this.searchMappingsCache = searchMappingsCache;
 	}
 
 	/**
@@ -143,7 +156,18 @@ public class ElasticSearchProvider implements SearchProvider {
 	}
 
 	@Override
-	public Completable clear() {
+	public Completable clear(String indexPattern) {
+		Pattern pattern = null;
+		if (indexPattern != null) {
+			indexPattern = StringUtils.removeStartIgnoreCase(indexPattern, options.getSearchOptions().getPrefix());
+			try {
+				pattern = Pattern.compile(indexPattern);
+			} catch (PatternSyntaxException e) {
+				log.warn("Index pattern {} is not valid, synchronizing all indices", e, indexPattern);
+			}
+		}
+		Optional<Pattern> optPattern = Optional.ofNullable(pattern);
+
 		String prefix = installationPrefix();
 		// Read all indices and locate indices which have been created for/by mesh.
 		Completable clearIndices = client.readIndex("_all").async()
@@ -163,6 +187,8 @@ public class ElasticSearchProvider implements SearchProvider {
 					}
 				}
 				return Observable.fromIterable(indices);
+			}).filter(index -> {
+				return optPattern.orElse(IndexHandler.MATCH_ALL).matcher(index).matches();
 			}).flatMapCompletable(index -> {
 				// Now delete the found indices
 				log.debug("Deleting index {" + index + "}");
@@ -412,9 +438,12 @@ public class ElasticSearchProvider implements SearchProvider {
 				if (log.isDebugEnabled()) {
 					log.debug("Deleted index {" + indices + "}. Duration " + (System.currentTimeMillis() - start) + "[ms]");
 				}
-			}).ignoreElement()
-			.onErrorResumeNext(ignore404)
-			.compose(withTimeoutAndLog("Deletion of indices " + indices, true));
+			}).ignoreElement();
+
+		if (!failOnMissingIndex) {
+			deleteIndex = deleteIndex.onErrorResumeNext(ignore404);
+		}
+		deleteIndex = deleteIndex.compose(withTimeoutAndLog("Deletion of indices " + indices, !failOnMissingIndex));
 
 		return deleteIndex;
 	}
@@ -556,6 +585,119 @@ public class ElasticSearchProvider implements SearchProvider {
 	@Override
 	public boolean isActive() {
 		return client != null;
+	}
+
+	@Override
+	public Completable check(IndexInfo info) {
+		String indexName = installationPrefix() + info.getIndexName();
+
+		return client.readIndex(indexName).async().flatMapCompletable(response -> {
+			JsonObject existing = response.getJsonObject(indexName).getJsonObject("mappings");
+			cleanMappings(existing);
+
+			return getExpectedMapping(info).flatMapCompletable(expected -> {
+				// make a copy to not change the original expected (which is cached and will be used again)
+				expected = expected.copy();
+				cleanMappings(expected);
+
+				// merge the existing mapping into the expected mapping, because ES may have added things (dynamic mapping) when documents were stored
+				expected.mergeIn(existing, true);
+				if (expected.equals(existing)) {
+					log.debug(indexName + ": Mapping is ok");
+					return Completable.complete();
+				} else {
+					log.warn(indexName + ": Mapping is NOT OK. Index will be dropped and re-created.");
+					if (log.isDebugEnabled()) {
+						log.debug(indexName + ": Expected mapping " + expected + ", but found mapping " + existing);
+					}
+					// trigger resync for the index
+					return client.deleteIndex(indexName).async().ignoreElement().andThen(createIndex(info)).andThen(resync(info.getIndexName()));
+				}
+			});
+		}).onErrorResumeNext(error -> {
+			if (isNotFoundError(error)) {
+				return createIndex(info).andThen(resync(info.getIndexName()));
+			} else {
+				log.error("Error while checking index " + indexName, error);
+				return Completable.complete();
+			}
+		}).compose(withTimeoutAndLog("Check mappings of index {" + indexName + "}", false));
+	}
+
+	/**
+	 * Initiate (but do not wait for end of) resync of the given index and complete
+	 * @param indexName index name (without the installation prefix)
+	 * @return completable
+	 */
+	protected Completable resync(String indexName) {
+		return Completable.fromAction(() -> {
+			SyncEventHandler.invokeSync(vertx.get(), indexName);
+		});
+	}
+
+	/**
+	 * Get the expected mapping for the index.
+	 * If the expected mapping is not found in the cache, it will be determined like this:
+	 * <ol>
+	 * <li>A temporary index with the settings and mappings is created</li>
+	 * <li>The mappings are read from ES for that temporary index</li>
+	 * <li>The temporary index is deleted</li>
+	 * </ol>
+	 * The reason for this is that ES will not store the index mapping exactly like the mapping was POSTed when creating the index.
+	 * @param info index info
+	 * @return single mappings as JsonObject
+	 */
+	protected Single<JsonObject> getExpectedMapping(IndexInfo info) {
+		String cacheKey = info.getIndexName();
+
+		JsonObject cachedMappings = searchMappingsCache.get().get(cacheKey);
+		if (cachedMappings != null) {
+			return Single.just(cachedMappings);
+		}
+
+		JsonObject json = createIndexSettings(info);
+
+		String randomName = info.getIndexName() + UUIDUtil.randomUUID();
+		String tempIndexName = randomName.toLowerCase();
+
+		return client.createIndex(tempIndexName, json).async()
+			.doOnSuccess(response -> {
+				if (log.isDebugEnabled()) {
+					log.debug("Created temporary index {" + tempIndexName + "} response: {" + response.toString() + "}");
+				}
+			})
+			.doOnError(error -> {
+				log.error("Error getting index mapping for index " + cacheKey, error);
+			})
+			.flatMap(response -> client.readIndex(tempIndexName).async())
+			.flatMap(response -> {
+				JsonObject mappings = response.getJsonObject(tempIndexName).getJsonObject("mappings");
+				searchMappingsCache.get().put(cacheKey, mappings);
+				return client.deleteIndex(tempIndexName).async().ignoreElement()
+						.andThen(Single.just(mappings));
+			});
+	}
+
+	/**
+	 * Clean mappings, so that they can be compared
+	 * <ul>
+	 * <li>Remove entries completely that contain the attribute "dynamic": "true", because those mappings are likely to be changed by ES when documents are indexed (e.g. the attribute "type": "object" is removed from the mapping)</li>
+	 * </ul>
+	 * @param mapping mappings to be cleaned (will be modified)
+	 */
+	protected void cleanMappings(JsonObject mapping) {
+		Set<String> fieldNames = new HashSet<>(mapping.fieldNames());
+		for (String field : fieldNames) {
+			Object value = mapping.getValue(field);
+			if (value instanceof JsonObject) {
+				JsonObject object = (JsonObject) value;
+				if (Objects.equals(object.getValue("dynamic"), "true")) {
+					mapping.remove(field);
+				} else {
+					cleanMappings(object);
+				}
+			}
+		}
 	}
 
 	private String getType() {

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/SearchMappingsCacheImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/SearchMappingsCacheImpl.java
@@ -1,0 +1,55 @@
+package com.gentics.mesh.search.impl;
+
+import java.time.temporal.ChronoUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.gentics.mesh.cache.AbstractMeshCache;
+import com.gentics.mesh.cache.CacheRegistry;
+import com.gentics.mesh.cache.EventAwareCache;
+import com.gentics.mesh.cache.impl.EventAwareCacheFactory;
+import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.search.SearchMappingsCache;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Implementation of the {@link SearchMappingsCache}
+ */
+@Singleton
+public class SearchMappingsCacheImpl extends AbstractMeshCache<String, JsonObject> implements SearchMappingsCache {
+	private static final long CACHE_SIZE = 1000;
+
+	/**
+	 * Create the cache
+	 * @param factory factory
+	 * @param options mesh options
+	 * @return cache instance
+	 */
+	private static EventAwareCache<String, JsonObject> createCache(EventAwareCacheFactory factory, MeshOptions options) {
+		return factory.<String, JsonObject>builder()
+				.maxSize(CACHE_SIZE)
+				.events(MeshEvent.STARTUP)
+				.expireAfterAccess(options.getSearchOptions().getIndexMappingCacheTimeout(), ChronoUnit.MILLIS)
+				.name("searchmappings")
+				.build();
+	}
+
+	/**
+	 * Create the instance
+	 * @param factory cache factory
+	 * @param registry cache registry
+	 * @param options mesh options
+	 */
+	@Inject
+	public SearchMappingsCacheImpl(EventAwareCacheFactory factory, CacheRegistry registry, MeshOptions options) {
+		super(createCache(factory, options), registry, CACHE_SIZE);
+	}
+
+	@Override
+	public void put(String key, JsonObject value) {
+		cache.put(key, value);
+	}
+}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/AdminIndexHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/AdminIndexHandler.java
@@ -19,6 +19,7 @@ import com.gentics.mesh.core.rest.search.EntityMetrics;
 import com.gentics.mesh.core.rest.search.SearchStatusResponse;
 import com.gentics.mesh.core.verticle.handler.HandlerUtilities;
 import com.gentics.mesh.graphdb.spi.Database;
+import com.gentics.mesh.parameter.IndexMaintenanceParameters;
 import com.gentics.mesh.search.IndexHandlerRegistryImpl;
 import com.gentics.mesh.search.SearchProvider;
 import com.gentics.mesh.search.verticle.eventhandler.SyncEventHandler;
@@ -99,7 +100,8 @@ public class AdminIndexHandler {
 		db.asyncTx(() -> Single.just(ac.getUser().isAdmin()))
 			.subscribe(isAdmin -> {
 				if (isAdmin) {
-					SyncEventHandler.invokeSync(vertx);
+					IndexMaintenanceParameters param = ac.getIndexMaintenanceParameters();
+					SyncEventHandler.invokeSync(vertx, param.getIndex());
 					ac.send(message(ac, "search_admin_index_sync_invoked"), OK);
 				} else {
 					ac.fail(error(FORBIDDEN, "error_admin_permission_required"));
@@ -115,7 +117,8 @@ public class AdminIndexHandler {
 	public void handleClear(InternalActionContext ac) {
 		db.asyncTx(() -> Single.just(ac.getUser().isAdmin())).flatMapCompletable(isAdmin -> {
 			if (isAdmin) {
-				return searchProvider.clear()
+				IndexMaintenanceParameters param = ac.getIndexMaintenanceParameters();
+				return searchProvider.clear(param.getIndex())
 					.andThen(Observable.fromIterable(registry.getHandlers())
 						.flatMapCompletable(handler -> handler.init()));
 			} else {

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/entry/AbstractIndexHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/entry/AbstractIndexHandler.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.gentics.elasticsearch.client.ElasticsearchClient;
@@ -189,7 +190,8 @@ public abstract class AbstractIndexHandler<T extends HibBaseElement> implements 
 		return searchProvider != null;
 	}
 
-	protected Flowable<SearchRequest> diffAndSync(String indexName, String projectUuid) {
+	protected Flowable<SearchRequest> diffAndSync(String indexName, String projectUuid, Optional<Pattern> indexPattern) {
+		if (indexPattern.orElse(MATCH_ALL).matcher(indexName).matches()) {
 		// Sync each bucket individually
 		Flowable<Bucket> buckets = bucketManager.getBuckets(getTotalCountFromGraph());
 		log.info("Handling index sync on handler {" + getClass().getName() + "}");
@@ -197,6 +199,9 @@ public abstract class AbstractIndexHandler<T extends HibBaseElement> implements 
 			log.info("Handling sync of {" + bucket + "}");
 			return diffAndSync(indexName, projectUuid, bucket);
 		}, 1);
+		} else {
+			return Flowable.empty();
+	}
 	}
 
 	/**
@@ -416,6 +421,19 @@ public abstract class AbstractIndexHandler<T extends HibBaseElement> implements 
 	@Override
 	public EntityMetrics getMetrics() {
 		return meters.createSnapshot();
+	}
+
+	@Override
+	public Completable check() {
+		// check the indices
+		return Observable.defer(() -> Observable.fromIterable(getIndices().values()))
+				.flatMap(info -> searchProvider.check(info).toObservable()
+					.doOnSubscribe(ignore -> {
+						if (log.isDebugEnabled()) {
+							log.debug("Checking index {" + info + "}");
+						}
+					}), 1)
+				.ignoreElements();
 	}
 
 	/**

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/group/GroupIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/group/GroupIndexHandlerImpl.java
@@ -2,8 +2,10 @@ package com.gentics.mesh.search.index.group;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -105,8 +107,8 @@ public class GroupIndexHandlerImpl extends AbstractIndexHandler<HibGroup> implem
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
-		return diffAndSync(Group.composeIndexName(), null);
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
+		return diffAndSync(Group.composeIndexName(), null, indexPattern);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/microschema/MicroschemaContainerIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/microschema/MicroschemaContainerIndexHandlerImpl.java
@@ -2,8 +2,10 @@ package com.gentics.mesh.search.index.microschema;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -87,8 +89,8 @@ public class MicroschemaContainerIndexHandlerImpl extends AbstractIndexHandler<H
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
-		return diffAndSync(Microschema.composeIndexName(), null);
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
+		return diffAndSync(Microschema.composeIndexName(), null, indexPattern);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/project/ProjectIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/project/ProjectIndexHandlerImpl.java
@@ -2,8 +2,10 @@ package com.gentics.mesh.search.index.project;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -84,8 +86,8 @@ public class ProjectIndexHandlerImpl extends AbstractIndexHandler<HibProject> im
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
-		return diffAndSync(Project.composeIndexName(), null);
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
+		return diffAndSync(Project.composeIndexName(), null, indexPattern);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/role/RoleIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/role/RoleIndexHandlerImpl.java
@@ -2,8 +2,10 @@ package com.gentics.mesh.search.index.role;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -91,8 +93,8 @@ public class RoleIndexHandlerImpl extends AbstractIndexHandler<HibRole>  impleme
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
-		return diffAndSync(Role.composeIndexName(), null);
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
+		return diffAndSync(Role.composeIndexName(), null, indexPattern);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/schema/SchemaContainerIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/schema/SchemaContainerIndexHandlerImpl.java
@@ -2,8 +2,10 @@ package com.gentics.mesh.search.index.schema;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -84,8 +86,8 @@ public class SchemaContainerIndexHandlerImpl extends AbstractIndexHandler<HibSch
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
-		return diffAndSync(Schema.composeIndexName(), null);
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
+		return diffAndSync(Schema.composeIndexName(), null, indexPattern);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/tag/TagIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/tag/TagIndexHandlerImpl.java
@@ -4,8 +4,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -133,12 +135,12 @@ public class TagIndexHandlerImpl extends AbstractIndexHandler<HibTag> implements
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
 		return Flowable.defer(() -> db.tx(() -> {
 			return boot.meshRoot().getProjectRoot().findAll().stream()
 				.map(project -> {
 					String uuid = project.getUuid();
-					return diffAndSync(Tag.composeIndexName(uuid), uuid);
+					return diffAndSync(Tag.composeIndexName(uuid), uuid, indexPattern);
 				}).collect(Collectors.collectingAndThen(Collectors.toList(), Flowable::merge));
 		}));
 	}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/tagfamily/TagFamilyIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/tagfamily/TagFamilyIndexHandlerImpl.java
@@ -4,8 +4,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -119,13 +121,13 @@ public class TagFamilyIndexHandlerImpl extends AbstractIndexHandler<HibTagFamily
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
 		return Flowable.defer(() -> db.tx(() -> {
 			return boot.meshRoot().getProjectRoot().findAll().stream()
 				.map(project -> {
 					String uuid = project.getUuid();
 					String indexName = TagFamily.composeIndexName(uuid);
-					return diffAndSync(indexName, uuid);
+					return diffAndSync(indexName, uuid, indexPattern);
 				}).collect(Collectors.collectingAndThen(Collectors.toList(), Flowable::merge));
 		}));
 	}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/user/UserIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/user/UserIndexHandlerImpl.java
@@ -2,8 +2,10 @@ package com.gentics.mesh.search.index.user;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -86,8 +88,8 @@ public class UserIndexHandlerImpl extends AbstractIndexHandler<HibUser> implemen
 	}
 
 	@Override
-	public Flowable<SearchRequest> syncIndices() {
-		return diffAndSync(User.composeIndexName(), null);
+	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
+		return diffAndSync(User.composeIndexName(), null, indexPattern);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/ElasticsearchProcessVerticle.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/ElasticsearchProcessVerticle.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.search.verticle;
 
+import static com.gentics.mesh.core.rest.MeshEvent.INDEX_CHECK_REQUEST;
 import static com.gentics.mesh.core.rest.MeshEvent.INDEX_SYNC_REQUEST;
 import static com.gentics.mesh.core.rest.MeshEvent.IS_SEARCH_IDLE;
 import static com.gentics.mesh.core.rest.MeshEvent.SEARCH_FLUSH_REQUEST;
@@ -21,9 +22,12 @@ import javax.inject.Inject;
 import com.gentics.mesh.core.data.search.request.SearchRequest;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.event.MeshEventModel;
+import com.gentics.mesh.core.rest.event.search.SearchIndexSyncEventModel;
+import com.gentics.mesh.distributed.RequestDelegator;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.etc.config.search.ElasticSearchOptions;
 import com.gentics.mesh.event.EventQueueBatch;
+import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.search.SearchProvider;
 import com.gentics.mesh.search.impl.ElasticsearchResponseErrorStreamable;
 import com.gentics.mesh.search.verticle.bulk.BulkOperator;
@@ -69,7 +73,9 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 	private final IdleChecker idleChecker;
 	private final SyncEventHandler syncEventHandler;
 	private final ElasticSearchOptions options;
+	private final RequestDelegator delegator;
 	private final String nodeName;
+	private final boolean clusteringEnabled;
 
 	private FlowableProcessor<MessageEvent> requests = PublishProcessor.create();
 
@@ -83,13 +89,16 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 		SearchProvider searchProvider,
 		IdleChecker idleChecker,
 		SyncEventHandler syncEventHandler,
-		MeshOptions options) {
+										MeshOptions options,
+										RequestDelegator delegator) {
 		this.mainEventhandler = mainEventhandler;
 		this.searchProvider = searchProvider;
 		this.idleChecker = idleChecker;
 		this.syncEventHandler = syncEventHandler;
 		this.options = options.getSearchOptions();
+		this.delegator = delegator;
 		this.nodeName = options.getNodeName();
+		this.clusteringEnabled = options.getClusterOptions().isEnabled();
 	}
 
 	@Override
@@ -126,6 +135,19 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 
 		vertxHandlers.add(replyingEventHandler(IS_SEARCH_IDLE, Single.fromCallable(idleChecker::isIdle)));
 		vertxHandlers.add(replyingEventHandler(SEARCH_REFRESH_REQUEST, refresh().andThen(Single.just(true))));
+
+		if (options.getIndexCheckInterval() > 0) {
+			log.trace("Setup periodic index check every {} ms", options.getIndexCheckInterval());
+			// periodically send the event to check the indices
+			vertx.setPeriodic(options.getIndexCheckInterval(), id -> {
+				// only do this for the current master
+				if (!clusteringEnabled || delegator.isMaster()) {
+					vertx.eventBus().publish(INDEX_CHECK_REQUEST.address, null);
+				}
+			});
+		} else {
+			log.trace("Periodic index check disabled (interval set to {} ms)", options.getIndexCheckInterval());
+		}
 
 		log.trace("Done Initializing Elasticsearch process verticle");
 	}
@@ -247,7 +269,7 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 				log.info("Elasticsearch is available again. Starting sync.");
 				elasticsearchAvailable.onNext(available);
 			});
-		vertx.eventBus().publish(INDEX_SYNC_REQUEST.address, null);
+		vertx.eventBus().publish(INDEX_SYNC_REQUEST.address, new JsonObject(JsonUtil.toJson(new SearchIndexSyncEventModel())));
 	}
 
 	/**
@@ -324,7 +346,7 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 			boolean indexNotFound = ((ElasticsearchResponseErrorStreamable) error).stream()
 				.anyMatch(err -> "index_not_found_exception".equals(err.getType()));
 			if (indexNotFound && !stopped.get()) {
-				return syncEventHandler.generateSyncRequests()
+				return syncEventHandler.generateSyncRequests(null)
 					.doOnNext(request -> {
 						log.trace("SyncRequest+{}", request);
 						idleChecker.addAndGetRequests(request.requestCount());

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/CheckIndicesHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/CheckIndicesHandler.java
@@ -1,0 +1,66 @@
+package com.gentics.mesh.search.verticle.eventhandler;
+
+import static com.gentics.mesh.core.rest.MeshEvent.INDEX_CHECK_REQUEST;
+import static com.gentics.mesh.core.rest.MeshEvent.INDEX_CHECK_START;
+import static com.gentics.mesh.core.rest.MeshEvent.INDEX_CHECK_FINISHED;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.gentics.mesh.core.data.search.request.SearchRequest;
+import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.search.IndexHandlerRegistry;
+import com.gentics.mesh.search.verticle.MessageEvent;
+
+import dagger.Lazy;
+import io.reactivex.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * Event handler, that will check the currently existing indices (for existence and correctness of the mapping)
+ */
+@Singleton
+public class CheckIndicesHandler implements EventHandler {
+	private static final Logger log = LoggerFactory.getLogger(CheckIndicesHandler.class);
+
+	private final Lazy<IndexHandlerRegistry> registry;
+
+	private final Vertx vertx;
+
+	/**
+	 * Create an instance
+	 * @param registry index handler registry
+	 * @param vertx vertx
+	 */
+	@Inject
+	public CheckIndicesHandler(Lazy<IndexHandlerRegistry> registry, Vertx vertx) {
+		this.registry = registry;
+		this.vertx = vertx;
+	}
+
+	@Override
+	public Collection<MeshEvent> handledEvents() {
+		return Collections.singletonList(INDEX_CHECK_REQUEST);
+	}
+
+	@Override
+	public Flowable<SearchRequest> handle(MessageEvent messageEvent) {
+		return syncIndices().doOnSubscribe(ignore -> {
+			log.debug("Processing index check job.");
+			vertx.eventBus().publish(INDEX_CHECK_START.address, null);
+		}).doFinally(() -> {
+			log.debug("Index check job finished.");
+			vertx.eventBus().publish(INDEX_CHECK_FINISHED.address, null);
+		});
+	}
+
+	protected Flowable<SearchRequest> syncIndices() {
+		return Flowable.fromIterable(registry.get().getHandlers())
+				.flatMap(handler -> handler.check().toFlowable());
+	}
+}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/MainEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/MainEventHandler.java
@@ -65,6 +65,8 @@ public class MainEventHandler implements EventHandler {
 	private final ProjectCreateEventHandler projectCreateEventHandler;
 	private final ProjectDeleteEventHandler projectDeleteEventHandler;
 
+	private final CheckIndicesHandler checkIndicesHandler;
+
 	@Inject
 	public MainEventHandler(SyncEventHandler syncEventHandler,
 							EventHandlerFactory eventHandlerFactory,
@@ -78,7 +80,7 @@ public class MainEventHandler implements EventHandler {
 							SchemaMigrationEventHandler schemaMigrationEventHandler,
 							PermissionChangedEventHandler permissionChangedEventHandler,
 							GroupUserAssignmentHandler userGroupAssignmentHandler,
-							ProjectUpdateEventHandler projectUpdateEventHandler, ProjectCreateEventHandler projectCreateEventHandler) {
+							ProjectUpdateEventHandler projectUpdateEventHandler, ProjectCreateEventHandler projectCreateEventHandler, CheckIndicesHandler checkIndicesHandler) {
 		this.syncEventHandler = syncEventHandler;
 		this.eventHandlerFactory = eventHandlerFactory;
 		this.groupEventHandler = groupEventHandler;
@@ -96,6 +98,7 @@ public class MainEventHandler implements EventHandler {
 		this.userGroupAssignmentHandler = userGroupAssignmentHandler;
 		this.projectUpdateEventHandler = projectUpdateEventHandler;
 		this.projectCreateEventHandler = projectCreateEventHandler;
+		this.checkIndicesHandler = checkIndicesHandler;
 
 		handlers = createHandlers();
 	}
@@ -127,7 +130,8 @@ public class MainEventHandler implements EventHandler {
 			branchEventHandler,
 			schemaMigrationEventHandler,
 			permissionChangedEventHandler,
-			userGroupAssignmentHandler
+			userGroupAssignmentHandler,
+			checkIndicesHandler
 		).collect(toMultiMap(EventHandler::handledEvents));
 	}
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/SyncEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/SyncEventHandler.java
@@ -9,15 +9,23 @@ import static com.gentics.mesh.core.rest.MeshEvent.INDEX_SYNC_START;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.gentics.mesh.Mesh;
 import com.gentics.mesh.core.data.search.IndexHandler;
 import com.gentics.mesh.core.data.search.request.DropIndexRequest;
 import com.gentics.mesh.core.data.search.request.SearchRequest;
 import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.core.rest.event.search.SearchIndexSyncEventModel;
+import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.search.IndexHandlerRegistryImpl;
 import com.gentics.mesh.search.SearchProvider;
 import com.gentics.mesh.search.index.metric.SyncMetersFactory;
@@ -28,6 +36,7 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -46,12 +55,16 @@ public class SyncEventHandler implements EventHandler {
 
 	private final SyncMetersFactory syncMetersFactory;
 
+	private final MeshOptions options;
+
 	/**
 	 * Send the index sync event which will trigger the index sync job.
+	 * @param indexPattern optional index pattern
 	 */
-	public static void invokeSync(Vertx vertx) {
-		log.info("Sending sync event");
-		vertx.eventBus().publish(INDEX_SYNC_REQUEST.address, null);
+	public static void invokeSync(Vertx vertx, String indexPattern) {
+		SearchIndexSyncEventModel eventModel = new SearchIndexSyncEventModel().setIndexPattern(indexPattern);
+		log.info("Sending sync event for index pattern {}", eventModel.getIndexPattern());
+		vertx.eventBus().publish(INDEX_SYNC_REQUEST.address, new JsonObject(JsonUtil.toJson(eventModel)));
 	}
 
 	/**
@@ -71,7 +84,7 @@ public class SyncEventHandler implements EventHandler {
 	 * @return
 	 */
 	public static Completable invokeSyncCompletable(Vertx vertx) {
-		return MeshEvent.doAndWaitForEvent(vertx, INDEX_SYNC_FINISHED, () -> SyncEventHandler.invokeSync(vertx));
+		return MeshEvent.doAndWaitForEvent(vertx, INDEX_SYNC_FINISHED, () -> SyncEventHandler.invokeSync(vertx, null));
 	}
 
 	/**
@@ -104,27 +117,33 @@ public class SyncEventHandler implements EventHandler {
 	}
 
 	@Inject
-	public SyncEventHandler(Lazy<IndexHandlerRegistryImpl> registry, SearchProvider provider, Vertx vertx, SyncMetersFactory syncMetersFactory) {
+	public SyncEventHandler(Lazy<IndexHandlerRegistryImpl> registry, SearchProvider provider, Vertx vertx, SyncMetersFactory syncMetersFactory, MeshOptions options) {
 		this.registry = registry;
 		this.provider = provider;
 		this.vertx = vertx;
 		this.syncMetersFactory = syncMetersFactory;
+		this.options = options;
 	}
 
 	@Override
 	public Flowable<SearchRequest> handle(MessageEvent messageEvent) {
-		return generateSyncRequests();
+		String indexPattern = ".*";
+		if (messageEvent.message instanceof SearchIndexSyncEventModel) {
+			indexPattern = ((SearchIndexSyncEventModel) messageEvent.message).getIndexPattern();
+	}
+		return generateSyncRequests(indexPattern);
 	}
 
 	/**
 	 * Generate the sync requests which consist of purging the old indices, syncing the data, publishing the finished event.
 	 * 
+	 * @param indexPatterm
 	 * @return
 	 */
-	public Flowable<SearchRequest> generateSyncRequests() {
+	public Flowable<SearchRequest> generateSyncRequests(String indexPattern) {
 		return Flowable.concatArray(
 			purgeOldIndices(),
-			syncIndices(),
+			syncIndices(indexPattern),
 			publishSyncEndEvent()).doOnSubscribe(ignore -> {
 				log.info("Processing index sync job.");
 				vertx.eventBus().publish(INDEX_SYNC_START.address, null);
@@ -151,14 +170,25 @@ public class SyncEventHandler implements EventHandler {
 	/**
 	 * Return search requests needed to init and sync all indices (for all registered type handlers).
 	 * 
+	 * @param indexPatterm
 	 * @return
 	 */
-	private Flowable<SearchRequest> syncIndices() {
+	private Flowable<SearchRequest> syncIndices(String indexPattern) {
+		Pattern pattern = null;
+		if (indexPattern != null) {
+			indexPattern = StringUtils.removeStartIgnoreCase(indexPattern, options.getSearchOptions().getPrefix());
+			try {
+				pattern = Pattern.compile(indexPattern);
+			} catch (PatternSyntaxException e) {
+				log.warn("Index pattern {} is not valid, synchronizing all indices", e, indexPattern);
+			}
+		}
+		Optional<Pattern> optPattern = Optional.ofNullable(pattern);
 		return Flowable.fromIterable(registry.get().getHandlers())
 			.flatMap(handler -> handler.init()
 				.doOnSubscribe(ignore -> log.debug("Init for {}", handler.getClass()))
 				.doOnComplete(() -> log.debug("Init for {} complete", handler.getClass()))
-				.andThen(handler.syncIndices()
+				.andThen(handler.syncIndices(optPattern)
 					.doOnSubscribe(ignore -> log.debug("Syncing for {}", handler.getClass()))));
 	}
 

--- a/mdm/api/src/main/java/com/gentics/mesh/parameter/ParameterProviderContext.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/parameter/ParameterProviderContext.java
@@ -5,6 +5,7 @@ import com.gentics.mesh.parameter.impl.BackupParametersImpl;
 import com.gentics.mesh.parameter.impl.DeleteParametersImpl;
 import com.gentics.mesh.parameter.impl.GenericParametersImpl;
 import com.gentics.mesh.parameter.impl.ImageManipulationParametersImpl;
+import com.gentics.mesh.parameter.impl.IndexMaintenanceParametersImpl;
 import com.gentics.mesh.parameter.impl.NodeParametersImpl;
 import com.gentics.mesh.parameter.impl.PagingParametersImpl;
 import com.gentics.mesh.parameter.impl.ProjectPurgeParametersImpl;
@@ -70,5 +71,9 @@ public interface ParameterProviderContext extends ActionContext {
 
 	default BackupParameters getBackupParameters() {
 		return new BackupParametersImpl(this);
+	}
+
+	default IndexMaintenanceParameters getIndexMaintenanceParameters() {
+		return new IndexMaintenanceParametersImpl(this);
 	}
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/parameter/impl/IndexMaintenanceParametersImpl.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/parameter/impl/IndexMaintenanceParametersImpl.java
@@ -1,0 +1,49 @@
+package com.gentics.mesh.parameter.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.raml.model.ParamType;
+import org.raml.model.parameter.QueryParameter;
+
+import com.gentics.mesh.handler.ActionContext;
+import com.gentics.mesh.parameter.AbstractParameters;
+import com.gentics.mesh.parameter.IndexMaintenanceParameters;
+
+/**
+ * Parameter implementation for index maintenance parameters
+ */
+public class IndexMaintenanceParametersImpl extends AbstractParameters implements IndexMaintenanceParameters {
+	/**
+	 * Create empty instance
+	 */
+	public IndexMaintenanceParametersImpl() {
+	}
+
+	/**
+	 * Create instance with parameters filled from the action context
+	 * @param ac action context
+	 */
+	public IndexMaintenanceParametersImpl(ActionContext ac) {
+		super(ac);
+	}
+
+	@Override
+	public String getName() {
+		return "Index Maintenance Parameters";
+	}
+
+	@Override
+	public Map<? extends String, ? extends QueryParameter> getRAMLParameters() {
+		Map<String, QueryParameter> parameters = new HashMap<>();
+
+		// index parameter
+		QueryParameter indexParameter = new QueryParameter();
+		indexParameter.setDescription("Index pattern to handle");
+		indexParameter.setExample("node-.*");
+		indexParameter.setRequired(false);
+		indexParameter.setType(ParamType.STRING);
+		parameters.put(INDEX_PARAMETER_KEY, indexParameter);
+		return parameters;
+	}
+}

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/search/IndexHandler.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/search/IndexHandler.java
@@ -1,8 +1,10 @@
 package com.gentics.mesh.core.data.search;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import com.gentics.mesh.context.InternalActionContext;
@@ -28,6 +30,7 @@ import io.reactivex.Observable;
  * @param <T>
  */
 public interface IndexHandler<T extends HibBaseElement> {
+	public final static Pattern MATCH_ALL = Pattern.compile(".*");
 
 	/**
 	 * Initialise the search index by creating the index first and setting the mapping afterwards.
@@ -85,9 +88,10 @@ public interface IndexHandler<T extends HibBaseElement> {
 	/**
 	 * Diff the elements within all indices that are handled by the index handler and synchronize the data.
 	 * 
+	 * @param indexPattern optional index pattern to restrict synchronized indices
 	 * @return
 	 */
-	Flowable<SearchRequest> syncIndices();
+	Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern);
 
 	/**
 	 * Filter the given list and return only indices which match the type of the handler but are no longer in use or unknown.
@@ -193,4 +197,9 @@ public interface IndexHandler<T extends HibBaseElement> {
 	 */
 	MappingProvider getMappingProvider();
 
+	/**
+	 * Check indices handled by this handler for existence and correctness (mapping)
+	 * @return completable
+	 */
+	Completable check();
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/distributed/RequestDelegator.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/distributed/RequestDelegator.java
@@ -23,4 +23,10 @@ public interface RequestDelegator extends Handler<RoutingContext> {
 	 * @param routingContext
 	 */
 	void redirectToMaster(RoutingContext routingContext);
+
+	/**
+	 * Returns true when this instance is the master
+	 * @return true for master
+	 */
+	boolean isMaster();
 }

--- a/rest-client/src/main/java/com/gentics/mesh/parameter/client/IndexMaintenanceParametersImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/parameter/client/IndexMaintenanceParametersImpl.java
@@ -1,0 +1,10 @@
+package com.gentics.mesh.parameter.client;
+
+import com.gentics.mesh.parameter.IndexMaintenanceParameters;
+
+/**
+ * Client Implementation of {@link IndexMaintenanceParameters}
+ */
+public class IndexMaintenanceParametersImpl extends AbstractParameters implements IndexMaintenanceParameters {
+
+}

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestHttpClientImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestHttpClientImpl.java
@@ -1000,13 +1000,13 @@ public abstract class MeshRestHttpClientImpl extends AbstractMeshRestHttpClient 
 	}
 
 	@Override
-	public MeshRequest<GenericMessageResponse> invokeIndexClear() {
-		return prepareRequest(POST, "/search/clear", GenericMessageResponse.class);
+	public MeshRequest<GenericMessageResponse> invokeIndexClear(ParameterProvider... parameters) {
+		return prepareRequest(POST, "/search/clear" + getQuery(parameters), GenericMessageResponse.class);
 	}
 
 	@Override
-	public MeshRequest<GenericMessageResponse> invokeIndexSync() {
-		return prepareRequest(POST, "/search/sync", GenericMessageResponse.class);
+	public MeshRequest<GenericMessageResponse> invokeIndexSync(ParameterProvider... parameters) {
+		return prepareRequest(POST, "/search/sync" + getQuery(parameters), GenericMessageResponse.class);
 	}
 
 	@Override

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/method/SearchClientMethods.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/method/SearchClientMethods.java
@@ -248,17 +248,19 @@ public interface SearchClientMethods {
 	/**
 	 * Clear all search indices by removing and re-creating them.
 	 * 
+	 * @param parameters
 	 * @return
 	 */
-	MeshRequest<GenericMessageResponse> invokeIndexClear();
+	MeshRequest<GenericMessageResponse> invokeIndexClear(ParameterProvider... parameters);
 
 	/**
 	 * Trigger the index sync action which will synchronize the index for all elements. This is useful when you want to sync the search index after restoring a
 	 * backup.
 	 * 
+	 * @param parameters
 	 * @return
 	 */
-	MeshRequest<GenericMessageResponse> invokeIndexSync();
+	MeshRequest<GenericMessageResponse> invokeIndexSync(ParameterProvider... parameters);
 
 	/**
 	 * Return the elasticsearch status. This will also contain information about the progress of running index sync operations.

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/MeshEvent.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/MeshEvent.java
@@ -32,6 +32,7 @@ import com.gentics.mesh.core.rest.event.project.ProjectMicroschemaEventModel;
 import com.gentics.mesh.core.rest.event.project.ProjectSchemaEventModel;
 import com.gentics.mesh.core.rest.event.role.PermissionChangedEventModel;
 import com.gentics.mesh.core.rest.event.s3binary.S3BinaryEventModel;
+import com.gentics.mesh.core.rest.event.search.SearchIndexSyncEventModel;
 import com.gentics.mesh.core.rest.event.tag.TagMeshEventModel;
 import com.gentics.mesh.core.rest.event.tagfamily.TagFamilyMeshEventModel;
 
@@ -487,7 +488,7 @@ public enum MeshEvent {
 	 * Address for the handler which will process index sync requests.
 	 */
 	INDEX_SYNC_REQUEST("mesh.search.index.sync.request",
-		null,
+		SearchIndexSyncEventModel.class,
 		"Event address which can be used to trigger the sync process."),
 
 	/**
@@ -526,6 +527,27 @@ public enum MeshEvent {
 	INDEX_CLEAR_FINISHED("mesh.search.index.clear.finished",
 		null,
 		"Emitted when the index clear process finishes."),
+
+	/**
+	 * Event address which will trigger an index check.
+	 */
+	INDEX_CHECK_REQUEST("mesh.search.index.check.request",
+		null,
+		"Event address which will trigger an index check."),
+
+	/**
+	 * Emitted when an index check process starts.
+	 */
+	INDEX_CHECK_START("mesh.search.index.check.start",
+		null,
+		"Emitted when the index check process starts."),
+
+	/**
+	 * Address to which index check results will be published (failed, succeeded)
+	 */
+	INDEX_CHECK_FINISHED("mesh.search.index.check.finished",
+		null,
+		"Emitted when the index check process finishes."),
 
 	/**
 	 * Event that is emitted when the search verticle has been working and is now idle.

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/event/search/SearchIndexSyncEventModel.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/event/search/SearchIndexSyncEventModel.java
@@ -1,0 +1,40 @@
+package com.gentics.mesh.core.rest.event.search;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.gentics.mesh.core.rest.event.AbstractMeshEventModel;
+
+/**
+ * Model of the event, which is sent to initiate an index sync
+ */
+public class SearchIndexSyncEventModel extends AbstractMeshEventModel {
+	@JsonProperty(required = true)
+	@JsonPropertyDescription("Index pattern")
+	private String indexPattern = ".*";
+
+	/**
+	 * Create empty instance
+	 */
+	public SearchIndexSyncEventModel() {
+	}
+
+	/**
+	 * Get the index pattern
+	 * @return index pattern
+	 */
+	public String getIndexPattern() {
+		return indexPattern;
+	}
+
+	/**
+	 * Set the index pattern
+	 * @param indexPattern index pattern
+	 * @return fluent API
+	 */
+	public SearchIndexSyncEventModel setIndexPattern(String indexPattern) {
+		if (indexPattern != null) {
+			this.indexPattern = indexPattern;
+		}
+		return this;
+	}
+}

--- a/rest-model/src/main/java/com/gentics/mesh/parameter/IndexMaintenanceParameters.java
+++ b/rest-model/src/main/java/com/gentics/mesh/parameter/IndexMaintenanceParameters.java
@@ -1,0 +1,29 @@
+package com.gentics.mesh.parameter;
+
+/**
+ * Interface for index maintenance parameters
+ */
+public interface IndexMaintenanceParameters extends ParameterProvider {
+	/**
+	 * Key of the parameter to restrict the indices (via regex)
+	 */
+	public static final String INDEX_PARAMETER_KEY = "index";
+
+	/**
+	 * Regex to restrict the index maintenance action to specific indices (via regex)
+	 * @return index parameter
+	 */
+	default String getIndex() {
+		return getParameter(INDEX_PARAMETER_KEY);
+	}
+
+	/**
+	 * Set the index parameter
+	 * @param index parameter
+	 * @return fluent API
+	 */
+	default IndexMaintenanceParameters setIndex(String index) {
+		setParameter(INDEX_PARAMETER_KEY, index);
+		return this;
+	}
+}


### PR DESCRIPTION
Add option to restrict index maintenance actions to specific indices
Let index maintenance actions run on the master, if cluster coordinator
is used

## Abstract

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
