### PR TITLE
Configure CORS for S3

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,11 @@ include::content/docs/variables.adoc-include[]
 
 * The support for the *embedded* version of Elasticsearch will be dropped in the future. It is highly recommended to link:{{< relref "elasticsearch.asciidoc" >}}#_dedicated_elasticsearch[setup Elasticsearch as a dedicated service].
 
+[[v1.7.21]]
+== 1.7.21 (TBD)
+
+icon:plus[] AWS S3: Now the Cross-Origin Request Settings parameters of a S3 connection can be configured. By default the allowed headers/origins are set to `*`, the allowed methods are set to `"GET", "PUT", "POST", "DELETE"`. Setting any of the CORS configuration to `null` prevents is to override the server's default configuration. Setting all the CORS configuration to null or empty value prevents the CORS config to be changed at all.
+
 [[v1.7.20]]
 == 1.7.20 (19.10.2021)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.23]]
+== 1.6.23 (TBD)
+
+icon:plus[] AWS S3: Now the Cross-Origin Request Settings parameters of a S3 connection can be configured. By default the allowed headers/origins are set to `*`, the allowed methods are set to `"GET", "PUT", "POST", "DELETE"`. Setting any of the CORS configuration to `null` prevents is to override the server's default configuration. Setting all the CORS configuration to null or empty value prevents the CORS config to be changed at all.
+
 [[v1.6.22]]
 == 1.6.22 (19.10.2021)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/S3Options.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/S3Options.java
@@ -1,13 +1,17 @@
 package com.gentics.mesh.etc.config;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.annotation.Setter;
 import com.gentics.mesh.doc.GenerateDocumentation;
 import com.gentics.mesh.etc.config.env.EnvironmentVariable;
 import com.gentics.mesh.etc.config.env.Option;
