### PR TITLE
Add periodic disk quota check.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.23]]
+== 1.6.23 (TBD)
+
+icon:plus[] Core: A periodic check for available disk space has been added. If not enough disk space is available, Gentics Mesh will be set to read-only to avoid corruption of the storage due to a full disk.
+
 [[v1.6.22]]
 == 1.6.22 (19.10.2021)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,7 +20,8 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.6.23]]
 == 1.6.23 (TBD)
 
-icon:plus[] Core: A periodic check for available disk space has been added. If not enough disk space is available, Gentics Mesh will be set to read-only to avoid corruption of the storage due to a full disk.
+icon:plus[] Core: A periodic check for available disk space has been added. If not enough disk space is available, Gentics Mesh will be set to read-only to avoid corruption
+of the storage due to a full disk. Additionally, the metrics `mesh_storage_disk_total` and `mesh_storage_disk_usable` have been added to monitoring.
 
 [[v1.6.22]]
 == 1.6.22 (19.10.2021)

--- a/api/src/main/java/com/gentics/mesh/etc/config/DiskQuotaOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/DiskQuotaOptions.java
@@ -1,0 +1,199 @@
+package com.gentics.mesh.etc.config;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.gentics.mesh.doc.GenerateDocumentation;
+import com.gentics.mesh.etc.config.env.EnvironmentVariable;
+import com.gentics.mesh.etc.config.env.Option;
+
+/**
+ * Options for disk quota check
+ */
+@GenerateDocumentation
+public class DiskQuotaOptions implements Option {
+	public final static Pattern QUOTA_PATTERN_PERCENTAGE = Pattern.compile("(?<value>[0-9]{1,2})%");
+
+	public final static Pattern QUOTA_PATTERN_ABSOLUTE = Pattern.compile("(?<value>[0-9]+)(?<unit>b|B|k|K|m|M|g|G|t|T)");
+
+	public final static int DEFAULT_CHECK_INTERVAL = 10_000;
+	public final static String DEFAULT_WARN_THRESHOLD = "15%";
+	public final static String DEFAULT_READ_ONLY_THRESHOLD = "10%";
+
+	public final static String MESH_STORAGE_DISK_QUOTA_CHECK_INTERVAL_ENV = "MESH_STORAGE_DISK_QUOTA_CHECK_INTERVAL";
+	public final static String MESH_STORAGE_DISK_QUOTA_WARN_THRESHOLD_ENV = "MESH_STORAGE_DISK_QUOTA_WARN_THRESHOLD";
+	public final static String MESH_STORAGE_DISK_QUOTA_READ_ONLY_THRESHOLD_ENV = "MESH_STORAGE_DISK_QUOTA_READ_ONLY_THRESHOLD";
+
+	@JsonProperty(defaultValue = DEFAULT_CHECK_INTERVAL + " ms")
+	@JsonPropertyDescription("Check interval in ms. Setting this to 0 will disable the disk quota check. Default: " + DEFAULT_CHECK_INTERVAL)
+	@EnvironmentVariable(name = MESH_STORAGE_DISK_QUOTA_CHECK_INTERVAL_ENV, description = "Overwrite the disk quota check interval.")
+	private int checkInterval = DEFAULT_CHECK_INTERVAL;
+
+	@JsonProperty(defaultValue = DEFAULT_WARN_THRESHOLD)
+	@JsonPropertyDescription("Threshold for the disk quota warn level. This can be set either as percentage (e.g. 15%) or as absolute disk space (e.g. 10G). If less than the defined disk space is available, warnings will be logged. Default: " + DEFAULT_WARN_THRESHOLD)
+	@EnvironmentVariable(name = MESH_STORAGE_DISK_QUOTA_WARN_THRESHOLD_ENV, description = "Overwrite the disk quota warn threshold.")
+	private String warnThreshold = DEFAULT_WARN_THRESHOLD;
+
+	private int warnThresholdPercent = -1;
+	private long warnThresholdAbsolute = -1;
+
+	@JsonProperty(defaultValue = DEFAULT_READ_ONLY_THRESHOLD)
+	@JsonPropertyDescription("Threshold for the disk quota ready only level. This can be set either as percentage (e.g. 10%) or as absolute disk space (e.g. 5G). If less than the defined disk space is available, Mesh will automatically be set to readonly. Default: " + DEFAULT_READ_ONLY_THRESHOLD)
+	@EnvironmentVariable(name = MESH_STORAGE_DISK_QUOTA_READ_ONLY_THRESHOLD_ENV, description = "Overwrite the disk quota ready only threshold.")
+	private String readOnlyThreshold = DEFAULT_READ_ONLY_THRESHOLD;
+
+	private int readOnlyThresholdPercent = -1;
+	private long readOnlyThresholdAbsolute = -1;
+
+	/**
+	 * Check interval in ms
+	 * @return check interval
+	 */
+	public int getCheckInterval() {
+		return checkInterval;
+	}
+
+	/**
+	 * Set the check interval in ms
+	 * @param checkInterval in ms
+	 * @return fluent API
+	 */
+	public DiskQuotaOptions setCheckInterval(int checkInterval) {
+		this.checkInterval = checkInterval;
+		return this;
+	}
+
+	/**
+	 * Warn threshold
+	 * @return threshold
+	 */
+	public String getWarnThreshold() {
+		return warnThreshold;
+	}
+
+	/**
+	 * Set the warn threshold
+	 * @param warnThreshold warn threshold
+	 * @return fluent API
+	 */
+	public DiskQuotaOptions setWarnThreshold(String warnThreshold) {
+		this.warnThreshold = warnThreshold;
+		return this;
+	}
+
+	/**
+	 * Read only threshold
+	 * @return threshold
+	 */
+	public String getReadOnlyThreshold() {
+		return readOnlyThreshold;
+	}
+
+	/**
+	 * Set the read only threshold
+	 * @param readOnlyThreshold threshold
+	 * @return fluent API
+	 */
+	public DiskQuotaOptions setReadOnlyThreshold(String readOnlyThreshold) {
+		this.readOnlyThreshold = readOnlyThreshold;
+		return this;
+	}
+
+	@JsonIgnore
+	public long getAbsoluteWarnThreshold(File storageDir) {
+		if (warnThresholdPercent < 0 || warnThresholdAbsolute < 0) {
+			Matcher percentageMatcher = DiskQuotaOptions.QUOTA_PATTERN_PERCENTAGE.matcher(this.warnThreshold);
+			Matcher absoluteMatcher = DiskQuotaOptions.QUOTA_PATTERN_ABSOLUTE.matcher(this.warnThreshold);
+
+			if (percentageMatcher.matches()) {
+				this.warnThresholdPercent = Integer.parseInt(percentageMatcher.group("value"));
+				this.warnThresholdAbsolute = 0;
+			} else if (absoluteMatcher.matches()) {
+				this.warnThresholdPercent = 0;
+				this.warnThresholdAbsolute = getBytes(absoluteMatcher);
+			} else {
+				this.warnThresholdPercent = 0;
+				this.warnThresholdAbsolute = 0;
+			}
+		}
+		if (warnThresholdPercent > 0) {
+			return storageDir.getTotalSpace() * warnThresholdPercent / 100;
+		} else if (warnThresholdAbsolute > 0) {
+			return warnThresholdAbsolute;
+		} else {
+			return 0;
+		}
+	}
+
+	@JsonIgnore
+	public long getAbsoluteReadOnlyThreshold(File storageDir) {
+		if (readOnlyThresholdPercent < 0 || readOnlyThresholdAbsolute < 0) {
+			Matcher percentageMatcher = DiskQuotaOptions.QUOTA_PATTERN_PERCENTAGE.matcher(this.readOnlyThreshold);
+			Matcher absoluteMatcher = DiskQuotaOptions.QUOTA_PATTERN_ABSOLUTE.matcher(this.readOnlyThreshold);
+
+			if (percentageMatcher.matches()) {
+				this.readOnlyThresholdPercent = Integer.parseInt(percentageMatcher.group("value"));
+				this.readOnlyThresholdAbsolute = 0;
+			} else if (absoluteMatcher.matches()) {
+				this.readOnlyThresholdPercent = 0;
+				this.readOnlyThresholdAbsolute = getBytes(absoluteMatcher);
+			} else {
+				this.readOnlyThresholdPercent = 0;
+				this.warnThresholdAbsolute = 0;
+			}
+		}
+		if (readOnlyThresholdPercent > 0) {
+			return storageDir.getTotalSpace() * readOnlyThresholdPercent / 100;
+		} else if (readOnlyThresholdAbsolute > 0) {
+			return readOnlyThresholdAbsolute;
+		} else {
+			return 0;
+		}
+	}
+
+	@Override
+	public void validate(MeshOptions options) {
+		if (checkInterval > 0) {
+			Objects.requireNonNull(readOnlyThreshold, "The readOnlyThreshold must be specified.");
+			if (!DiskQuotaOptions.QUOTA_PATTERN_ABSOLUTE.matcher(readOnlyThreshold).matches()
+					&& !DiskQuotaOptions.QUOTA_PATTERN_PERCENTAGE.matcher(readOnlyThreshold).matches()) {
+				throw new IllegalArgumentException("The readOnlyThreshold was set to " + readOnlyThreshold
+						+ ", but is expected to either be a percentage (e.g. 10%) or an absolute memory size (like 10M)");
+			}
+
+			Objects.requireNonNull(warnThreshold, "The warnThreshold must be specified.");
+			if (!DiskQuotaOptions.QUOTA_PATTERN_ABSOLUTE.matcher(warnThreshold).matches()
+					&& !DiskQuotaOptions.QUOTA_PATTERN_PERCENTAGE.matcher(warnThreshold).matches()) {
+				throw new IllegalArgumentException("The warnThreshold was set to " + warnThreshold
+						+ ", but is expected to either be a percentage (e.g. 10%) or an absolute memory size (like 10M)");
+			}
+		}
+	}
+
+	private long getBytes(Matcher absoluteMatcher) {
+		switch (absoluteMatcher.group("unit")) {
+		case "b":
+		case "B":
+			return Long.parseLong(absoluteMatcher.group("value"));
+		case "k":
+		case "K":
+			return Long.parseLong(absoluteMatcher.group("value")) * 1024;
+		case "m":
+		case "M":
+			return Long.parseLong(absoluteMatcher.group("value")) * 1024 * 1024;
+		case "g":
+		case "G":
+			return Long.parseLong(absoluteMatcher.group("value")) * 1024 * 1024 * 1024;
+		case "t":
+		case "T":
+			return Long.parseLong(absoluteMatcher.group("value")) * 1024 * 1024 * 1024 * 1024;
+		default:
+			return 0;
+		}
+	}
+}

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphStorageOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphStorageOptions.java
@@ -95,6 +95,10 @@ public class GraphStorageOptions implements Option {
 	@EnvironmentVariable(name = MESH_GRAPH_CLUSTER_JOIN_TIMEOUT_ENV, description = "Override the graphdb cluster join timeout. Default: " + DEFAULT_CLUSTER_JOIN_TIMEOUT + " ms")
 	private int clusterJoinTimeout = DEFAULT_CLUSTER_JOIN_TIMEOUT;
 
+	@JsonProperty("diskQuota")
+	@JsonPropertyDescription("Options for the disk quota check")
+	private DiskQuotaOptions diskQuotaOptions = new DiskQuotaOptions();
+
 	public String getDirectory() {
 		return directory;
 	}
@@ -216,11 +220,30 @@ public class GraphStorageOptions implements Option {
 		return this;
 	}
 
+	/**
+	 * Disk quota options
+	 * @return options
+	 */
+	public DiskQuotaOptions getDiskQuotaOptions() {
+		return diskQuotaOptions;
+	}
+
+	/**
+	 * Set the disk quota options
+	 * @param diskQuotaOptions options (if null, the options are reset to the default values)
+	 * @return fluent API
+	 */
+	public GraphStorageOptions setDiskQuotaOptions(DiskQuotaOptions diskQuotaOptions) {
+		this.diskQuotaOptions = diskQuotaOptions != null ? diskQuotaOptions : new DiskQuotaOptions();
+		return this;
+	}
+
 	public void validate(MeshOptions meshOptions) {
 		if (getStartServer() && getDirectory() == null) {
 			throw new NullPointerException(
 				"You have not specified a data directory and enabled the graph server. It is not possible to run Gentics Mesh in memory mode and start the graph server.");
 		}
+		getDiskQuotaOptions().validate(meshOptions);
 	}
 
 }

