### PR TITLE
CL-648 extract common logic to persisting dao: user/role/group

### DIFF
--- a/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
+++ b/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
@@ -260,7 +260,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 					sb.append("- Password: " + pw + "\n");
 					sb.append("-----------------------\n");
 					// TODO figure out a way to avoid the encode call during test execution. This will otherwise slow down tests big time.
-					adminUser.setPasswordHash(hash);
+					tx.userDao().changePasswordHash(adminUser, hash);
 					if (config.isForceInitialAdminPasswordReset()) {
 						sb.append("- Password reset forced on initial login.\n");
 						adminUser.setForcedPasswordChange(true);
@@ -833,7 +833,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 					anonymousUser.setCreationTimestamp();
 					anonymousUser.setEditor(anonymousUser);
 					anonymousUser.setLastEditedTimestamp();
-					anonymousUser.setPasswordHash(null);
+					tx.userDao().changePasswordHash(anonymousUser, null);
 					log.debug("Created anonymous user {" + anonymousUser.getUuid() + "}");
 				}
 

--- a/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
+++ b/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
@@ -260,7 +260,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 					sb.append("- Password: " + pw + "\n");
 					sb.append("-----------------------\n");
 					// TODO figure out a way to avoid the encode call during test execution. This will otherwise slow down tests big time.
-					tx.userDao().changePasswordHash(adminUser, hash);
+					tx.userDao().updatePasswordHash(adminUser, hash);
 					if (config.isForceInitialAdminPasswordReset()) {
 						sb.append("- Password reset forced on initial login.\n");
 						adminUser.setForcedPasswordChange(true);
@@ -833,7 +833,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 					anonymousUser.setCreationTimestamp();
 					anonymousUser.setEditor(anonymousUser);
 					anonymousUser.setLastEditedTimestamp();
-					tx.userDao().changePasswordHash(anonymousUser, null);
+					tx.userDao().updatePasswordHash(anonymousUser, null);
 					log.debug("Created anonymous user {" + anonymousUser.getUuid() + "}");
 				}
 

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/GroupImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/GroupImpl.java
@@ -1,21 +1,15 @@
 package com.gentics.mesh.core.data.impl;
 
-import static com.gentics.mesh.core.data.util.HibClassConverter.toGraph;
 import static com.gentics.mesh.madl.index.VertexIndexDefinition.vertexIndex;
-
-import java.util.Set;
 
 import com.gentics.madl.index.IndexHandler;
 import com.gentics.madl.type.TypeHandler;
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.Group;
-import com.gentics.mesh.core.data.User;
 import com.gentics.mesh.core.data.dao.GroupDao;
 import com.gentics.mesh.core.data.generic.AbstractMeshCoreVertex;
 import com.gentics.mesh.core.data.generic.MeshVertexImpl;
-import com.gentics.mesh.core.data.perm.InternalPermission;
-import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.search.BucketableElementHelper;
 import com.gentics.mesh.core.data.user.HibUser;
 import com.gentics.mesh.core.db.Tx;
@@ -69,21 +63,6 @@ public class GroupImpl extends AbstractMeshCoreVertex<GroupResponse> implements 
 	}
 
 	@Override
-	public boolean applyPermissions(EventQueueBatch batch, HibRole role, boolean recursive, Set<InternalPermission> permissionsToGrant,
-		Set<InternalPermission> permissionsToRevoke) {
-		GroupDao groupDao = Tx.get().groupDao();
-		boolean permissionChanged = false;
-		if (recursive) {
-			for (HibUser user : groupDao.getUsers(this)) {
-				User graphUser = toGraph(user);
-				permissionChanged = graphUser.applyPermissions(batch, role, false, permissionsToGrant, permissionsToRevoke) || permissionChanged;
-			}
-		}
-		permissionChanged = super.applyPermissions(batch, role, recursive, permissionsToGrant, permissionsToRevoke) || permissionChanged;
-		return permissionChanged;
-	}
-
-	@Override
 	public HibUser getCreator() {
 		return mesh().userProperties().getCreator(this);
 	}
