### PR TITLE
Fix changelog system to store database revision and Mesh version

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,9 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.14`.
 
+icon:check[] Cluster: When doing a rolling update in a cluster, a OConcurrentModificationException could occur during the startup, which could cause
+subsequent errors. This has been fixed.
+
 [[v1.6.22]]
 == 1.6.22 (19.10.2021)
 

--- a/changelog-system/src/main/java/com/gentics/mesh/changelog/ChangelogSystem.java
+++ b/changelog-system/src/main/java/com/gentics/mesh/changelog/ChangelogSystem.java
@@ -2,6 +2,8 @@ package com.gentics.mesh.changelog;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.gentics.mesh.Mesh;
 import com.gentics.mesh.changelog.changes.ChangesList;
 import com.gentics.mesh.cli.PostProcessFlags;
@@ -139,19 +141,20 @@ public class ChangelogSystem {
 		log.info("Updating stored database revision and mesh version.");
 		// Version is okay. So lets store the version and the updated revision.
 		String currentVersion = Mesh.getPlainVersion();
-		TransactionalGraph graph = db.rawTx();
-		try {
-			Vertex root = MeshGraphHelper.getMeshRootVertex(graph);
+
+		db.tx(tx -> {
+			Vertex root = MeshGraphHelper.getMeshRootVertex(tx.getGraph());
 			String rev = db.getDatabaseRevision();
-			if (!Objects.equal(root.getProperty(MESH_VERSION), currentVersion)) {
+			String storedVersion = root.getProperty(MESH_VERSION);
+			String storedRev = root.getProperty(MESH_DB_REV);
+			if (!Objects.equal(storedVersion, currentVersion)) {
+				log.info("Changing persisted Mesh Version from {} to {}", storedVersion, currentVersion);
 				root.setProperty(MESH_VERSION, currentVersion);
 			}
-			if (!Objects.equal(root.getProperty(MESH_DB_REV), rev)) {
+			if (!Objects.equal(storedRev, rev)) {
+				log.info("Changing persisted DB Revision from {} to {}", storedRev, rev);
 				root.setProperty(MESH_DB_REV, rev);
 			}
-			graph.commit();
-		} finally {
-			graph.shutdown();
-		}
+		});
 	}
 }


### PR DESCRIPTION
with the "normal" transaction, which fixes a possible
OConcurrentModificationException during a rolling update.

## Abstract

When doing a rolling update with a new db revision, the first updated instance would write the new db revision into the MeshRootImpl. The second updated instance would get the change via a sync, and would also try to update the db revision, which caused a OConcurrentModificationException.
The mechanism writing the db revision has been changed to use the "normal" transaction, which fixes the problem.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