--- a/common/src/main/java/com/gentics/mesh/graphdb/spi/Database.java
+++ b/common/src/main/java/com/gentics/mesh/graphdb/spi/Database.java
@@ -528,4 +528,12 @@ public interface Database extends TxFactory {
 	 */
 	long count(Class<? extends MeshVertex> clazz);
 
+	/**
+	 * Check whether the database is considered to be read-only
+	 * @param logError true to log an error, false for logging a warning
+	 * @return true if database is read-only
+	 */
+	default boolean isReadOnly(boolean logError) {
+		return false;
+	}
 }

--- a/common/src/main/java/com/gentics/mesh/router/route/AbstractInternalEndpoint.java
+++ b/common/src/main/java/com/gentics/mesh/router/route/AbstractInternalEndpoint.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 
 import com.gentics.mesh.auth.MeshAuthChain;
 import com.gentics.mesh.core.endpoint.admin.LocalConfigApi;
+import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.rest.InternalEndpoint;
 import com.gentics.mesh.rest.InternalEndpointRoute;
 import com.gentics.mesh.rest.impl.InternalEndpointRouteImpl;
@@ -33,6 +34,9 @@ public abstract class AbstractInternalEndpoint implements InternalEndpoint {
 
 	@Inject
 	public LocalConfigApi localConfigApi;
+
+	@Inject
+	public Database db;
 
 	protected AbstractInternalEndpoint(String basePath, MeshAuthChain chain) {
 		this.basePath = basePath;
@@ -107,7 +111,7 @@ public abstract class AbstractInternalEndpoint implements InternalEndpoint {
 
 	@Override
 	public InternalEndpointRoute createRoute() {
-		InternalEndpointRoute endpoint = new InternalEndpointRouteImpl(getRouter(), localConfigApi);
+		InternalEndpointRoute endpoint = new InternalEndpointRouteImpl(getRouter(), localConfigApi, db);
 		endpointRoutes.add(endpoint);
 		return endpoint;
 	}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/handler/MonitoringCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/handler/MonitoringCrudHandler.java
@@ -6,6 +6,7 @@ import com.gentics.mesh.core.endpoint.admin.LocalConfigApi;
 import com.gentics.mesh.core.rest.admin.localconfig.LocalConfigModel;
 import com.gentics.mesh.core.rest.plugin.PluginStatus;
 import com.gentics.mesh.graphdb.cluster.ClusterManager;
+import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.monitor.liveness.LivenessManager;
 import com.gentics.mesh.plugin.manager.MeshPluginManager;
 import io.vertx.core.logging.Logger;
@@ -35,13 +36,16 @@ public class MonitoringCrudHandler {
 
 	private final LocalConfigApi localConfigApi;
 
+	private final Database db;
+
 	@Inject
-	public MonitoringCrudHandler(BootstrapInitializer boot, MeshPluginManager pluginManager, ClusterManager clusterManager, LivenessManager liveness, LocalConfigApi localConfigApi) {
+	public MonitoringCrudHandler(BootstrapInitializer boot, MeshPluginManager pluginManager, ClusterManager clusterManager, LivenessManager liveness, LocalConfigApi localConfigApi, Database db) {
 		this.boot = boot;
 		this.pluginManager = pluginManager;
 		this.clusterManager = clusterManager;
 		this.liveness = liveness;
 		this.localConfigApi = localConfigApi;
+		this.db = db;
 	}
 
 	public void handleLive(RoutingContext rc) {
@@ -110,6 +114,8 @@ public class MonitoringCrudHandler {
 				.subscribe(isReadOnly -> {
 					if (isReadOnly) {
 						log.warn("Local node cannot write - read only mode set");
+						rc.fail(error(SERVICE_UNAVAILABLE, "error_internal"));
+					} else if (db.isReadOnly(false)) {
 						rc.fail(error(SERVICE_UNAVAILABLE, "error_internal"));
 					} else if (clusterManager.isClusterTopologyLocked()) {
 						log.warn("Local node cannot write - cluster topology locked");

--- a/core/src/test/java/com/gentics/mesh/rest/EndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/rest/EndpointTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
+import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.rest.impl.InternalEndpointRouteImpl;
 
 import io.vertx.ext.web.Route;
@@ -19,7 +20,7 @@ public class EndpointTest {
 		Router router = mock(Router.class);
 		Route route = mock(Route.class);
 		when(router.route()).thenReturn(route);
-		InternalEndpointRoute e = new InternalEndpointRouteImpl(router, null);
+		InternalEndpointRoute e = new InternalEndpointRouteImpl(router, null, mock(Database.class));
 
 		when(route.getPath()).thenReturn("/:bla/:blub/:blar");
 		assertEquals("/{bla}/{blub}/{blar}", e.getRamlPath());

--- a/core/src/test/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -474,6 +474,9 @@ public class MeshTestContext extends TestWatcher {
 		// disable periodic index check
 		meshOptions.getSearchOptions().setIndexCheckInterval(0);
 
+		// disable periodic disk quota check
+		meshOptions.getStorageOptions().getDiskQuotaOptions().setCheckInterval(0);
+
 		// Clustering options
 		if (settings.clusterMode()) {
 			meshOptions.getClusterOptions().setEnabled(true);

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/OrientDBStorageMetric.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/OrientDBStorageMetric.java
@@ -1,0 +1,42 @@
+package com.gentics.mesh.graphdb;
+
+import com.gentics.mesh.metric.Metric;
+
+/**
+ * OrientDB storage metrics
+ */
+public enum OrientDBStorageMetric implements Metric {
+	/**
+	 * Total disk space
+	 */
+	DISK_TOTAL("storage_disk_total", "Total disk space for OrientDB storage."),
+
+	/**
+	 * Usable disk space
+	 */
+	DISK_USABLE("storage_disk_usable", "Usable disk space for OrientDB storage.");
+
+	private String key;
+
+	private String description;
+
+	/**
+	 * Create instance
+	 * @param key metric key
+	 * @param description metric description
+	 */
+	private OrientDBStorageMetric(String key, String description) {
+		this.key = key;
+		this.description = description;
+	}
+
+	@Override
+	public String key() {
+		return "mesh_" + key;
+	}
+
+	@Override
+	public String description() {
+		return description;
+	}
+}

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/check/DiskQuotaChecker.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/check/DiskQuotaChecker.java
@@ -1,0 +1,73 @@
+package com.gentics.mesh.graphdb.check;
+
+import java.io.File;
+import java.util.function.Consumer;
+
+import org.apache.commons.io.FileUtils;
+
+import com.gentics.mesh.etc.config.DiskQuotaOptions;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * {@link Runnable} which checks the disk quota
+ */
+public class DiskQuotaChecker implements Runnable {
+	private static final Logger log = LoggerFactory.getLogger(DiskQuotaChecker.class);
+
+	private final File storageDirectory;
+
+	private final DiskQuotaOptions options;
+
+	private final Consumer<Boolean> resultConsumer;
+
+	/**
+	 * Create an instance
+	 * @param storageDirectory storage directory
+	 * @param options disk quota options
+	 * @param resultConsumer result consumer
+	 */
+	public DiskQuotaChecker(File storageDirectory, DiskQuotaOptions options, Consumer<Boolean> resultConsumer) {
+		this.storageDirectory = storageDirectory;
+		this.options = options;
+		this.resultConsumer = resultConsumer;
+	}
+
+	@Override
+	public void run() {
+		try {
+			long absoluteReadOnlyThreshold = options.getAbsoluteReadOnlyThreshold(storageDirectory);
+			long absoluteWarnThreshold = options.getAbsoluteWarnThreshold(storageDirectory);
+			long usableSpace = storageDirectory.getUsableSpace();
+			long totalSpace = storageDirectory.getTotalSpace();
+			long quota = totalSpace > 0 ? usableSpace * 100 / totalSpace : 0;
+
+			if (log.isDebugEnabled()) {
+				log.debug(String.format("Warn below %s, read-only below %s",
+						FileUtils.byteCountToDisplaySize(absoluteWarnThreshold),
+						FileUtils.byteCountToDisplaySize(absoluteReadOnlyThreshold)));
+			}
+
+			if (absoluteReadOnlyThreshold > 0 && usableSpace < absoluteReadOnlyThreshold) {
+				resultConsumer.accept(true);
+				log.error(String.format("Total space: %s, usable: %s (%d%%)",
+						FileUtils.byteCountToDisplaySize(totalSpace), FileUtils.byteCountToDisplaySize(usableSpace),
+						quota));
+			} else if (absoluteWarnThreshold > 0 && usableSpace < absoluteWarnThreshold) {
+				resultConsumer.accept(false);
+				// warn
+				log.warn(String.format("Total space: %s, usable: %s (%d%%)",
+						FileUtils.byteCountToDisplaySize(totalSpace), FileUtils.byteCountToDisplaySize(usableSpace),
+						quota));
+			} else {
+				resultConsumer.accept(false);
+				log.info(String.format("Total space: %s, usable: %s (%d%%)",
+						FileUtils.byteCountToDisplaySize(totalSpace), FileUtils.byteCountToDisplaySize(usableSpace),
+						quota));
+			}
+		} catch (Throwable e) {
+			log.error("Error while checking disk quota", e);
+		}
+	}
+}

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/check/DiskQuotaChecker.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/check/DiskQuotaChecker.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.function.Consumer;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Triple;
 
 import com.gentics.mesh.etc.config.DiskQuotaOptions;
 
@@ -20,7 +21,7 @@ public class DiskQuotaChecker implements Runnable {
 
 	private final DiskQuotaOptions options;
 
-	private final Consumer<Boolean> resultConsumer;
+	private final Consumer<Triple<Boolean, Long, Long>> resultConsumer;
 
 	/**
 	 * Create an instance
@@ -28,7 +29,7 @@ public class DiskQuotaChecker implements Runnable {
 	 * @param options disk quota options
 	 * @param resultConsumer result consumer
 	 */
-	public DiskQuotaChecker(File storageDirectory, DiskQuotaOptions options, Consumer<Boolean> resultConsumer) {
+	public DiskQuotaChecker(File storageDirectory, DiskQuotaOptions options, Consumer<Triple<Boolean, Long, Long>> resultConsumer) {
 		this.storageDirectory = storageDirectory;
 		this.options = options;
 		this.resultConsumer = resultConsumer;
@@ -50,18 +51,18 @@ public class DiskQuotaChecker implements Runnable {
 			}
 
 			if (absoluteReadOnlyThreshold > 0 && usableSpace < absoluteReadOnlyThreshold) {
-				resultConsumer.accept(true);
+				resultConsumer.accept(Triple.of(true, totalSpace, usableSpace));
 				log.error(String.format("Total space: %s, usable: %s (%d%%)",
 						FileUtils.byteCountToDisplaySize(totalSpace), FileUtils.byteCountToDisplaySize(usableSpace),
 						quota));
 			} else if (absoluteWarnThreshold > 0 && usableSpace < absoluteWarnThreshold) {
-				resultConsumer.accept(false);
+				resultConsumer.accept(Triple.of(false, totalSpace, usableSpace));
 				// warn
 				log.warn(String.format("Total space: %s, usable: %s (%d%%)",
 						FileUtils.byteCountToDisplaySize(totalSpace), FileUtils.byteCountToDisplaySize(usableSpace),
 						quota));
 			} else {
-				resultConsumer.accept(false);
+				resultConsumer.accept(Triple.of(false, totalSpace, usableSpace));
 				log.info(String.format("Total space: %s, usable: %s (%d%%)",
 						FileUtils.byteCountToDisplaySize(totalSpace), FileUtils.byteCountToDisplaySize(usableSpace),
 						quota));

--- a/databases/orientdb/src/test/java/com/gentics/mesh/graphdb/orientdb/DiskQuotaCheckerTest.java
+++ b/databases/orientdb/src/test/java/com/gentics/mesh/graphdb/orientdb/DiskQuotaCheckerTest.java
@@ -1,0 +1,100 @@
+package com.gentics.mesh.graphdb.orientdb;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.function.Consumer;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.gentics.mesh.etc.config.DiskQuotaOptions;
+import com.gentics.mesh.graphdb.check.DiskQuotaChecker;
+import com.gentics.mesh.mock.MockingLoggerRule;
+
+import io.vertx.core.spi.logging.LogDelegate;
+
+/**
+ * Test cases for the disk quota checker
+ */
+public class DiskQuotaCheckerTest {
+	private final static long MB = 1024 * 1024;
+
+	@Rule
+	public MockingLoggerRule rule = new MockingLoggerRule();
+
+	protected LogDelegate logger = rule.get(DiskQuotaChecker.class.getName());
+
+	/**
+	 * Test that enough disk space usable will be accepted
+	 * @throws Exception
+	 */
+	@Test
+	public void testDiskOk() throws Exception {
+		File storageDirectory = mock(File.class);
+		when(storageDirectory.getTotalSpace()).thenReturn(100 * MB);
+		when(storageDirectory.getUsableSpace()).thenReturn(80 * MB);
+		DiskQuotaOptions options = new DiskQuotaOptions().setCheckInterval(1_000).setWarnThreshold("10M")
+				.setReadOnlyThreshold("5M");
+		@SuppressWarnings("unchecked")
+		Consumer<Boolean> resultConsumer = mock(Consumer.class);
+
+		DiskQuotaChecker checker = new DiskQuotaChecker(storageDirectory, options, resultConsumer);
+		checker.run();
+
+		verify(resultConsumer).accept(false);
+		verify(logger).info("Total space: 100 MB, usable: 80 MB (80%)");
+		verify(logger, never()).warn(any());
+		verify(logger, never()).error(any());
+	}
+
+	/**
+	 * Test that for nearly not enough disk space, a warning will be logged
+	 * @throws Exception
+	 */
+	@Test
+	public void testDiskWarn() throws Exception {
+		File storageDirectory = mock(File.class);
+		when(storageDirectory.getTotalSpace()).thenReturn(100 * MB);
+		when(storageDirectory.getUsableSpace()).thenReturn(8 * MB);
+		DiskQuotaOptions options = new DiskQuotaOptions().setCheckInterval(1_000).setWarnThreshold("10M")
+				.setReadOnlyThreshold("5M");
+		@SuppressWarnings("unchecked")
+		Consumer<Boolean> resultConsumer = mock(Consumer.class);
+
+		DiskQuotaChecker checker = new DiskQuotaChecker(storageDirectory, options, resultConsumer);
+		checker.run();
+
+		verify(resultConsumer).accept(false);
+		verify(logger, never()).info(any());
+		verify(logger).warn("Total space: 100 MB, usable: 8 MB (8%)");
+		verify(logger, never()).error(any());
+	}
+
+	/**
+	 * Test that not enough disk space usable will not be accepted
+	 * @throws Exception
+	 */
+	@Test
+	public void testDiskFull() throws Exception {
+		File storageDirectory = mock(File.class);
+		when(storageDirectory.getTotalSpace()).thenReturn(100 * MB);
+		when(storageDirectory.getUsableSpace()).thenReturn(3 * MB);
+		DiskQuotaOptions options = new DiskQuotaOptions().setCheckInterval(1_000).setWarnThreshold("10M")
+				.setReadOnlyThreshold("5M");
+		@SuppressWarnings("unchecked")
+		Consumer<Boolean> resultConsumer = mock(Consumer.class);
+
+		DiskQuotaChecker checker = new DiskQuotaChecker(storageDirectory, options, resultConsumer);
+		checker.run();
+
+		verify(resultConsumer).accept(true);
+		verify(logger, never()).info(any());
+		verify(logger, never()).warn(any());
+		verify(logger).error("Total space: 100 MB, usable: 3 MB (3%)");
+	}
+}

--- a/databases/orientdb/src/test/java/com/gentics/mesh/graphdb/orientdb/DiskQuotaCheckerTest.java
+++ b/databases/orientdb/src/test/java/com/gentics/mesh/graphdb/orientdb/DiskQuotaCheckerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -41,12 +42,12 @@ public class DiskQuotaCheckerTest {
 		DiskQuotaOptions options = new DiskQuotaOptions().setCheckInterval(1_000).setWarnThreshold("10M")
 				.setReadOnlyThreshold("5M");
 		@SuppressWarnings("unchecked")
-		Consumer<Boolean> resultConsumer = mock(Consumer.class);
+		Consumer<Triple<Boolean, Long, Long>> resultConsumer = mock(Consumer.class);
 
 		DiskQuotaChecker checker = new DiskQuotaChecker(storageDirectory, options, resultConsumer);
 		checker.run();
 
-		verify(resultConsumer).accept(false);
+		verify(resultConsumer).accept(Triple.of(false, 100 * MB, 80 * MB));
 		verify(logger).info("Total space: 100 MB, usable: 80 MB (80%)");
 		verify(logger, never()).warn(any());
 		verify(logger, never()).error(any());
@@ -64,12 +65,12 @@ public class DiskQuotaCheckerTest {
 		DiskQuotaOptions options = new DiskQuotaOptions().setCheckInterval(1_000).setWarnThreshold("10M")
 				.setReadOnlyThreshold("5M");
 		@SuppressWarnings("unchecked")
-		Consumer<Boolean> resultConsumer = mock(Consumer.class);
+		Consumer<Triple<Boolean, Long, Long>> resultConsumer = mock(Consumer.class);
 
 		DiskQuotaChecker checker = new DiskQuotaChecker(storageDirectory, options, resultConsumer);
 		checker.run();
 
-		verify(resultConsumer).accept(false);
+		verify(resultConsumer).accept(Triple.of(false, 100 * MB, 8 * MB));
 		verify(logger, never()).info(any());
 		verify(logger).warn("Total space: 100 MB, usable: 8 MB (8%)");
 		verify(logger, never()).error(any());
@@ -87,12 +88,12 @@ public class DiskQuotaCheckerTest {
 		DiskQuotaOptions options = new DiskQuotaOptions().setCheckInterval(1_000).setWarnThreshold("10M")
 				.setReadOnlyThreshold("5M");
 		@SuppressWarnings("unchecked")
-		Consumer<Boolean> resultConsumer = mock(Consumer.class);
+		Consumer<Triple<Boolean, Long, Long>> resultConsumer = mock(Consumer.class);
 
 		DiskQuotaChecker checker = new DiskQuotaChecker(storageDirectory, options, resultConsumer);
 		checker.run();
 
-		verify(resultConsumer).accept(true);
+		verify(resultConsumer).accept(Triple.of(true, 100 * MB, 3 * MB));
 		verify(logger, never()).info(any());
 		verify(logger, never()).warn(any());
 		verify(logger).error("Total space: 100 MB, usable: 3 MB (3%)");

--- a/doc/src/main/docs/administration-guide.asciidoc
+++ b/doc/src/main/docs/administration-guide.asciidoc
@@ -155,6 +155,13 @@ The underlying storage filesystem for the Graph Database must support DirectIO.
 
 Storage solutions which provide one of the supported filesystems by the means of iSCSI or Fiberchannel are supported.
 
+Gentics Mesh will periodically check the available disk space. If less disk space is available than defined as
+warn threshold, a warning will be logged. If less disk space is available than defined as read-only threshold,
+the Mesh instance (in cluster mode all Mesh instances) will be set read-only, so mutating requests will all fail
+with an appropriate message.
+
+The thresholds can be configured with the configuration settings `storage.diskQuota.warnThreshold` and `storage.diskQuota.readOnlyThreshold` either as percentage of the total disk space (e.g. `10%`) or as absolute disk space (e.g. `10M`). The check interval can be configured with `storage.diskQuota.checkInterval` (in ms). Setting this to `0` will disable the check.
+
 ==== Cluster Requirements
 
 * Each Gentics Mesh instance needs at least 1.5 GB heap memory.

--- a/doc/src/main/docs/monitoring.asciidoc
+++ b/doc/src/main/docs/monitoring.asciidoc
@@ -183,6 +183,12 @@ More metrics will be added over time.
 | `graphql_time`
 | Timer which tracks duration of graphql requests.
 
+| `mesh_storage_disk_total`
+| Total disk size in bytes for the storage.
+
+| `mesh_storage_disk_usable`
+| Usable (free) disk size in bytes for the storage.
+
 |======
 
 

--- a/services/jwt-auth/src/main/java/com/gentics/mesh/auth/oauth2/MeshOAuth2ServiceImpl.java
+++ b/services/jwt-auth/src/main/java/com/gentics/mesh/auth/oauth2/MeshOAuth2ServiceImpl.java
@@ -260,6 +260,9 @@ public class MeshOAuth2ServiceImpl implements MeshOAuthService {
 	}
 
 	private Completable assertReadOnlyDeactivated() {
+		if (db.isReadOnly(true)) {
+			return Completable.error(error(METHOD_NOT_ALLOWED, "error_readonly_mode_oauth"));
+		}
 		return localConfigApi.getActiveConfig()
 			.flatMapCompletable(config -> {
 				if (config.isReadOnly()) {

--- a/test-common/src/main/java/com/gentics/mesh/mock/MockingLoggerRule.java
+++ b/test-common/src/main/java/com/gentics/mesh/mock/MockingLoggerRule.java
@@ -1,0 +1,55 @@
+package com.gentics.mesh.mock;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.mockito.Mockito;
+
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.spi.logging.LogDelegate;
+import io.vertx.core.spi.logging.LogDelegateFactory;
+
+/**
+ * Test rule, that will register itself as logger delegate factory for vert.x logging.
+ * Every LogDelegate will be a mock, and they will all be stored in a static map, so that tests can get the mocks and can verify specific log messages
+ */
+public class MockingLoggerRule extends TestWatcher implements LogDelegateFactory {
+	/**
+	 * Static map of all mocks, which were created
+	 */
+	protected static Map<String, LogDelegate> mocks = new HashMap<>();
+
+	/**
+	 * When a test is starting, register as logger delegate factory
+	 */
+	@Override
+	protected void starting(Description description) {
+		System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME, MockingLoggerRule.class.getName());
+	}
+
+	/**
+	 * When a test finished, reset all mocks
+	 */
+	@Override
+	protected void finished(Description description) {
+		mocks.values().forEach(mock -> Mockito.reset(mock));
+	}
+
+	/**
+	 * Get the LogDelegate (mock) for the given logger
+	 * @param name logger name
+	 * @return LogDelegate mock
+	 */
+	public LogDelegate get(String name) {
+		return mocks.computeIfAbsent(name, key -> mock(LogDelegate.class));
+	}
+
+	@Override
+	public LogDelegate createDelegate(String name) {
+		return get(name);
+	}
+}


### PR DESCRIPTION
## Abstract

When the disk, where the OrientDB database is located becomes full, this may cause a corruption of the database. To avoid this, a periodic check for available disk space has been added, which will log warnings (if less than the "warn" threshold is available) or log errors and set Mesh to be read-only (if less than the "read-only" threshold is available).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