@@ -91,11 +70,6 @@ public class GroupImpl extends AbstractMeshCoreVertex<GroupResponse> implements 
 	@Override
 	public HibUser getEditor() {
 		return mesh().userProperties().getEditor(this);
-	}
-
-	@Override
-	public void removeElement() {
-		getElement().remove();
 	}
 
 	@Override

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -296,8 +296,6 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse> implements Us
 	@Override
 	public User setPasswordHash(String hash) {
 		property(PASSWORD_HASH_PROPERTY_KEY, hash);
-		// Password has changed, the user is not forced to change their password anymore.
-		setForcedPasswordChange(false);
 		return this;
 	}
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/GroupDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/GroupDao.java
@@ -66,22 +66,6 @@ public interface GroupDao extends DaoGlobal<HibGroup>, DaoTransformable<HibGroup
 	GroupRoleAssignModel createRoleAssignmentEvent(HibGroup group, HibRole role, Assignment assignment);
 
 	/**
-	 * Add the group to the aggregation vertex.
-	 * 
-	 * @param group
-	 *            HibGroup to be added
-	 */
-	void addGroup(HibGroup group);
-
-	/**
-	 * Remove the group from the aggregation vertex.
-	 * 
-	 * @param group
-	 *            HibGroup to be removed
-	 */
-	void removeGroup(HibGroup group);
-
-	/**
 	 * Assign the given user to this group.
 	 *
 	 * @param group

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/RoleDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/RoleDao.java
@@ -47,7 +47,7 @@ public interface RoleDao extends DaoGlobal<HibRole>, DaoTransformable<HibRole, R
 
 	/**
 	 * Create a new role
-	 * 
+	 *
 	 * @param ac
 	 * @param batch
 	 * @param uuid
@@ -57,7 +57,7 @@ public interface RoleDao extends DaoGlobal<HibRole>, DaoTransformable<HibRole, R
 	HibRole create(InternalActionContext ac, EventQueueBatch batch, String uuid);
 
 	/**
-	 * Grant the given permissions on the vertex.
+	 * Grant the given permissions on the given role.
 	 *
 	 * @param role
 	 * @param element
@@ -67,7 +67,7 @@ public interface RoleDao extends DaoGlobal<HibRole>, DaoTransformable<HibRole, R
 	boolean grantPermissions(HibRole role, HibBaseElement element, InternalPermission... permissions);
 
 	/**
-	 * Revoke the given permissions on the vertex.
+	 * Revoke the given permissions on the given role.
 	 *
 	 * @param role
 	 * @param element
@@ -86,7 +86,7 @@ public interface RoleDao extends DaoGlobal<HibRole>, DaoTransformable<HibRole, R
 	Set<InternalPermission> getPermissions(HibRole role, HibBaseElement element);
 
 	/**
-	 * Add the given role to this aggregation vertex.
+	 * Add the given role to this role.
 	 * 
 	 * @param role
 	 *            HibRoleto be added
@@ -94,7 +94,7 @@ public interface RoleDao extends DaoGlobal<HibRole>, DaoTransformable<HibRole, R
 	void addRole(HibRole role);
 
 	/**
-	 * Remove the given role from this aggregation vertex.
+	 * Remove the given role from this role.
 	 * 
 	 * @param role
 	 *            HibRoleto be removed

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/UserDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/UserDao.java
@@ -317,4 +317,10 @@ public interface UserDao extends DaoGlobal<HibUser>, DaoTransformable<HibUser, U
 	 * @return A hash of the users roles
 	 */
 	String getRolesHash(HibUser user);
+
+	/**
+	 * Set the user password hash and update forced password change flag
+	 * @param passwordHash
+	 */
+	void changePasswordHash(HibUser user, String passwordHash);
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/UserDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/UserDao.java
@@ -322,5 +322,5 @@ public interface UserDao extends DaoGlobal<HibUser>, DaoTransformable<HibUser, U
 	 * Set the user password hash and update forced password change flag
 	 * @param passwordHash
 	 */
-	void changePasswordHash(HibUser user, String passwordHash);
+	void updatePasswordHash(HibUser user, String passwordHash);
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/group/HibGroup.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/group/HibGroup.java
@@ -7,14 +7,19 @@ import static com.gentics.mesh.core.rest.MeshEvent.GROUP_UPDATED;
 import com.gentics.mesh.ElementType;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.TypeInfo;
-import com.gentics.mesh.core.data.HibBucketableElement;
-import com.gentics.mesh.core.data.HibCoreElement;
-import com.gentics.mesh.core.data.HibNamedElement;
-import com.gentics.mesh.core.data.HibReferenceableElement;
+import com.gentics.mesh.core.data.*;
+import com.gentics.mesh.core.data.dao.GroupDao;
+import com.gentics.mesh.core.data.perm.InternalPermission;
+import com.gentics.mesh.core.data.role.HibRole;
+import com.gentics.mesh.core.data.user.HibUser;
 import com.gentics.mesh.core.data.user.HibUserTracking;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.group.GroupReference;
 import com.gentics.mesh.core.rest.group.GroupResponse;
