### PR TITLE
Getting the elasticsearch version will not fail in all cases, when

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -35,6 +35,9 @@ This update will automatically drop and recreate all existing indices for schema
 
 icon:plus[] AWS S3: Now the Cross-Origin Request Settings parameters of a S3 connection can be configured. By default the allowed headers/origins are set to `*`, the allowed methods are set to `"GET", "PUT", "POST", "DELETE"`. Setting any of the CORS configuration to `null` prevents is to override the server's default configuration. Setting all the CORS configuration to null or empty value prevents the CORS config to be changed at all.
 
+icon:check[] Search: When the ElasticSearch instance is not available, getting version information from the endpoint `/api/v1` failed with an internal
+server error. This has been fixed, calling the endpoint `/api/v1` will not fail anymore, but will not contain the ElasticSearch version.
+
 [[v1.6.22]]
 == 1.6.22 (19.10.2021)
 

--- a/common/src/main/java/com/gentics/mesh/search/DevNullSearchProvider.java
+++ b/common/src/main/java/com/gentics/mesh/search/DevNullSearchProvider.java
@@ -116,7 +116,7 @@ public class DevNullSearchProvider implements SearchProvider {
 	}
 
 	@Override
-	public String getVersion() {
+	public String getVersion(boolean failIfNotAvailable) {
 		return "1.0";
 	}
 

--- a/common/src/main/java/com/gentics/mesh/search/SearchProvider.java
+++ b/common/src/main/java/com/gentics/mesh/search/SearchProvider.java
@@ -181,9 +181,10 @@ public interface SearchProvider {
 	/**
 	 * Returns the version of the used search engine.
 	 * 
+	 * @param failIfNotAvailable whether the method should fail (with an "internal server error"), if the search engine is not available, or just return null
 	 * @return
 	 */
-	String getVersion();
+	String getVersion(boolean failIfNotAvailable);
 
 	/**
 	 * Initialize and start the search provider.

--- a/common/src/main/java/com/gentics/mesh/search/TrackingSearchProvider.java
+++ b/common/src/main/java/com/gentics/mesh/search/TrackingSearchProvider.java
@@ -181,7 +181,7 @@ public class TrackingSearchProvider implements SearchProvider {
 	}
 
 	@Override
-	public String getVersion() {
+	public String getVersion(boolean failIfNotAvailable) {
 		return "1.0";
 	}
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
@@ -305,7 +305,7 @@ public class AdminHandler extends AbstractHandler {
 			info.setDatabaseVendor(db.getVendorName());
 			info.setSearchVendor(searchProvider.getVendorName());
 			info.setDatabaseVersion(db.getVersion());
-			info.setSearchVersion(searchProvider.getVersion());
+			info.setSearchVersion(searchProvider.getVersion(false));
 			info.setMeshVersion(Mesh.getPlainVersion());
 			info.setVertxVersion(VersionCommand.getVersion());
 			info.setDatabaseRevision(db.getDatabaseRevision());

--- a/core/src/test/java/com/gentics/mesh/search/ElasticSearchProviderTest.java
+++ b/core/src/test/java/com/gentics/mesh/search/ElasticSearchProviderTest.java
@@ -50,7 +50,7 @@ public class ElasticSearchProviderTest extends AbstractMeshTest {
 	@Test
 	public void testVersion() {
 		ElasticSearchProvider provider = getProvider();
-		assertEquals("6.8.1", provider.getVersion());
+		assertEquals("6.8.1", provider.getVersion(true));
 	}
 
 	@Test

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
@@ -480,13 +480,17 @@ public class ElasticSearchProvider implements SearchProvider {
 	}
 
 	@Override
-	public String getVersion() {
+	public String getVersion(boolean failIfNotAvailable) {
 		try {
 			JsonObject info = client.info().sync();
 			return info.getJsonObject("version").getString("number");
 		} catch (HttpErrorException e) {
 			log.error("Unable to fetch node information.", e);
-			throw error(INTERNAL_SERVER_ERROR, "Error while fetching version info from elasticsearch.");
+			if (failIfNotAvailable) {
+				throw error(INTERNAL_SERVER_ERROR, "Error while fetching version info from elasticsearch.");
+			} else {
+				return null;
+			}
 		}
 	}
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/MeshTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/MeshTypeProvider.java
@@ -99,7 +99,7 @@ public class MeshTypeProvider {
 		root.field(
 				newFieldDefinition().name("searchVersion").description("Version of the used search index").type(GraphQLString).dataFetcher(env -> {
 					if (isTokenAllowed(env)) {
-						return searchProvider.getVersion();
+						return searchProvider.getVersion(true);
 					} else {
 						return null;
 					}


### PR DESCRIPTION
elasticsearch is not available.

## Abstract

Calling /api/v1 will try to fetch the elasticsearch version, which failed if elasticsearch was not available.
This change will still log the error, but will not fail in such cases.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