-
-import java.util.Set;
 
 /**
  * S3 configuration POJO.
@@ -21,6 +25,9 @@ public class S3Options implements Option {
 	public static final int DEFAULT_EXPIRATION_TIME_UPLOAD = 60_000;
 	public static final int DEFAULT_EXPIRATION_TIME_DOWNLOAD = 360_000;
 	public static final int DEFAULT_PARSER_LIMIT = 40_000;
+	public static final List<String> DEFAULT_CORS_ALLOWED_HEADERS = Arrays.asList("*");
+	public static final List<String> DEFAULT_CORS_ALLOWED_ORIGINS = Arrays.asList("*");
+	public static final List<String> DEFAULT_CORS_ALLOWED_METHODS = Arrays.asList("GET", "PUT", "POST", "DELETE");
 
 	public static final String MESH_S3_BINARY_ENABLED_KEY_ENV = "MESH_S3_BINARY_ENABLED_KEY";
 	public static final String MESH_S3_BINARY_SECRET_ACCESS_KEY_ENV = "MESH_S3_BINARY_SECRET_ACCESS_KEY";
@@ -33,6 +40,9 @@ public class S3Options implements Option {
 	public static final String MESH_S3_BINARY_METADATA_WHITELIST_ENV = "MESH_S3_BINARY_METADATA_WHITELIST";
 	public static final String MESH_S3_BINARY_PARSER_LIMIT_ENV = "MESH_S3_BINARY_PARSER_LIMIT";
 	public static final String MESH_S3_BINARY_REGION_ENV = "MESH_S3_BINARY_REGION";
+	public static final String MESH_S3_CORS_ALLOWED_ORIGINS_ENV = "MESH_S3_CORS_ALLOWED_ORIGINS";
+	public static final String MESH_S3_CORS_ALLOWED_HEADERS_ENV = "MESH_S3_CORS_ALLOWED_HEADERS";
+	public static final String MESH_S3_CORS_ALLOWED_METHODS_ENV = "MESH_S3_CORS_ALLOWED_METHODS";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Flag to enable or disable the S3 engine.")
@@ -92,6 +102,21 @@ public class S3Options implements Option {
 	@JsonProperty(required = true)
 	@JsonPropertyDescription("S3 Cache Bucket Options.")
 	private S3CacheOptions s3cacheOptions = new S3CacheOptions();
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("AWS S3 setting for allowed headers for Cross-Origin Resource Sharing. Setting this to null will force default server values.")
+	@EnvironmentVariable(name = MESH_S3_CORS_ALLOWED_HEADERS_ENV, description = "Override the configured AWS S3 CORS allowed headers.")
+	private List<String> corsAllowedHeaders = DEFAULT_CORS_ALLOWED_HEADERS;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("AWS S3 setting for allowed origins for Cross-Origin Resource Sharing. Setting this to null will force default server values.")
+	@EnvironmentVariable(name = MESH_S3_CORS_ALLOWED_ORIGINS_ENV, description = "Override the configured AWS S3 CORS allowed origins.")
+	private List<String> corsAllowedOrigins = DEFAULT_CORS_ALLOWED_ORIGINS;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("AWS S3 setting for allowed methods for Cross-Origin Resource Sharing. Setting this to null will force default server values.")
+	@EnvironmentVariable(name = MESH_S3_CORS_ALLOWED_METHODS_ENV, description = "Override the configured AWS S3 CORS allowed methods.")
+	private List<String> corsAllowedMethods = DEFAULT_CORS_ALLOWED_METHODS;
 
 	@JsonProperty("s3cacheOptions")
 	public S3CacheOptions getS3CacheOptions() {
@@ -225,5 +250,32 @@ public class S3Options implements Option {
 						"You have not specified the required S3 parameters: accessKeyId, secretAccessKey, bucket, region. Please either fill in the required parameters or disable S3 support.");
 			}
 		}
+	}
+
+	public List<String> getCorsAllowedHeaders() {
+		return corsAllowedHeaders;
+	}
+
+	@Setter
+	public void setCorsAllowedHeaders(Collection<String> corsAllowedHeaders) {
+		this.corsAllowedHeaders = corsAllowedHeaders == null ? null : new ArrayList<>(corsAllowedHeaders);
+	}
+
+	@Setter
+	public List<String> getCorsAllowedOrigins() {
+		return corsAllowedOrigins;
+	}
+
+	@Setter
+	public void setCorsAllowedOrigins(Collection<String> corsAllowedOrigins) {
+		this.corsAllowedOrigins = corsAllowedOrigins == null ? null : new ArrayList<>(corsAllowedOrigins);
+	}
+
+	public List<String> getCorsAllowedMethods() {
+		return corsAllowedMethods;
+	}
+
+	public void setCorsAllowedMethods(Collection<String> corsAllowedMethods) {
+		this.corsAllowedMethods = corsAllowedMethods == null ? null : new ArrayList<>(corsAllowedMethods);
 	}
 }

--- a/tests/common/src/main/java/com/gentics/mesh/test/docker/AWSContainer.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/docker/AWSContainer.java
@@ -34,6 +34,7 @@ public class AWSContainer extends GenericContainer<AWSContainer> {
             withEnv(MINIO_ACCESS_KEY, credentials.getAccessKey());
             withEnv(MINIO_SECRET_KEY, credentials.getSecretKey());
         }
+        withEnv("MINIO_HTTP_TRACE", "/dev/stdout");
         withCommand("server", DEFAULT_STORAGE_DIRECTORY);
         setWaitStrategy(new HttpWaitStrategy()
                 .forPort(DEFAULT_PORT)

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -628,11 +628,14 @@ public class MeshTestContext extends TestWatcher {
 			case AWS:
 				break;
 			case MINIO:
-				AWSContainer awsContainer = new AWSContainer(
-						new AWSContainer.CredentialsProvider("accessKey", "secretKey"));
-				awsContainer.start();
 				String ACCESS_KEY = "accessKey";
 				String SECRET_KEY = "secretKey";
+				AWSContainer awsContainer = new AWSContainer(
+						new AWSContainer.CredentialsProvider(ACCESS_KEY, SECRET_KEY));
+				awsContainer.start();
+				s3Options.setCorsAllowedOrigins(null);
+				s3Options.setCorsAllowedHeaders(null);
+				s3Options.setCorsAllowedMethods(null);
 				s3Options.setEnabled(true);
 				s3Options.setAccessKeyId(ACCESS_KEY);
 				s3Options.setBucket("test-bucket");


### PR DESCRIPTION
## Abstract

Allow CORS options being configured for AWS S3. This will also fix our unit tests based on MINIO. This fix can also be ported to dev/hotfix.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