+import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.handler.VersionUtils;
+
+import java.util.Set;
 
 /**
  * Domain model for group.
@@ -36,13 +41,6 @@ public interface HibGroup extends HibCoreElement<GroupResponse>, HibReferenceabl
 	GroupReference transformToReference();
 
 	/**
-	 * Delete the element.
-	 * 
-	 * TODO: This method should be removed in the future.
-	 */
-	void removeElement();
-
-	/**
 	 * Return the current element version.
 	 * 
 	 * TODO: Check how versions can be accessed via Hibernate and refactor / remove this method accordingly
@@ -58,5 +56,18 @@ public interface HibGroup extends HibCoreElement<GroupResponse>, HibReferenceabl
 	@Override
 	default String getAPIPath(InternalActionContext ac) {
 		return VersionUtils.baseRoute(ac) + "/groups/" + getUuid();
+	}
+
+	@Override
+	default boolean applyPermissions(EventQueueBatch batch, HibRole role, boolean recursive, Set<InternalPermission> permissionsToGrant, Set<InternalPermission> permissionsToRevoke) {
+		GroupDao groupDao = Tx.get().groupDao();
+		boolean permissionChanged = false;
+		if (recursive) {
+			for (HibUser user : groupDao.getUsers(this)) {
+				permissionChanged = user.applyPermissions(batch, role, false, permissionsToGrant, permissionsToRevoke) || permissionChanged;
+			}
+		}
+		permissionChanged = HibCoreElement.super.applyPermissions(batch, role, recursive, permissionsToGrant, permissionsToRevoke) || permissionChanged;
+		return permissionChanged;
 	}
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingGroupDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingGroupDao.java
@@ -1,6 +1,34 @@
 package com.gentics.mesh.core.data.dao;
 
+import com.gentics.mesh.context.BulkActionContext;
+import com.gentics.mesh.context.InternalActionContext;
+import com.gentics.mesh.core.data.HibBaseElement;
 import com.gentics.mesh.core.data.group.HibGroup;
+import com.gentics.mesh.core.data.role.HibRole;
+import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.Tx;
+import com.gentics.mesh.core.rest.event.group.GroupRoleAssignModel;
+import com.gentics.mesh.core.rest.event.group.GroupUserAssignModel;
+import com.gentics.mesh.core.rest.group.GroupCreateRequest;
+import com.gentics.mesh.core.rest.group.GroupResponse;
+import com.gentics.mesh.core.rest.group.GroupUpdateRequest;
+import com.gentics.mesh.event.Assignment;
+import com.gentics.mesh.event.EventQueueBatch;
+import com.gentics.mesh.parameter.GenericParameters;
+import com.gentics.mesh.parameter.value.FieldsSet;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.gentics.mesh.core.data.perm.InternalPermission.CREATE_PERM;
+import static com.gentics.mesh.core.rest.MeshEvent.*;
+import static com.gentics.mesh.core.rest.MeshEvent.GROUP_USER_UNASSIGNED;
+import static com.gentics.mesh.core.rest.error.Errors.conflict;
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * A persisting extension to {@link SchemaDao}
@@ -10,4 +38,130 @@ import com.gentics.mesh.core.data.group.HibGroup;
  */
 public interface PersistingGroupDao extends GroupDao, PersistingDaoGlobal<HibGroup> {
 
+    @Override
+    default HibGroup create(InternalActionContext ac, EventQueueBatch batch, String uuid) {
+        HibUser requestUser = ac.getUser();
+        UserDao userDao = Tx.get().userDao();
+        GroupCreateRequest requestModel = ac.fromJson(GroupCreateRequest.class);
+
+        if (StringUtils.isEmpty(requestModel.getName())) {
+            throw error(BAD_REQUEST, "error_name_must_be_set");
+        }
+        HibBaseElement groupPermissionRoot = Tx.get().data().permissionRoots().group();
+        if (!userDao.hasPermission(requestUser, groupPermissionRoot, CREATE_PERM)) {
+            throw error(FORBIDDEN, "error_missing_perm", groupPermissionRoot.getUuid(), CREATE_PERM.getRestPerm().getName());
+        }
+
+        // Check whether a group with the same name already exists
+        HibGroup groupWithSameName = findByName(requestModel.getName());
+        // TODO why would we want to check for uuid's here? Makes no sense: && !groupWithSameName.getUuid().equals(getUuid())
+        if (groupWithSameName != null) {
+            throw conflict(groupWithSameName.getUuid(), requestModel.getName(), "group_conflicting_name", requestModel.getName());
+        }
+
+        // Finally create the group and set the permissions
+        HibGroup group = create(requestModel.getName(), requestUser, uuid);
+        userDao.inheritRolePermissions(requestUser, groupPermissionRoot, group);
+        batch.add(group.onCreated());
+        return group;
+    }
+
+    @Override
+    default HibGroup create(String name, HibUser user, String uuid) {
+        HibGroup group = createPersisted(uuid);
+        group.setName(name);
+        group.setCreated(user);
+        group.generateBucketId();
+        return group;
+    }
+
+    @Override
+    default GroupRoleAssignModel createRoleAssignmentEvent(HibGroup group, HibRole role, Assignment assignment) {
+        GroupRoleAssignModel model = new GroupRoleAssignModel();
+        model.setGroup(group.transformToReference());
+        model.setRole(role.transformToReference());
+        switch (assignment) {
+            case ASSIGNED:
+                model.setEvent(GROUP_ROLE_ASSIGNED);
+                break;
+            case UNASSIGNED:
+                model.setEvent(GROUP_ROLE_UNASSIGNED);
+                break;
+        }
+        return model;
+    }
+
+    @Override
+    default GroupUserAssignModel createUserAssignmentEvent(HibGroup group, HibUser user, Assignment assignment) {
+        GroupUserAssignModel model = new GroupUserAssignModel();
+        model.setGroup(group.transformToReference());
+        model.setUser(user.transformToReference());
+        switch (assignment) {
+            case ASSIGNED:
+                model.setEvent(GROUP_USER_ASSIGNED);
+                break;
+            case UNASSIGNED:
+                model.setEvent(GROUP_USER_UNASSIGNED);
+                break;
+        }
+        return model;
+    }
+
+    @Override
+    default boolean update(HibGroup group, InternalActionContext ac, EventQueueBatch batch) {
+        GroupUpdateRequest requestModel = ac.fromJson(GroupUpdateRequest.class);
+
+        if (isEmpty(requestModel.getName())) {
+            throw error(BAD_REQUEST, "error_name_must_be_set");
+        }
+
+        if (shouldUpdate(requestModel.getName(), group.getName())) {
+            HibGroup groupWithSameName = findByName(requestModel.getName());
+            if (groupWithSameName != null && !groupWithSameName.getUuid().equals(group.getUuid())) {
+                throw conflict(groupWithSameName.getUuid(), requestModel.getName(), "group_conflicting_name", requestModel.getName());
+            }
+
+            group.setName(requestModel.getName());
+
+            batch.add(group.onUpdated());
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    default void delete(HibGroup group, BulkActionContext bac) {
+        bac.batch().add(group.onDeleted());
+        deletePersisted(group);
+        Set<? extends HibUser> affectedUsers = getUsers(group).stream().collect(Collectors.toSet());
+        for (HibUser affectedUser : affectedUsers) {
+            bac.add(affectedUser.onUpdated());
+            bac.inc();
+        }
+        bac.process();
+
+        Tx.get().permissionCache().clear();
+    }
+
+    @Override
+    default GroupResponse transformToRestSync(HibGroup group, InternalActionContext ac, int level, String... languageTags) {
+        GenericParameters generic = ac.getGenericParameters();
+        FieldsSet fields = generic.getFields();
+
+        GroupResponse restGroup = new GroupResponse();
+        if (fields.has("name")) {
+            restGroup.setName(group.getName());
+        }
+        if (fields.has("roles")) {
+            for (HibRole role : getRoles(group)) {
+                String name = role.getName();
+                if (name != null) {
+                    restGroup.getRoles().add(role.transformToReference());
+                }
+            }
+        }
+        group.fillCommonRestFields(ac, fields, restGroup);
+        return restGroup;
+    }
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingRoleDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingRoleDao.java
@@ -1,6 +1,22 @@
 package com.gentics.mesh.core.data.dao;
 
+import com.gentics.mesh.cache.PermissionCache;
+import com.gentics.mesh.context.BulkActionContext;
+import com.gentics.mesh.context.InternalActionContext;
+import com.gentics.mesh.core.data.HibBaseElement;
+import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.data.role.HibRole;
+import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.Tx;
+import com.gentics.mesh.core.rest.role.RoleCreateRequest;
+import com.gentics.mesh.event.EventQueueBatch;
+import org.apache.commons.lang3.StringUtils;
+
+import static com.gentics.mesh.core.data.perm.InternalPermission.CREATE_PERM;
+import static com.gentics.mesh.core.rest.error.Errors.conflict;
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 
 /**
  * A persisting extension to {@link RoleDao}
@@ -10,4 +26,74 @@ import com.gentics.mesh.core.data.role.HibRole;
  */
 public interface PersistingRoleDao extends RoleDao, PersistingDaoGlobal<HibRole> {
 
+    /**
+     * Create a new role
+     *
+     * @param ac
+     * @param batch
+     * @param uuid
+     *            Uuid of the role
+     * @return
+     */
+    default HibRole create(InternalActionContext ac, EventQueueBatch batch, String uuid) {
+        RoleCreateRequest requestModel = ac.fromJson(RoleCreateRequest.class);
+        String roleName = requestModel.getName();
+        UserDao userDao = Tx.get().userDao();
+        HibBaseElement roleRoot = Tx.get().data().permissionRoots().role();
+
+        HibUser requestUser = ac.getUser();
+        if (StringUtils.isEmpty(roleName)) {
+            throw error(BAD_REQUEST, "error_name_must_be_set");
+        }
+
+        HibRole conflictingRole = findByName(roleName);
+        if (conflictingRole != null) {
+            throw conflict(conflictingRole.getUuid(), roleName, "role_conflicting_name");
+        }
+
+        if (!userDao.hasPermission(requestUser, roleRoot, CREATE_PERM)) {
+            throw error(FORBIDDEN, "error_missing_perm", roleRoot.getUuid(), CREATE_PERM.getRestPerm().getName());
+        }
+
+        HibRole role = create(requestModel.getName(), requestUser, uuid);
+        userDao.inheritRolePermissions(requestUser, roleRoot, role);
+        batch.add(role.onCreated());
+        return role;
+    }
+
+    /**
+     * Revoke the given permissions and clear the cache when successful
+     *
+     * @param role
+     * @param element
+     * @param permissions
+     * @return
+     */
+    default boolean revokePermissions(HibRole role, HibBaseElement element, InternalPermission... permissions) {
+        boolean permissionsRevoked = revokeRolePermissions(role, element, permissions);
+        if (permissionsRevoked) {
+            PermissionCache cache = Tx.get().permissionCache();
+            cache.clear();
+        }
+
+        return permissionsRevoked;
+    }
+
+    /**
+     * Revoke role permission. Consumers implementing this method do not need to invalidate the cache
+     * @param role the role
+     * @param element
+     * @param permissions
+     */
+    boolean revokeRolePermissions(HibRole role, HibBaseElement element, InternalPermission... permissions);
+
+    @Override
+    default void delete(HibRole role, BulkActionContext bac) {
+        bac.add(role.onDeleted());
+        deletePersisted(role);
+        bac.process();
+        PermissionCache permissionCache = Tx.get().permissionCache();
+
+        permissionCache.clear();
+    }
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingRoleDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingRoleDao.java
@@ -75,7 +75,6 @@ public interface PersistingRoleDao extends RoleDao, PersistingDaoGlobal<HibRole>
             PermissionCache cache = Tx.get().permissionCache();
             cache.clear();
         }
-
         return permissionsRevoked;
     }
 

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingSchemaDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingSchemaDao.java
@@ -436,7 +436,7 @@ public interface PersistingSchemaDao extends SchemaDao, PersistingContainerDao<S
 			job.remove();
 		}
 		// Delete version
-		((CommonTx) Tx.get()).delete(version, version.getClass());
+		CommonTx.get().delete(version, version.getClass());
 	}
 
 	/**

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingUserDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingUserDao.java
@@ -48,6 +48,7 @@ import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.parameter.GenericParameters;
 import com.gentics.mesh.parameter.NodeParameters;
 import com.gentics.mesh.parameter.value.FieldsSet;
+
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -75,7 +76,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 	 * @return
 	 */
 	default boolean hasPermission(HibUser user, HibBaseElement element, InternalPermission permission) {
-		if (log.isTraceEnabled()) {
+		if (log.isDebugEnabled()) {
 			log.debug("Checking permissions for element {" + element.getUuid() + "}");
 		}
 		return hasPermissionForId(user, element.getId(), permission);
@@ -505,7 +506,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 		user.setUsername(requestModel.getUsername());
 		user.setLastname(requestModel.getLastname());
 		user.setEmailAddress(requestModel.getEmailAddress());
-		changePasswordHash(user, Tx.get().passwordEncoder().encode(requestModel.getPassword()));
+		updatePasswordHash(user, Tx.get().passwordEncoder().encode(requestModel.getPassword()));
 		Boolean forcedPasswordChange = requestModel.getForcedPasswordChange();
 		if (forcedPasswordChange != null) {
 			user.setForcedPasswordChange(forcedPasswordChange);
@@ -576,12 +577,12 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 	@Override
 	default HibUser setPassword(HibUser user, String password) {
 		String hashedPassword = Tx.get().passwordEncoder().encode(password);
-		changePasswordHash(user, hashedPassword);
+		updatePasswordHash(user, hashedPassword);
 		return mergeIntoPersisted(user);
 	}
 
 	@Override
-	default void changePasswordHash(HibUser user, String passwordHash) {
+	default void updatePasswordHash(HibUser user, String passwordHash) {
 		user.setPasswordHash(passwordHash);
 		// Password has changed, the user is not forced to change their password anymore.
 		user.setForcedPasswordChange(false);
@@ -652,7 +653,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 
 		if (!isEmpty(requestModel.getPassword())) {
 			if (!dry) {
-				changePasswordHash(user, Tx.get().passwordEncoder().encode(requestModel.getPassword()));
+				updatePasswordHash(user, Tx.get().passwordEncoder().encode(requestModel.getPassword()));
 			}
 			modified = true;
 		}

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/GroupDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/GroupDaoWrapperImpl.java
@@ -1,32 +1,17 @@
 package com.gentics.mesh.core.data.dao.impl;
 
-import static com.gentics.mesh.core.data.perm.InternalPermission.CREATE_PERM;
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.ASSIGNED_TO_ROLE;
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_ROLE;
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_USER;
 import static com.gentics.mesh.core.data.util.HibClassConverter.toGraph;
-import static com.gentics.mesh.core.rest.MeshEvent.GROUP_ROLE_ASSIGNED;
-import static com.gentics.mesh.core.rest.MeshEvent.GROUP_ROLE_UNASSIGNED;
-import static com.gentics.mesh.core.rest.MeshEvent.GROUP_USER_ASSIGNED;
-import static com.gentics.mesh.core.rest.MeshEvent.GROUP_USER_UNASSIGNED;
-import static com.gentics.mesh.core.rest.error.Errors.conflict;
-import static com.gentics.mesh.core.rest.error.Errors.error;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.gentics.mesh.cache.PermissionCache;
 import com.gentics.mesh.cli.OrientDBBootstrapInitializer;
-import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.Group;
 import com.gentics.mesh.core.data.Role;
@@ -34,7 +19,6 @@ import com.gentics.mesh.core.data.User;
 import com.gentics.mesh.core.data.dao.AbstractCoreDaoWrapper;
 import com.gentics.mesh.core.data.dao.GroupDaoWrapper;
 import com.gentics.mesh.core.data.dao.PersistingUserDao;
-import com.gentics.mesh.core.data.dao.UserDao;
 import com.gentics.mesh.core.data.generic.PermissionPropertiesImpl;
 import com.gentics.mesh.core.data.group.HibGroup;
 import com.gentics.mesh.core.data.page.Page;
@@ -43,18 +27,9 @@ import com.gentics.mesh.core.data.root.GroupRoot;
 import com.gentics.mesh.core.data.root.RootVertex;
 import com.gentics.mesh.core.data.user.HibUser;
 import com.gentics.mesh.core.db.CommonTx;
-import com.gentics.mesh.core.db.Tx;
-import com.gentics.mesh.core.rest.event.group.GroupRoleAssignModel;
-import com.gentics.mesh.core.rest.event.group.GroupUserAssignModel;
-import com.gentics.mesh.core.rest.group.GroupCreateRequest;
 import com.gentics.mesh.core.rest.group.GroupResponse;
-import com.gentics.mesh.core.rest.group.GroupUpdateRequest;
 import com.gentics.mesh.core.result.Result;
-import com.gentics.mesh.event.Assignment;
-import com.gentics.mesh.event.EventQueueBatch;
-import com.gentics.mesh.parameter.GenericParameters;
 import com.gentics.mesh.parameter.PagingParameters;
-import com.gentics.mesh.parameter.value.FieldsSet;
 
 import dagger.Lazy;
 
@@ -72,56 +47,6 @@ public class GroupDaoWrapperImpl extends AbstractCoreDaoWrapper<GroupResponse, H
 	public GroupDaoWrapperImpl(Lazy<OrientDBBootstrapInitializer> boot, Lazy<PermissionPropertiesImpl> permissions, Lazy<PermissionCache> permissionCache) {
 		super(boot, permissions);
 		this.permissionCache = permissionCache;
-	}
-
-	@Override
-	public boolean update(HibGroup group, InternalActionContext ac, EventQueueBatch batch) {
-		GroupUpdateRequest requestModel = ac.fromJson(GroupUpdateRequest.class);
-
-		if (isEmpty(requestModel.getName())) {
-			throw error(BAD_REQUEST, "error_name_must_be_set");
-		}
-
-		if (shouldUpdate(requestModel.getName(), group.getName())) {
-			HibGroup groupWithSameName = findByName(requestModel.getName());
-			if (groupWithSameName != null && !groupWithSameName.getUuid().equals(group.getUuid())) {
-				throw conflict(groupWithSameName.getUuid(), requestModel.getName(), "group_conflicting_name", requestModel.getName());
-			}
-
-			group.setName(requestModel.getName());
-
-			batch.add(group.onUpdated());
-			return true;
-		}
-		return false;
-	}
-
-	@Override
-	public HibGroup create(InternalActionContext ac, EventQueueBatch batch, String uuid) {
-		HibUser requestUser = ac.getUser();
-		UserDao userDao = Tx.get().userDao();
-		GroupCreateRequest requestModel = ac.fromJson(GroupCreateRequest.class);
-		GroupRoot groupRoot = boot.get().meshRoot().getGroupRoot();
-
-		if (StringUtils.isEmpty(requestModel.getName())) {
-			throw error(BAD_REQUEST, "error_name_must_be_set");
-		}
-		if (!userDao.hasPermission(requestUser, groupRoot, CREATE_PERM)) {
-			throw error(FORBIDDEN, "error_missing_perm", groupRoot.getUuid(), CREATE_PERM.getRestPerm().getName());
-		}
-
-		// Check whether a group with the same name already exists
-		HibGroup groupWithSameName = findByName(requestModel.getName());
-		// TODO why would we want to check for uuid's here? Makes no sense: && !groupWithSameName.getUuid().equals(getUuid())
-		if (groupWithSameName != null) {
-			throw conflict(groupWithSameName.getUuid(), requestModel.getName(), "group_conflicting_name", requestModel.getName());
-		}
-
-		// Finally create the group and set the permissions
-		HibGroup group = create(requestModel.getName(), requestUser, uuid);
-		userDao.inheritRolePermissions(requestUser, groupRoot, group);
-		batch.add(group.onCreated());
-		return group;
 	}
 
 	@Override
@@ -216,119 +141,6 @@ public class GroupDaoWrapperImpl extends AbstractCoreDaoWrapper<GroupResponse, H
 		GroupRoot groupRoot = boot.get().meshRoot().getGroupRoot();
 		Group graphGroup = toGraph(group);
 		return groupRoot.getRoles(graphGroup, user, pagingInfo);
-	}
-
-	@Override
-	public GroupRoleAssignModel createRoleAssignmentEvent(HibGroup group, HibRole role, Assignment assignment) {
-		GroupRoleAssignModel model = new GroupRoleAssignModel();
-		model.setGroup(group.transformToReference());
-		model.setRole(role.transformToReference());
-		switch (assignment) {
-		case ASSIGNED:
-			model.setEvent(GROUP_ROLE_ASSIGNED);
-			break;
-		case UNASSIGNED:
-			model.setEvent(GROUP_ROLE_UNASSIGNED);
-			break;
-		}
-		return model;
-	}
-
-	@Override
-	public GroupUserAssignModel createUserAssignmentEvent(HibGroup group, HibUser user, Assignment assignment) {
-		GroupUserAssignModel model = new GroupUserAssignModel();
-		model.setGroup(group.transformToReference());
-		model.setUser(user.transformToReference());
-		switch (assignment) {
-		case ASSIGNED:
-			model.setEvent(GROUP_USER_ASSIGNED);
-			break;
-		case UNASSIGNED:
-			model.setEvent(GROUP_USER_UNASSIGNED);
-			break;
-		}
-		return model;
-	}
-
-	@Override
-	public GroupResponse transformToRestSync(HibGroup group, InternalActionContext ac, int level, String... languageTags) {
-		Group graphGroup = toGraph(group);
-		GenericParameters generic = ac.getGenericParameters();
-		FieldsSet fields = generic.getFields();
-
-		GroupResponse restGroup = new GroupResponse();
-		if (fields.has("name")) {
-			restGroup.setName(group.getName());
-		}
-		if (fields.has("roles")) {
-			setRoles(group, ac, restGroup);
-		}
-		graphGroup.fillCommonRestFields(ac, fields, restGroup);
-
-		setRolePermissions(graphGroup, ac, restGroup);
-		return restGroup;
-	}
-
-	/**
-	 * Load the roles that are assigned to this group and add the transformed references to the rest model.
-	 *
-	 * @param ac
-	 * @param restGroup
-	 */
-	private void setRoles(HibGroup group, InternalActionContext ac, GroupResponse restGroup) {
-		for (HibRole role : getRoles(group)) {
-			String name = role.getName();
-			if (name != null) {
-				restGroup.getRoles().add(role.transformToReference());
-			}
-		}
-	}
-
-	@Override
-	public void addGroup(HibGroup group) {
-		Group graphGroup = toGraph(group);
-		GroupRoot groupRoot = boot.get().meshRoot().getGroupRoot();
-		groupRoot.addItem(graphGroup);
-	}
-
-	@Override
-	public void removeGroup(HibGroup group) {
-		Group graphGroup = toGraph(group);
-		GroupRoot groupRoot = boot.get().meshRoot().getGroupRoot();
-		groupRoot.removeItem(graphGroup);
-	}
-
-	@Override
-	public void delete(HibGroup group, BulkActionContext bac) {
-		PersistingUserDao userDao = CommonTx.get().userDao();
-		Group graphGroup = toGraph(group);
-		// TODO don't allow deletion of the admin group
-		bac.batch().add(group.onDeleted());
-
-		Set<? extends HibUser> affectedUsers = getUsers(group).stream().collect(Collectors.toSet());
-		graphGroup.getElement().remove();
-		for (HibUser user : affectedUsers) {
-			userDao.updateShortcutEdges(user);
-			bac.add(user.onUpdated());
-			bac.inc();
-		}
-		bac.process();
-		permissionCache.get().clear();
-	}
-
-	@Override
-	public HibGroup create(String name, HibUser creator, String uuid) {
-		GroupRoot groupRoot = boot.get().meshRoot().getGroupRoot();
-		Group group = groupRoot.create();
-		if (uuid != null) {
-			group.setUuid(uuid);
-		}
-		group.setName(name);
-		group.setCreated(creator);
-		group.generateBucketId();
-		addGroup(group);
-
-		return group;
 	}
 
 	@Override

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/UserDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/UserDaoWrapperImpl.java
@@ -35,27 +35,15 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 
 import dagger.Lazy;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 /**
  * @see UserDaoWrapper
  */
 public class UserDaoWrapperImpl extends AbstractCoreDaoWrapper<UserResponse, HibUser, User> implements UserDaoWrapper {
 
-	private static final Logger log = LoggerFactory.getLogger(UserDaoWrapperImpl.class);
-
 	@Inject
 	public UserDaoWrapperImpl(Lazy<OrientDBBootstrapInitializer> boot, Lazy<PermissionPropertiesImpl> permissions) {
 		super(boot, permissions);
-	}
-
-	@Override
-	public boolean hasPermission(HibUser user, HibBaseElement element, InternalPermission permission) {
-		if (log.isTraceEnabled()) {
-			log.debug("Checking permissions for element {" + element.getUuid() + "}");
-		}
-		return hasPermissionForId(user, element.getId(), permission);
 	}
 
 	@Override

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -982,7 +982,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		String oldHash;
 
 		try (Tx tx = tx()) {
-			tx.userDao().changePasswordHash(user(), null);
+			tx.userDao().updatePasswordHash(user(), null);
 			uuid = user().getUuid();
 			oldHash = user().getPasswordHash();
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -982,7 +982,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		String oldHash;
 
 		try (Tx tx = tx()) {
-			user().setPasswordHash(null);
+			tx.userDao().changePasswordHash(user(), null);
 			uuid = user().getUuid();
 			oldHash = user().getPasswordHash();
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserTest.java
@@ -452,7 +452,7 @@ public class UserTest extends AbstractMeshTest implements BasicObjectTestcases {
 			user.setEmailAddress(EMAIL);
 			user.setFirstname(FIRSTNAME);
 			user.setLastname(LASTNAME);
-			tx.userDao().changePasswordHash(user, PASSWDHASH);
+			tx.userDao().updatePasswordHash(user, PASSWDHASH);
 			assertTrue(user.isEnabled());
 
 			HibUser reloadedUser = userDao.findByUuid(user.getUuid());

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserTest.java
@@ -452,7 +452,7 @@ public class UserTest extends AbstractMeshTest implements BasicObjectTestcases {
 			user.setEmailAddress(EMAIL);
 			user.setFirstname(FIRSTNAME);
 			user.setLastname(LASTNAME);
-			user.setPasswordHash(PASSWDHASH);
+			tx.userDao().changePasswordHash(user, PASSWDHASH);
 			assertTrue(user.isEnabled());
 
 			HibUser reloadedUser = userDao.findByUuid(user.getUuid());

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/index/BasicIndexSyncTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/index/BasicIndexSyncTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.gentics.mesh.core.data.group.HibGroup;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -153,7 +154,8 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 
 		// Assert deletion
 		tx(() -> {
-			boot().groupDao().findByName("group_3").removeElement();
+			HibGroup group3 = boot().groupDao().findByName("group_3");
+			CommonTx.get().groupDao().deletePersisted(group3);
 		});
 		syncIndex();
 		assertMetrics("group", 0, 0, 1);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
@@ -210,7 +210,7 @@ public class TestDataProvider {
 
 	private void setAdminPassword() {
 		String hash = "$2a$10$X7NA0kiqrFlyX0NUhPdW1e7jevHyoaoB4OyoxV1pdA7B3SLVSkx22";
-		boot.userDao().findByUsername("admin").setPasswordHash(hash);
+		boot.userDao().findByUsername("admin").setPasswordHash(hash).setForcedPasswordChange(false);
 	}
 
 	private void addPermissions(HibBaseElement element) {
@@ -349,6 +349,7 @@ public class TestDataProvider {
 		// Precomputed hash since hashing takes some time and we want to keep out tests
 		// fast
 		user.setPasswordHash(hashedPassword);
+		user.setForcedPasswordChange(false);
 		user.setFirstname(firstname);
 		user.setLastname(lastname);
 		user.setEmailAddress(email);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
@@ -210,7 +210,8 @@ public class TestDataProvider {
 
 	private void setAdminPassword() {
 		String hash = "$2a$10$X7NA0kiqrFlyX0NUhPdW1e7jevHyoaoB4OyoxV1pdA7B3SLVSkx22";
-		boot.userDao().findByUsername("admin").setPasswordHash(hash).setForcedPasswordChange(false);
+		UserDao userDao = boot.userDao();
+		userDao.updatePasswordHash(userDao.findByUsername("admin"), hash);
 	}
 
 	private void addPermissions(HibBaseElement element) {
@@ -348,8 +349,7 @@ public class TestDataProvider {
 		HibUser user = userDao.create(username, null);
 		// Precomputed hash since hashing takes some time and we want to keep out tests
 		// fast
-		user.setPasswordHash(hashedPassword);
-		user.setForcedPasswordChange(false);
+		userDao.updatePasswordHash(user, hashedPassword);
 		user.setFirstname(firstname);
 		user.setLastname(lastname);
 		user.setEmailAddress(email);


### PR DESCRIPTION
## Abstract
Scope of this change is to extract business logic to PersistingDao for the User/Group/Role entities

## Checklist

* [x] Extract logic to PersistingRoleDao
* [x] Extract logic to PersistingUserDao
* [x] Extract logic to PersistingGroupDao

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
