### PR TITLE
Fix class cast exception (happening in enterprise)

### DIFF
--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
@@ -104,7 +104,7 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 		}
 		if (fieldProperties.get(SchemaChangeModel.ELASTICSEARCH_KEY) != null) {
 			Object value = fieldProperties.get(ELASTICSEARCH_KEY);
-			JsonObject options = new JsonObject((String) value);
+			JsonObject options = value instanceof JsonObject ? (JsonObject) value : new JsonObject((String) value);
 			setElasticsearch(options);
 		}
 


### PR DESCRIPTION
## Abstract
Updating a schema field type in enterprise is currently not working due to a class cast exception. This fix the error

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
