### PR TITLE
Fix mounting the subrouters for a project to not interfere with static

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -23,6 +23,9 @@ All fixes and changes in LTS releases will be released the next minor release. C
 icon:check[] Search: When the ElasticSearch instance is not available, getting version information from the endpoint `/api/v1` failed with an internal
 server error. This has been fixed, calling the endpoint `/api/v1` will not fail anymore, but will not contain the ElasticSearch version.
 
+icon:check[] Rest: When a project with name "project" was deleted, calls to the endpoint `/projects` would cause 404 errors, until the Mesh instance was restarted.
+This has been fixed now.
+
 [[v1.6.23]]
 == 1.6.23 (11.11.2021)
 

--- a/common/src/main/java/com/gentics/mesh/router/ProjectsRouter.java
+++ b/common/src/main/java/com/gentics/mesh/router/ProjectsRouter.java
@@ -95,7 +95,10 @@ public class ProjectsRouter {
 				ctx.data().put(ProjectsRouter.PROJECT_CONTEXT_KEY, project);
 				ctx.next();
 			});
-			router.mountSubRouter("/" + encodedName, projectRouter);
+			// Note: the end slash in the subrouter mount point is important, otherwise the subrouter for e.g. /project
+			// (for a project named "project") would also match for the route /projects, which will cause problems,
+			// if the project "project" is deleted
+			router.mountSubRouter("/" + encodedName + "/", projectRouter);
 			projectRouter.mountSubRouter("/", this.projectRouter.getRouter());
 			// mountSubRoutersForProjectRouter(projectRouter, encodedName);
 		}

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
@@ -808,4 +808,24 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 		deleteRole(role.getUuid());
 		createProject("testProject");
 	}
+
+	/**
+	 * Test that the endpoints for /api/v[x]/projects is unaffected from deleting a project named "project"
+	 */
+	@Test
+	public void testDeleteProjectNamedProject() {
+		// create project named "project"
+		ProjectResponse project = createProject("project");
+
+		// get all projects
+		ProjectListResponse list = call(() -> client().findProjects());
+		assertThat(list.getData().stream().map(ProjectResponse::getName)).as("List of projects").containsOnly("dummy", "project");
+
+		// delete project
+		deleteProject(project.getUuid());
+
+		// get the list of projects
+		list = call(() -> client().findProjects());
+		assertThat(list.getData().stream().map(ProjectResponse::getName)).as("List of projects").containsOnly("dummy");
+	}
 }

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectInfoEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectInfoEndpointTest.java
@@ -1,8 +1,10 @@
 package com.gentics.mesh.core.project;
 
+import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.PROJECT;
-import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.util.URIUtils.encodeSegment;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -20,4 +22,19 @@ public class ProjectInfoEndpointTest extends AbstractMeshTest {
 		assertEquals(PROJECT_NAME, project.getName());
 	}
 
+	/**
+	 * Test reading an unknown project by name
+	 */
+	@Test
+	public void testReadUnknownProjectByName() {
+		call(() -> client().findProjectByName("Unknown"), NOT_FOUND, "object_not_found_for_name", "Unknown");
+	}
+
+	/**
+	 * Test trying to read a project by name with an end slash
+	 */
+	@Test
+	public void testReadProjectWithEndSlash() {
+		call(() -> client().get("/" + encodeSegment(PROJECT_NAME) + "/", ProjectResponse.class), NOT_FOUND);
+	}
 }


### PR DESCRIPTION
routes (like /projects).

## Abstract

When a new project is created, a subrouter for the project specific routes is added to the base router at mount point /[projectname]. This subrouter would then also be used for routes *beginning* with /[projectname], so e.g. if a project with name "project" was created, the subrouter would be mounted at /project and would also handle calls to the static router /projects.
If the project was deleted afterwards, calls to /projects would then fail with 404, because the subrouter would try to find the project named "project".
This has been fixed now by mounting the subrouter at path /[projectname]/ (note the end slash).
Calls to /[projectname] (which would load the project by name) are handled by another router, so will still work.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
