### PR TITLE
Content versions tx

### DIFF
--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryTransformHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryTransformHandler.java
@@ -407,7 +407,7 @@ public class BinaryTransformHandler extends AbstractHandler {
 				field.setImageFocalPoint(parameters.getFocalPoint());
 			}
 			// If the s3 binary field is the segment field, we need to update the webroot info in the node
-			if (field.getFieldKey().equals(newDraftVersion.getSchemaContainerVersion().getSchema().getSegmentField())) {
+			if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
 				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
 			}
 			BranchDao branchDao = tx.branchDao();
@@ -415,7 +415,7 @@ public class BinaryTransformHandler extends AbstractHandler {
 			String branchUuid = branchDao.getLatestBranch(node.getProject()).getUuid();
 
 			// Purge the old draft
-			if (ac.isPurgeAllowed() && newDraftVersion.isAutoPurgeEnabled() && latestDraftVersion.isPurgeable()) {
+			if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
 				contentDao.purge(latestDraftVersion);
 			}
 
@@ -470,7 +470,7 @@ public class BinaryTransformHandler extends AbstractHandler {
 				field.setImageFocalPoint(parameters.getFocalPoint());
 			}
 			// If the binary field is the segment field, we need to update the webroot info in the node
-			if (field.getFieldKey().equals(newDraftVersion.getSchemaContainerVersion().getSchema().getSegmentField())) {
+			if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
 				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
 			}
 			BranchDao branchDao = tx.branchDao();
@@ -478,7 +478,7 @@ public class BinaryTransformHandler extends AbstractHandler {
 			String branchUuid = branchDao.getLatestBranch(node.getProject()).getUuid();
 
 			// Purge the old draft
-			if (ac.isPurgeAllowed() && newDraftVersion.isAutoPurgeEnabled() && latestDraftVersion.isPurgeable()) {
+			if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
 				contentDao.purge(latestDraftVersion);
 			}
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandlerImpl.java
@@ -363,11 +363,11 @@ public class BinaryUploadHandlerImpl extends AbstractHandler implements BinaryUp
 				newDraftVersion.removeField(oldField);
 
 				// If the binary field is the segment field, we need to update the webroot info in the node
-				if (field.getFieldKey().equals(newDraftVersion.getSchemaContainerVersion().getSchema().getSegmentField())) {
+				if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
 					contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
 				}
 
-				if (ac.isPurgeAllowed() && newDraftVersion.isAutoPurgeEnabled() && latestDraftVersion.isPurgeable()) {
+				if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
 					contentDao.purge(latestDraftVersion);
 				}
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryMetadataExtractionHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryMetadataExtractionHandlerImpl.java
@@ -294,11 +294,11 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 				newDraftVersion.removeField(oldField);
 
 				// If the binary field is the segment field, we need to update the webroot info in the node
-				if (field.getFieldKey().equals(newDraftVersion.getSchemaContainerVersion().getSchema().getSegmentField())) {
+				if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
 					contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
 				}
 
-				if (ac.isPurgeAllowed() && newDraftVersion.isAutoPurgeEnabled() && latestDraftVersion.isPurgeable()) {
+				if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
 					contentDao.purge(latestDraftVersion);
 				}
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryUploadHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryUploadHandlerImpl.java
@@ -195,11 +195,11 @@ public class S3BinaryUploadHandlerImpl extends AbstractHandler implements S3Bina
 
 				// Now get rid of the old field
 				// If the s3 binary field is the segment field, we need to update the webroot info in the node
-				if (field.getFieldKey().equals(newDraftVersion.getSchemaContainerVersion().getSchema().getSegmentField())) {
+				if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
 					contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
 				}
 
-				if (ac.isPurgeAllowed() && newDraftVersion.isAutoPurgeEnabled() && latestDraftVersion.isPurgeable()) {
+				if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
 					contentDao.purge(latestDraftVersion);
 				}
 

--- a/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
@@ -190,12 +190,12 @@ public abstract class AbstractMigrationHandler extends AbstractHandler implement
 
 		// The purge operation was suppressed before. We need to invoke it now
 		// Purge the old publish container if it did not match the draft container. In this case we need to purge the published container dedicatedly.
-		if (oldPublished != null && !oldPublished.equals(container) && oldPublished.isAutoPurgeEnabled() && contentDao.isPurgeable(oldPublished)) {
+		if (oldPublished != null && !oldPublished.equals(container) && contentDao.isAutoPurgeEnabled(oldPublished) && contentDao.isPurgeable(oldPublished)) {
 			log.debug("Removing old published container {" + oldPublished.getUuid() + "}");
 			contentDao.purge(oldPublished);
 		}
 		// Now we can purge the draft container (which may also be the published container)
-		if (container.isAutoPurgeEnabled() && contentDao.isPurgeable(container)) {
+		if (contentDao.isAutoPurgeEnabled(container) && contentDao.isPurgeable(container)) {
 			log.debug("Removing source container {" + container.getUuid() + "}");
 			contentDao.purge(container);
 		}

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/MicronodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/MicronodeMigrationImpl.java
@@ -153,7 +153,7 @@ public class MicronodeMigrationImpl extends AbstractMigrationHandler implements 
 		String branchUuid = branch.getUuid();
 		ac.getVersioningParameters().setVersion(container.getVersion().getFullVersion());
 
-		boolean publish = container.isPublished(branchUuid);
+		boolean publish = contentDao.isPublished(container, branchUuid);
 
 		// Clone the field container. This will also update the draft edge
 		HibNodeFieldContainer migrated = contentDao.createFieldContainer(node, container.getLanguageTag(), branch, container.getEditor(), container, true);
@@ -283,8 +283,9 @@ public class MicronodeMigrationImpl extends AbstractMigrationHandler implements 
 	 */
 	protected void migrateMicronodeFields(NodeMigrationActionContextImpl ac, HibNodeFieldContainer container,
 		HibMicroschemaVersion fromVersion, HibMicroschemaVersion toVersion, Set<String> touchedFields) throws Exception {
+		ContentDao contentDao = Tx.get().contentDao();
 		// iterate over all fields with micronodes to migrate
-		for (HibMicronodeField field : container.getMicronodeFields(fromVersion)) {
+		for (HibMicronodeField field : contentDao.getMicronodeFields(container, fromVersion)) {
 			// clone the field (this will clone the micronode)
 			field = container.createMicronode(field.getFieldKey(), fromVersion);
 			HibMicronode micronode = field.getMicronode();
@@ -294,7 +295,7 @@ public class MicronodeMigrationImpl extends AbstractMigrationHandler implements 
 		}
 
 		// iterate over all micronode list fields to migrate
-		for (HibMicronodeFieldList field : container.getMicronodeListFields(fromVersion)) {
+		for (HibMicronodeFieldList field : contentDao.getMicronodeListFields(container, fromVersion)) {
 			HibMicronodeFieldList oldListField = field;
 
 			// clone the field (this will not clone the micronodes)

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
@@ -231,7 +231,7 @@ public class NodeMigrationImpl extends AbstractMigrationHandler implements NodeM
 		// Check whether the same container is also used as a published version within the given branch.
 		// A migration is always scoped to a specific branch.
 		// We need to ensure that the migrated container is also published.
-		boolean publish = container.isPublished(branchUuid);
+		boolean publish = contentDao.isPublished(container, branchUuid);
 
 		ac.getVersioningParameters().setVersion(container.getVersion().getFullVersion());
 		ac.getGenericParameters().setFields("fields");

--- a/core/src/main/java/com/gentics/mesh/core/project/maintenance/ProjectVersionPurgeHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/project/maintenance/ProjectVersionPurgeHandlerImpl.java
@@ -89,7 +89,7 @@ public class ProjectVersionPurgeHandlerImpl implements ProjectVersionPurgeHandle
 		boolean isNewerThanMaxAge = maxAge != null && !isOlderThanMaxAge(version, maxAge);
 		boolean isInTimeFrame = maxAge == null || isOlderThanMaxAge(version, maxAge);
 
-		if (isInTimeFrame && version.isPurgeable()) {
+		if (isInTimeFrame && contentDao.isPurgeable(version)) {
 			log.info("Purging container " + version.getUuid() + "@" + version.getVersion());
 			// Delete this version - This will also take care of removing the version references
 			contentDao.delete(version, bac, false);

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerTransformer.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerTransformer.java
@@ -541,9 +541,9 @@ public class NodeContainerTransformer extends AbstractTransformer<HibNodeFieldCo
 
 		String language = container.getLanguageTag();
 		document.put("language", language);
-		addSchema(document, container.getSchemaContainerVersion());
+		addSchema(document, contentDao.getSchemaContainerVersion(container));
 
-		addFields(document, "fields", container, container.getSchemaContainerVersion().getSchema().getFields());
+		addFields(document, "fields", container, contentDao.getSchemaContainerVersion(container).getSchema().getFields());
 		if (log.isTraceEnabled()) {
 			String json = document.toString();
 			log.trace("Search index json:");
@@ -552,7 +552,7 @@ public class NodeContainerTransformer extends AbstractTransformer<HibNodeFieldCo
 
 		// Add display field value
 		JsonObject displayField = new JsonObject();
-		displayField.put("key", container.getSchemaContainerVersion().getSchema().getDisplayField());
+		displayField.put("key", contentDao.getSchemaContainerVersion(container).getSchema().getDisplayField());
 		displayField.put("value", contentDao.getDisplayFieldValue(container));
 		document.put("displayField", displayField);
 		document.put("branchUuid", branchUuid);

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibNodeFieldContainer.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibNodeFieldContainer.java
@@ -1,27 +1,17 @@
 package com.gentics.mesh.core.data;
 
-import static com.gentics.mesh.core.rest.common.ContainerType.DRAFT;
-import static com.gentics.mesh.core.rest.common.ContainerType.INITIAL;
-import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
-
-import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
-import com.gentics.mesh.context.impl.DummyBulkActionContext;
-import com.gentics.mesh.core.data.branch.HibBranch;
 import com.gentics.mesh.core.data.dao.ContentDao;
 import com.gentics.mesh.core.data.node.HibNode;
-import com.gentics.mesh.core.data.node.field.list.HibMicronodeFieldList;
-import com.gentics.mesh.core.data.node.field.nesting.HibMicronodeField;
-import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
 import com.gentics.mesh.core.data.schema.HibSchemaVersion;
 import com.gentics.mesh.core.data.user.HibEditorTracking;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.common.ReferenceType;
-import com.gentics.mesh.core.result.Result;
+import com.gentics.mesh.util.ETag;
 import com.gentics.mesh.util.VersionNumber;
 
 /**
@@ -58,31 +48,6 @@ public interface HibNodeFieldContainer extends HibFieldContainer, HibEditorTrack
 	default String getDocumentId() {
 		return ContentDao.composeDocumentId(getNode().getUuid(), getLanguageTag());
 	}
-
-	/**
-	 * Delete the field container. This will also delete linked elements like lists. If the container has a "next" container, that container will be deleted as
-	 * well.
-	 * 
-	 * @param bac
-	 */
-	void delete(BulkActionContext bac);
-
-	/**
-	 * Delete the field container. This will also delete linked elements like lists.
-	 * 
-	 * @param bac
-	 * @param deleteNext
-	 *            true to also delete all "next" containers, false to only delete this container
-	 */
-	void delete(BulkActionContext bac, boolean deleteNext);
-
-	/**
-	 * "Delete" the field container from the branch. This will not actually delete the container itself, but will remove DRAFT and PUBLISHED edges
-	 *
-	 * @param branch
-	 * @param bac
-	 */
-	void deleteFromBranch(HibBranch branch, BulkActionContext bac);
 
 	/**
 	 * Return the display field value for this container.
@@ -155,114 +120,8 @@ public interface HibNodeFieldContainer extends HibFieldContainer, HibEditorTrack
 	 */
 	void clone(HibNodeFieldContainer container);
 
-	/**
-	 * Check whether this field container is the initial version for any branch.
-	 * 
-	 * @return true if it is the initial, false if not
-	 */
-	default boolean isInitial() {
-		return isType(INITIAL);
-	}
-
-	/**
-	 * Check whether this field container is the draft version for any branch.
-	 * 
-	 * @return true if it is the draft, false if not
-	 */
-	default boolean isDraft() {
-		return isType(DRAFT);
-	}
-
-	/**
-	 * Check whether this field container is the published version for any branch.
-	 * 
-	 * @return true if it is published, false if not
-	 */
-	default boolean isPublished() {
-		return isType(PUBLISHED);
-	}
-
-	/**
-	 * Check whether this field container has the given type for any branch.
-	 * 
-	 * @param type
-	 * @return true if it matches the type, false if not
-	 */
-	boolean isType(ContainerType type);
-
-	/**
-	 * Check whether this field container is the initial version for the given branch.
-	 * 
-	 * @param branchUuid
-	 *            branch Uuid
-	 * @return true if it is the initial, false if not
-	 */
-	default boolean isInitial(String branchUuid) {
-		return isType(INITIAL, branchUuid);
-	}
-
-	/**
-	 * Check whether this field container is the draft version for the given branch.
-	 * 
-	 * @param branchUuid
-	 *            branch Uuid
-	 * @return true if it is the draft, false if not
-	 */
-	default boolean isDraft(String branchUuid) {
-		return isType(DRAFT, branchUuid);
-	}
-
-	/**
-	 * Check whether this field container is the published version for the given branch.
-	 * 
-	 * @param branchUuid
-	 *            branch Uuid
-	 * @return true if it is published, false if not
-	 */
-	default boolean isPublished(String branchUuid) {
-		return isType(PUBLISHED, branchUuid);
-	}
-
-	/**
-	 * Check whether this field container has the given type in the given branch.
-	 * 
-	 * @param type
-	 * @param branchUuid
-	 * @return true if it matches the type, false if not
-	 */
-	boolean isType(ContainerType type, String branchUuid);
-
-	/**
-	 * Get the branch Uuids for which this container is the container of given type.
-	 * 
-	 * @param type
-	 *            type
-	 * @return set of branch Uuids (may be empty, but never null)
-	 */
-	Set<String> getBranches(ContainerType type);
-
-	/**
-	 * Get the version of the schema of this container.
-	 */
+	@Override
 	HibSchemaVersion getSchemaContainerVersion();
-
-	/**
-	 * Get all micronode fields that have a micronode using the given microschema container version.
-	 * 
-	 * @param version
-	 *            microschema container version
-	 * @return list of micronode fields
-	 */
-	List<HibMicronodeField> getMicronodeFields(HibMicroschemaVersion version);
-
-	/**
-	 * Get all micronode list fields that have at least one micronode using the given microschema container version.
-	 * 
-	 * @param version
-	 *            microschema container version
-	 * @return list of micronode list fields
-	 */
-	Result<HibMicronodeFieldList> getMicronodeListFields(HibMicroschemaVersion version);
 
 	/**
 	 * Return the ETag for the field container.
@@ -270,53 +129,16 @@ public interface HibNodeFieldContainer extends HibFieldContainer, HibEditorTrack
 	 * @param ac
 	 * @return Generated entity tag
 	 */
-	String getETag(InternalActionContext ac);
+	default String getETag(InternalActionContext ac) {
+		Stream<String> referencedUuids = StreamSupport.stream(getReferencedNodes().spliterator(), false)
+			.map(HibNode::getUuid);
 
-	/**
-	 * Determine the display field value by checking the schema and the referenced field and store it as a property.
-	 */
-	void updateDisplayFieldValue();
+		int hashcode = Stream.concat(Stream.of(getUuid()), referencedUuids)
+			.collect(Collectors.toSet())
+			.hashCode();
 
-	/**
-	 * Update the current segment field and increment any found postfix number.
-	 */
-	void postfixSegmentFieldValue();
-
-	/**
-	 * A container is purgeable when it is not being utilized as draft, published or initial version in any branch.
-	 *
-	 * @return
-	 */
-	boolean isPurgeable();
-
-	/**
-	 * Check whether auto purge is enabled globally or for the schema of the container.
-	 *
-	 * @return
-	 */
-	boolean isAutoPurgeEnabled();
-
-	/**
-	 * Purge the container from the version history and ensure that the links between versions are consistent.
-	 *
-	 * @param bac
-	 *            Action context for the deletion process
-	 */
-	void purge(BulkActionContext bac);
-
-	/**
-	 * Purge the container from the version without the use of a Bulk Action Context.
-	 */
-	default void purge() {
-		purge(new DummyBulkActionContext());
+		return ETag.hash(hashcode);
 	}
-
-	/**
-	 * Return all versions.
-	 *
-	 * @return
-	 */
-	Result<HibNodeFieldContainer> versions();
 
 	@Override
 	default Stream<HibNodeFieldContainer> getContents() {

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibNodeFieldContainerEdge.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibNodeFieldContainerEdge.java
@@ -3,6 +3,7 @@ package com.gentics.mesh.core.data;
 import java.util.Set;
 
 import com.gentics.mesh.core.data.node.HibNode;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
 
 /**
@@ -77,4 +78,14 @@ public interface HibNodeFieldContainerEdge {
 	 * @return branch Uuid
 	 */
 	String getBranchUuid();
+
+	/**
+	 * Set the segment info which consists of :nodeUuid + "-" + segment. The property is indexed and used for the webroot path resolving mechanism.
+	 * 
+	 * @param parentNode
+	 * @param segment
+	 */
+	default void setSegmentInfo(HibNode parentNode, String segment) {
+		setSegmentInfo(Tx.get().contentDao().composeSegmentInfo(parentNode, segment));
+	}
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/ContainerDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/ContainerDao.java
@@ -49,12 +49,6 @@ public interface ContainerDao<
 	Result<? extends HibBranch> getBranches(SCV version);
 
 	/**
-	 * Method called before version is deleted
-	 * @param version
-	 */
-	void beforeVersionDeletedFromDatabase(SCV version);
-
-	/**
 	 * Delete the schema version, notifying context if necessary.
 	 * 
 	 * @param version

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/node/HibMicronode.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/node/HibMicronode.java
@@ -47,8 +47,6 @@ public interface HibMicronode extends HibFieldContainer, HibBaseElement, HibTran
 	 */
 	void clone(HibMicronode micronode);
 
-	HibMicroschemaVersion getSchemaContainerVersion();
-
 	/**
 	 * Compare the micronode and return a list of changes which identify the changes.
 	 * 
@@ -73,6 +71,9 @@ public interface HibMicronode extends HibFieldContainer, HibBaseElement, HibTran
 	default ReferenceType getReferenceType() {
 		return ReferenceType.MICRONODE;
 	}
+
+	@Override
+	HibMicroschemaVersion getSchemaContainerVersion();
 
 	default MicronodeResponse transformToRestSync(InternalActionContext ac, int level, String... languageTags) {
 		NodeParametersImpl parameters = new NodeParametersImpl(ac);

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContainerDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContainerDao.java
@@ -7,6 +7,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import com.gentics.mesh.context.BulkActionContext;
@@ -59,9 +60,10 @@ public interface PersistingContainerDao<
 	 * 
 	 * @return
 	 */
-	default SCV createPersistedVersion(SC container) {
+	default SCV createPersistedVersion(SC container, Consumer<SCV> inflater) {
 		SCV version = (SCV) CommonTx.get().create(getVersionPersistenceClass());
 		version.setSchemaContainer(container);
+		inflater.accept(version);
 		return version;
 	}
 
@@ -107,18 +109,19 @@ public interface PersistingContainerDao<
 		resultingSchema.setVersion(String.valueOf(Double.valueOf(resultingSchema.getVersion()) + 1));
 
 		// Create and set the next version of the schema
-		SCV nextVersion = CommonTx.get().create(version.getContainerVersionClass());
-		nextVersion.setSchema(resultingSchema);
-
-		// Check for conflicting container names
-		String newName = resultingSchema.getName();
-		SC foundContainer = findByName(resultingSchema.getName());
-		if (foundContainer != null && !foundContainer.getUuid().equals(version.getSchemaContainer().getUuid())) {
-			throw conflict(foundContainer.getUuid(), newName, "schema_conflicting_name", newName);
-		}
-
-		nextVersion.setSchemaContainer(version.getSchemaContainer());
-		nextVersion.setName(resultingSchema.getName());
+		SCV nextVersion = createPersistedVersion(version.getSchemaContainer(), v -> {
+			v.setSchema(resultingSchema);
+			
+			// Check for conflicting container names
+			String newName = resultingSchema.getName();
+			SC foundContainer = findByName(resultingSchema.getName());
+			if (foundContainer != null && !foundContainer.getUuid().equals(version.getSchemaContainer().getUuid())) {
+				throw conflict(foundContainer.getUuid(), newName, "schema_conflicting_name", newName);
+			}
+			v.setSchemaContainer(version.getSchemaContainer());
+			v.setName(resultingSchema.getName());
+		});
+		
 		version.getSchemaContainer().setName(resultingSchema.getName());
 		version.setNextVersion(nextVersion);
 		nextVersion.setPreviousVersion(version);
@@ -179,7 +182,6 @@ public interface PersistingContainerDao<
 		for (HibJob job : version.referencedJobsViaTo()) {
 			ctx.jobDao().delete(job, bac);
 		}
-		beforeVersionDeletedFromDatabase(version);
 		// Delete version
 		ctx.delete(version, version.getClass());
 	}
@@ -200,7 +202,4 @@ public interface PersistingContainerDao<
 				}
 			}));
 	}
-
-	@Override
-	default void beforeVersionDeletedFromDatabase(SCV version) {}
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingMicroschemaDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingMicroschemaDao.java
@@ -200,15 +200,14 @@ public interface PersistingMicroschemaDao
 			throw conflict(conflictingSchema.getUuid(), name, "schema_conflicting_name", name);
 		}
 
-		HibMicroschema container = createPersisted(uuid);
-		HibMicroschemaVersion version = container.getLatestVersion();
-
 		microschema.setVersion("1.0");
-		version.setName(microschema.getName());
-		version.setSchema(microschema);
-		version.setSchemaContainer(container);
-		CommonTx.get().persist(version, version.getClass());
-
+		HibMicroschema container = createPersisted(uuid);
+		HibMicroschemaVersion version = createPersistedVersion(container, v -> {
+			v.setName(microschema.getName());
+			v.setSchema(microschema);
+			v.setSchemaContainer(container);			
+		});
+		container.setLatestVersion(version);
 		container.setCreated(user);
 		container.setName(microschema.getName());
 		container.generateBucketId();

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
@@ -262,7 +262,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			}
 			// Additionally check whether the read published permission could grant read
 			// perm for published nodes
-			boolean isPublished = fieldContainer.isPublished(branch.getUuid());
+			boolean isPublished = contentDao.isPublished(fieldContainer, branch.getUuid());
 			if (isPublished && userDao.hasPermission(requestUser, element, READ_PUBLISHED_PERM)) {
 				return element;
 				// The container could be a draft. Check whether READ perm is granted.
@@ -379,7 +379,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			// We should change this behaviour and update the client implementations.
 			// throw error(NOT_FOUND, "object_not_found_for_uuid", getUuid());
 		} else {
-			SchemaModel schema = fieldContainer.getSchemaContainerVersion().getSchema();
+			SchemaModel schema = contentDao.getSchemaContainerVersion(fieldContainer).getSchema();
 			if (fieldsSet.has("container")) {
 				restNode.setContainer(schema.getContainer());
 			}
@@ -402,7 +402,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 
 			// Schema reference
 			if (fieldsSet.has("schema")) {
-				restNode.setSchema(fieldContainer.getSchemaContainerVersion().transformToReference());
+				restNode.setSchema(contentDao.getSchemaContainerVersion(fieldContainer).transformToReference());
 			}
 
 			// Version reference
@@ -796,7 +796,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 		}
 
 		// If the located draft version was already published we are done
-		if (draftVersion.isPublished(branchUuid)) {
+		if (contentDao.isPublished(draftVersion, branchUuid)) {
 			return;
 		}
 
@@ -817,7 +817,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 		Map<String, List<VersionInfo>> versions = new HashMap<>();
 		ContentDao contentDao = Tx.get().contentDao();
 		contentDao.getFieldContainers(node, Tx.get().getBranch(ac), DRAFT).forEach(c -> {
-			versions.put(c.getLanguageTag(), c.versions().stream()
+			versions.put(c.getLanguageTag(), contentDao.versions(c).stream()
 					.map(v -> contentDao.transformToVersionInfo(v, ac))
 					.collect(Collectors.toList()));
 		});
@@ -841,8 +841,9 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 		HibBranch branch = tx.getBranch(ac, node.getProject());
 		String branchUuid = branch.getUuid();
 
-		List<HibNodeFieldContainer> unpublishedContainers = tx.contentDao().getFieldContainers(node, branch, ContainerType.DRAFT).stream().filter(c -> !c
-				.isPublished(branchUuid)).collect(Collectors.toList());
+		List<HibNodeFieldContainer> unpublishedContainers = contentDao
+				.getFieldContainers(node, branch, ContainerType.DRAFT).stream().filter(
+						c -> !contentDao.isPublished(c, branchUuid)).collect(Collectors.toList());
 
 		// publish all unpublished containers and handle recursion
 		unpublishedContainers.stream().forEach(c -> {
@@ -1014,10 +1015,10 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 				bac.process();
 			}
 		}
-
+		ContentDao contentDao = Tx.get().contentDao();
 		// Delete all initial containers (which will delete all containers)
-		for (HibNodeFieldContainer container : Tx.get().contentDao().getFieldContainers(node, INITIAL)) {
-			container.delete(bac);
+		for (HibNodeFieldContainer container : contentDao.getFieldContainers(node, INITIAL)) {
+			contentDao.delete(container, bac);
 		}
 		if (log.isDebugEnabled()) {
 			log.debug("Deleting node {" + node.getUuid() + "} vertex.");
@@ -1305,7 +1306,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			}
 
 			// Make sure the container was already migrated. Otherwise the update can't proceed.
-			HibSchemaVersion schemaVersion = latestDraftVersion.getSchemaContainerVersion();
+			HibSchemaVersion schemaVersion = contentDao.getSchemaContainerVersion(latestDraftVersion);
 			if (!latestDraftVersion.getSchemaContainerVersion().equals(branch.findLatestSchemaVersion(schemaVersion
 					.getSchemaContainer()))) {
 				throw error(BAD_REQUEST, "node_error_migration_incomplete");
@@ -1366,8 +1367,8 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 				newDraftVersion.updateFieldsFromRest(ac, requestModel.getFields());
 
 				// Purge the old draft
-				if (ac.isPurgeAllowed() && newDraftVersion.isAutoPurgeEnabled() && latestDraftVersion.isPurgeable()) {
-					latestDraftVersion.purge();
+				if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled( newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
+					contentDao.purge(latestDraftVersion);
 				}
 
 				latestDraftVersion = newDraftVersion;
@@ -1435,7 +1436,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 		// fields version
 		if (container != null) {
 			keyBuilder.append("-");
-			keyBuilder.append(container.getETag(ac));
+			keyBuilder.append(contentDao.getETag(container, ac));
 		}
 
 		/**
@@ -1650,17 +1651,17 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			HibNodeFieldContainer content = edge.getNodeContainer();
 			bac.add(contentDao.onTakenOffline(content, branchUuid));
 			contentDao.removeEdge(edge);
-			if (content.isAutoPurgeEnabled() && content.isPurgeable()) {
-				content.purge(bac);
+			if (contentDao.isAutoPurgeEnabled(content) && contentDao.isPurgeable(content)) {
+				contentDao.purge(content, bac);
 			}
 		});
 	}
 
 	@Override
 	default void setPublished(HibNode node, InternalActionContext ac, HibNodeFieldContainer container, String branchUuid) {
-		String languageTag = container.getLanguageTag();
-		boolean isAutoPurgeEnabled = container.isAutoPurgeEnabled();
 		PersistingContentDao contentDao = CommonTx.get().contentDao();
+		String languageTag = container.getLanguageTag();
+		boolean isAutoPurgeEnabled = contentDao.isAutoPurgeEnabled(container);
 
 		// Remove an existing published edge
 		HibNodeFieldContainerEdge edge = contentDao.getEdge(node, languageTag, branchUuid, PUBLISHED);
@@ -1668,15 +1669,15 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			HibNodeFieldContainer oldPublishedContainer = contentDao.getFieldContainerOfEdge(edge);
 			contentDao.removeEdge(edge);
 			contentDao.updateWebrootPathInfo(oldPublishedContainer, branchUuid, "node_conflicting_segmentfield_publish");
-			if (ac.isPurgeAllowed() && isAutoPurgeEnabled && oldPublishedContainer.isPurgeable()) {
-				oldPublishedContainer.purge();
+			if (ac.isPurgeAllowed() && isAutoPurgeEnabled && contentDao.isPurgeable(oldPublishedContainer)) {
+				contentDao.purge(oldPublishedContainer);
 			}
 		}
 		if (ac.isPurgeAllowed()) {
 			// Check whether a previous draft can be purged.
 			HibNodeFieldContainer prev = container.getPreviousVersion();
-			if (isAutoPurgeEnabled && prev != null && prev.isPurgeable()) {
-				prev.purge();
+			if (isAutoPurgeEnabled && prev != null && contentDao.isPurgeable(prev)) {
+				contentDao.purge(prev);
 			}
 		}
 		// create new published edge

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingSchemaDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingSchemaDao.java
@@ -211,13 +211,14 @@ public interface PersistingSchemaDao
 		}
 
 		HibSchema container = createPersisted(uuid);
-		HibSchemaVersion version = container.getLatestVersion();
-
-		// set the initial version
-		schema.setVersion("1.0");
-		version.setSchema(schema);
-		version.setName(schema.getName());
-		version.setSchemaContainer(container);
+		HibSchemaVersion version = createPersistedVersion(container, v -> {
+			// set the initial version
+			schema.setVersion("1.0");
+			v.setSchema(schema);
+			v.setName(schema.getName());
+			v.setSchemaContainer(container);			
+		});
+		container.setLatestVersion(version);
 		container.setCreated(creator);
 		container.setName(schema.getName());
 		container.generateBucketId();

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingUserDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingUserDao.java
@@ -31,7 +31,6 @@ import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.data.project.HibProject;
 import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.user.HibUser;
-import com.gentics.mesh.core.db.CommonTx;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.common.PermissionInfo;
@@ -277,7 +276,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 		if (hasPermission(user, node, READ_PERM)) {
 			return true;
 		}
-		boolean published = container.isPublished(branchUuid);
+		boolean published = contentDao.isPublished(container, branchUuid);
 		if (published && hasPermission(user, node, READ_PUBLISHED_PERM)) {
 			return true;
 		}

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/NodeGraphFieldContainer.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/NodeGraphFieldContainer.java
@@ -1,9 +1,18 @@
 package com.gentics.mesh.core.data;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
+import com.gentics.mesh.context.BulkActionContext;
+import com.gentics.mesh.core.data.branch.HibBranch;
+import com.gentics.mesh.core.data.node.field.list.HibMicronodeFieldList;
+import com.gentics.mesh.core.data.node.field.nesting.HibMicronodeField;
+import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
+import com.gentics.mesh.core.data.schema.HibSchemaVersion;
 import com.gentics.mesh.core.data.search.GraphDBBucketableElement;
 import com.gentics.mesh.core.rest.common.ContainerType;
+import com.gentics.mesh.core.result.Result;
 
 /**
  * A node field container is an aggregation node that holds localized fields (e.g.: StringField, NodeField...)
@@ -40,6 +49,97 @@ public interface NodeGraphFieldContainer extends HibNodeFieldContainer, GraphFie
 	 * @return
 	 */
 	Iterator<GraphFieldContainerEdge> getContainerEdge(ContainerType type, String branchUuid);
+
+	/**
+	 * A container is purgeable when it is not being utilized as draft, published or initial version in any branch.
+	 *
+	 * @return
+	 */
+	boolean isPurgeable();
+
+	/**
+	 * Determine the display field value by checking the schema and the referenced field and store it as a property.
+	 */
+	void updateDisplayFieldValue();
+
+	/**
+	 * Update the current segment field and increment any found postfix number.
+	 */
+	void postfixSegmentFieldValue();
+
+	/**
+	 * Get all micronode fields that have a micronode using the given microschema container version.
+	 * 
+	 * @param version
+	 *            microschema container version
+	 * @return list of micronode fields
+	 */
+	List<HibMicronodeField> getMicronodeFields(HibMicroschemaVersion version);
+
+	/**
+	 * Get all micronode list fields that have at least one micronode using the given microschema container version.
+	 * 
+	 * @param version
+	 *            microschema container version
+	 * @return list of micronode list fields
+	 */
+	Result<HibMicronodeFieldList> getMicronodeListFields(HibMicroschemaVersion version);
+
+	/**
+	 * Check whether this field container has the given type for any branch.
+	 * 
+	 * @param type
+	 * @return true if it matches the type, false if not
+	 */
+	boolean isType(ContainerType type);
+
+	/**
+	 * Check whether this field container has the given type in the given branch.
+	 * 
+	 * @param type
+	 * @param branchUuid
+	 * @return true if it matches the type, false if not
+	 */
+	boolean isType(ContainerType type, String branchUuid);
+
+	/**
+	 * Get the branch Uuids for which this container is the container of given type.
+	 * 
+	 * @param type
+	 *            type
+	 * @return set of branch Uuids (may be empty, but never null)
+	 */
+	Set<String> getBranches(ContainerType type);
+
+	/**
+	 * Get the version of the schema of this container.
+	 */
+	HibSchemaVersion getSchemaContainerVersion();
+
+	/**
+	 * Delete the field container. This will also delete linked elements like lists. If the container has a "next" container, that container will be deleted as
+	 * well.
+	 * 
+	 * @param bac
+	 */
+	void delete(BulkActionContext bac);
+
+	/**
+	 * Delete the field container. This will also delete linked elements like lists.
+	 * 
+	 * @param bac
+	 * @param deleteNext
+	 *            true to also delete all "next" containers, false to only delete this container
+	 */
+	void delete(BulkActionContext bac, boolean deleteNext);
+
+	/**
+	 * "Delete" the field container from the branch. This will not actually delete the container itself, but will remove DRAFT and PUBLISHED edges
+	 *
+	 * @param branch
+	 * @param bac
+	 */
+	void deleteFromBranch(HibBranch branch, BulkActionContext bac);
 
 	@Override
 	default boolean isValid() {

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/node/Node.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/node/Node.java
@@ -111,6 +111,11 @@ public interface Node extends MeshCoreVertex<NodeResponse>, CreatorTrackingVerte
 	 */
 	void addReferenceUpdates(BulkActionContext bac);
 
+	/**
+	 * Unparent a node from the given branch.
+	 * 
+	 * @param branchUuid
+	 */
 	void removeParent(String branchUuid);
 
 	/**

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/MicroschemaContainerVersionImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/MicroschemaContainerVersionImpl.java
@@ -11,9 +11,9 @@ import java.util.stream.Stream;
 
 import com.gentics.madl.index.IndexHandler;
 import com.gentics.madl.type.TypeHandler;
-import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.core.data.NodeGraphFieldContainer;
 import com.gentics.mesh.core.data.branch.HibBranch;
+import com.gentics.mesh.core.data.dao.ContentDao;
 import com.gentics.mesh.core.data.generic.MeshVertexImpl;
 import com.gentics.mesh.core.data.impl.BranchImpl;
 import com.gentics.mesh.core.data.job.HibJob;
@@ -24,8 +24,8 @@ import com.gentics.mesh.core.data.schema.HibMicroschema;
 import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
 import com.gentics.mesh.core.data.schema.Microschema;
 import com.gentics.mesh.core.data.schema.MicroschemaVersion;
-import com.gentics.mesh.core.data.schema.SchemaChange;
 import com.gentics.mesh.core.data.schema.impl.AbstractGraphFieldSchemaContainerVersion;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.event.MeshElementEventModel;
 import com.gentics.mesh.core.rest.microschema.MicroschemaVersionModel;
 import com.gentics.mesh.core.rest.microschema.impl.MicroschemaResponse;
@@ -64,10 +64,11 @@ public class MicroschemaContainerVersionImpl extends
 
 	@Override
 	public Result<? extends NodeGraphFieldContainer> getDraftFieldContainers(String branchUuid) {
+		ContentDao contentDao = Tx.get().contentDao();
 		return new TraversalResult<>(getMicronodeStream()
 			.flatMap(micronode -> micronode.getContainers().stream())
 			.filter(uniqueBy(ElementFrame::getId))
-			.filter(container -> container.isDraft(branchUuid)));
+			.filter(container -> contentDao.isDraft(container, branchUuid)));
 	}
 
 	@Override

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/AbstractContainerDaoWrapper.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/AbstractContainerDaoWrapper.java
@@ -96,12 +96,5 @@ public abstract class AbstractContainerDaoWrapper<
 		return toGraph(version).getBranches();
 	}
 
-	@Override
-	public SC createPersisted(String uuid) {
-		SC vertex = super.createPersisted(uuid);
-		vertex.setLatestVersion(createPersistedVersion(vertex));
-		return vertex;
-	}
-
 	protected abstract RootVertex<D> getRoot();
 }

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/GraphFieldContainerEdgeImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/GraphFieldContainerEdgeImpl.java
@@ -19,11 +19,9 @@ import com.gentics.mesh.core.data.NodeGraphFieldContainer;
 import com.gentics.mesh.core.data.container.impl.AbstractBasicGraphFieldContainerImpl;
 import com.gentics.mesh.core.data.container.impl.NodeGraphFieldContainerImpl;
 import com.gentics.mesh.core.data.generic.MeshEdgeImpl;
-import com.gentics.mesh.core.data.node.HibNode;
 import com.gentics.mesh.core.data.node.Node;
 import com.gentics.mesh.core.data.node.impl.NodeImpl;
 import com.gentics.mesh.core.db.GraphDBTx;
-import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.graph.GraphAttribute;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.result.Result;
@@ -82,16 +80,6 @@ public class GraphFieldContainerEdgeImpl extends MeshEdgeImpl implements GraphFi
 		fields.put(WEBROOT_URLFIELD_PROPERTY_KEY, STRING_SET);
 		index.addCustomEdgeIndex(HAS_FIELD_CONTAINER, WEBROOT_URLFIELD_INDEX_POSTFIX_NAME, fields, true);
 
-	}
-
-	/**
-	 * Set the segment info which consists of :nodeUuid + "-" + segment. The property is indexed and used for the webroot path resolving mechanism.
-	 * 
-	 * @param parentNode
-	 * @param segment
-	 */
-	public void setSegmentInfo(HibNode parentNode, String segment) {
-		setSegmentInfo(Tx.get().contentDao().composeSegmentInfo(parentNode, segment));
 	}
 
 	/**

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/node/impl/NodeImpl.java
@@ -24,7 +24,6 @@ import static com.gentics.mesh.madl.field.FieldType.STRING_SET;
 import static com.gentics.mesh.madl.index.VertexIndexDefinition.vertexIndex;
 import static com.gentics.mesh.madl.type.VertexTypeDefinition.vertexType;
 import static com.gentics.mesh.util.StreamUtil.toStream;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
 import java.util.HashSet;
@@ -46,7 +45,6 @@ import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.BranchParentEntry;
 import com.gentics.mesh.core.data.GraphFieldContainerEdge;
 import com.gentics.mesh.core.data.HibNodeFieldContainer;
-import com.gentics.mesh.core.data.HibNodeFieldContainerEdge;
 import com.gentics.mesh.core.data.NodeGraphFieldContainer;
 import com.gentics.mesh.core.data.TagEdge;
 import com.gentics.mesh.core.data.branch.HibBranch;
@@ -443,9 +441,10 @@ public class NodeImpl extends AbstractGenericFieldContainerVertex<NodeResponse, 
 	}
 
 	private PathSegment getSegment(String branchUuid, ContainerType type, String segment) {
+		ContentDao contentDao = Tx.get().contentDao();
 		// Check the different language versions
-		for (HibNodeFieldContainer container : Tx.get().contentDao().getFieldContainers(this, branchUuid, type)) {
-			SchemaModel schema = container.getSchemaContainerVersion().getSchema();
+		for (HibNodeFieldContainer container : contentDao.getFieldContainers(this, branchUuid, type)) {
+			SchemaModel schema = contentDao.getSchemaContainerVersion(container).getSchema();
 			String segmentFieldName = schema.getSegmentField();
 			// First check whether a string field exists for the given name
 			HibStringField field = container.getString(segmentFieldName);

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/check/GraphFieldContainerCheck.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/check/GraphFieldContainerCheck.java
@@ -127,7 +127,7 @@ public class GraphFieldContainerCheck extends AbstractConsistencyCheck {
 		}
 
 		// GFC must either have a next GFC, or must be the draft GFC for a Node
-		if (!contentDao.hasNextVersion(container) && !container.isDraft()) {
+		if (!contentDao.hasNextVersion(container) && !contentDao.isDraft(container)) {
 			String nodeInfo = "unknown";
 			try {
 				HibNode node = contentDao.getNode(container);

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/NodeFieldSchemaImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/NodeFieldSchemaImpl.java
@@ -2,7 +2,9 @@ package com.gentics.mesh.core.rest.schema.impl;
 
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.ALLOW_KEY;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.gentics.mesh.core.rest.common.FieldTypes;
@@ -42,8 +44,14 @@ public class NodeFieldSchemaImpl extends AbstractFieldSchema implements NodeFiel
 	@Override
 	public void apply(Map<String, Object> fieldProperties) {
 		super.apply(fieldProperties);
-		if (fieldProperties.get(ALLOW_KEY) != null) {
-			setAllowedSchemas((String[]) fieldProperties.get(ALLOW_KEY));
+		Object allowed = fieldProperties.get(ALLOW_KEY);
+		if (allowed != null) {
+			if (allowed instanceof String[]) {
+				setAllowedSchemas((String[]) allowed);
+			} else {
+				Object[] allowedObjects = (Object[]) allowed;
+				setAllowedSchemas(Arrays.stream(allowedObjects).map(Object::toString).collect(Collectors.toList()).toArray(new String[allowedObjects.length]));
+			}
 		}
 	}
 }

--- a/tests/common/src/main/java/com/gentics/mesh/mock/TestMocks.java
+++ b/tests/common/src/main/java/com/gentics/mesh/mock/TestMocks.java
@@ -305,7 +305,7 @@ public final class TestMocks {
 		when(node.getUuid()).thenReturn(NODE_DELOREAN_UUID);
 		
 		HibNodeFieldContainer container = mockContainer(languageTag, user);
-		when(container.getSchemaContainerVersion()).thenReturn(latestVersion);
+		when(contentDao.getSchemaContainerVersion(container)).thenReturn(latestVersion);
 		when(contentDao.getNode(container)).thenReturn(node);
 		when(container.getNode()).thenReturn(node);
 		when(container.getElementVersion()).thenReturn(UUID_5);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/branch/BranchTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/branch/BranchTest.java
@@ -264,11 +264,15 @@ public class BranchTest extends AbstractMeshTest implements BasicObjectTestcases
 			List<HibSchemaVersion> versions = schemaDao.findAll(project).stream().filter(v -> !v.getName().equals("content"))
 				.map(HibSchema::getLatestVersion).collect(Collectors.toList());
 
-			HibSchemaVersion newVersion = schemaDao.createPersistedVersion(schemaContainer("content"));
-			newVersion.setVersion("4.0");
-			newVersion.setName("content");
+			HibSchema schema = schemaContainer("content");
+
+			HibSchemaVersion newVersion = schemaDao.createPersistedVersion(schema, v -> {
+				v.setVersion("4.0");
+				v.setName("content");
+				v.setSchemaContainer(schema);
+			});
+
 			versions.add(newVersion);
-			newVersion.setSchemaContainer(schemaContainer("content"));
 			branchDao.connectToSchemaVersion(branch, newVersion);
 
 			List<HibSchemaVersion> found = new ArrayList<>();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/container/NodeFieldContainerDiffTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/container/NodeFieldContainerDiffTest.java
@@ -99,13 +99,14 @@ public class NodeFieldContainerDiffTest extends AbstractFieldContainerDiffTest i
 
 			// Create microschema vcard
 			HibMicroschema schemaContainer = createMicroschema(tx);
-			HibMicroschemaVersion version = createMicroschemaVersion(tx, schemaContainer);
-			schemaContainer.setLatestVersion(version);
-			MicroschemaVersionModel microschema = new MicroschemaModelImpl();
-			microschema.setName("vcard");
-			microschema.getFields().add(FieldUtil.createStringFieldSchema("firstName"));
-			microschema.getFields().add(FieldUtil.createStringFieldSchema("lastName"));
-			version.setSchema(microschema);
+			HibMicroschemaVersion version = createMicroschemaVersion(tx, schemaContainer, v -> {
+				schemaContainer.setLatestVersion(v);
+				MicroschemaVersionModel microschema = new MicroschemaModelImpl();
+				microschema.setName("vcard");
+				microschema.getFields().add(FieldUtil.createStringFieldSchema("firstName"));
+				microschema.getFields().add(FieldUtil.createStringFieldSchema("lastName"));
+				v.setSchema(microschema);
+			});
 
 			HibMicronodeField micronodeA = containerA.createMicronode("micronodeField", version);
 			micronodeA.getMicronode().createString("firstName").setString("firstnameValue");

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicronodeFieldTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicronodeFieldTest.java
@@ -358,15 +358,17 @@ public class MicronodeFieldTest extends AbstractFieldTest<MicronodeFieldSchema> 
 		try (Tx tx = tx()) {
 			CommonTx ctx = tx.unwrap();
 			HibNodeFieldContainer container = CoreTestUtils.createContainer();
-			// Create microschema for the micronode
-			HibMicroschemaVersion containerVersion = ctx.microschemaDao().createPersistedVersion(dummyMicroschema);
+
 			MicroschemaVersionModel microschema = new MicroschemaModelImpl();
 			microschema.setVersion("1.0");
 			microschema.addField(FieldUtil.createStringFieldSchema("string"));
 			microschema.addField(FieldUtil.createDateFieldSchema("date"));
 
-			// rest null - graph null
-			containerVersion.setSchema(microschema);
+			// Create microschema for the micronode
+			HibMicroschemaVersion containerVersion = ctx.microschemaDao().createPersistedVersion(dummyMicroschema, v -> {
+				// rest null - graph null
+				v.setSchema(microschema);
+			});
 			HibMicronodeField fieldA = container.createMicronode(MICRONODE_FIELD, containerVersion);
 			MicronodeResponse restField = new MicronodeResponse();
 			assertTrue("Both fields should be equal to eachother since both values are null", fieldA.equals(restField));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/job/JobTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/job/JobTest.java
@@ -114,8 +114,8 @@ public class JobTest extends AbstractMeshTest {
 			JobDao dao = tx.jobDao();
 			HibSchema schema = tx.<CommonTx>unwrap().schemaDao().createPersisted(null);
 			HibMicroschema microschema = tx.<CommonTx>unwrap().microschemaDao().createPersisted(null);
-			dao.enqueueSchemaMigration(user(), latestBranch(), createSchemaVersion(tx, schema), createSchemaVersion(tx, schema));
-			dao.enqueueMicroschemaMigration(user(), latestBranch(), createMicroschemaVersion(tx, microschema), createMicroschemaVersion(tx, microschema));
+			dao.enqueueSchemaMigration(user(), latestBranch(), createSchemaVersion(tx, schema, v -> {}), createSchemaVersion(tx, schema, v -> {}));
+			dao.enqueueMicroschemaMigration(user(), latestBranch(), createMicroschemaVersion(tx, microschema, v -> {}), createMicroschemaVersion(tx, microschema, v -> {}));
 			dao.enqueueBranchMigration(user(), latestBranch());
 
 			List<? extends HibJob> list = dao.findAll().list();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointETagTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointETagTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 import com.gentics.mesh.FieldUtil;
+import com.gentics.mesh.core.data.dao.ContentDao;
 import com.gentics.mesh.core.data.dao.NodeDao;
 import com.gentics.mesh.core.data.node.HibNode;
 import com.gentics.mesh.core.db.Tx;
@@ -146,11 +147,12 @@ public class NodeEndpointETagTest extends AbstractMeshTest {
 		HibNode node = content();
 
 		try (Tx tx = tx()) {
+			ContentDao contentDao = tx.contentDao();
 			// Inject the reference node field
-			SchemaVersionModel schema = boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema();
+			SchemaVersionModel schema = contentDao.getSchemaContainerVersion(contentDao.getFieldContainer(node, "en")).getSchema();
 			schema.addField(FieldUtil.createNodeFieldSchema("reference"));
-			boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().setSchema(schema);
-			boot().contentDao().getFieldContainer(node, "en").createNode("reference", folder("2015"));
+			contentDao.getSchemaContainerVersion(contentDao.getFieldContainer(node, "en")).setSchema(schema);
+			contentDao.getFieldContainer(node, "en").createNode("reference", folder("2015"));
 			tx.success();
 		}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointTest.java
@@ -1935,7 +1935,9 @@ public class NodeEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		HibNode node = content("concorde");
 		String uuid = tx(() -> node.getUuid());
 		String schemaUuid = tx(() -> schemaContainer("content").getUuid());
-		assertTrue("The node is expected to be published", tx(() -> boot().contentDao().getFieldContainer(node, "en").isPublished()));
+		assertTrue("The node is expected to be published", tx(tx -> {
+			return tx.contentDao().isPublished(tx.contentDao().getFieldContainer(node, "en"));
+		}));
 
 		expect(NODE_DELETED).match(1, NodeMeshEventModel.class, event -> {
 			assertThat(event)

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -954,15 +954,15 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			microschemaDao.mergeIntoPersisted(container);
 
 			// create version 2 of the microschema (with the field renamed)
-			versionB = createMicroschemaVersion(tx, container);
-			MicroschemaModelImpl microschemaB = new MicroschemaModelImpl();
-			microschemaB.setName("migratedSchema");
-			microschemaB.setVersion("2.0");
-			FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
-			microschemaB.addField(newField);
-			versionB.setName("migratedSchema");
-			versionB.setSchema(microschemaB);
-			// boot().microschemaContainerRoot().addMicroschema(container);
+			versionB = createMicroschemaVersion(tx, container, v -> {
+				MicroschemaModelImpl microschemaB = new MicroschemaModelImpl();
+				microschemaB.setName("migratedSchema");
+				microschemaB.setVersion("2.0");
+				FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
+				microschemaB.addField(newField);
+				v.setName("migratedSchema");
+				v.setSchema(microschemaB);
+			});
 
 			// link the schemas with the changes in between
 			HibUpdateFieldChange updateFieldChange = (HibUpdateFieldChange) microschemaDao.createPersistedChange(versionA, SchemaChangeOperation.UPDATEFIELD);
@@ -1061,15 +1061,15 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			microschemaDao.mergeIntoPersisted(container);
 
 			// create version 2 of the microschema (with the field renamed)
-			versionB = createMicroschemaVersion(tx, container);
-			MicroschemaModelImpl microschemaB = new MicroschemaModelImpl();
-			microschemaB.setName("migratedSchema");
-			microschemaB.setVersion("2.0");
-			FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
-			microschemaB.addField(newField);
-			versionB.setName("migratedSchema");
-			versionB.setSchema(microschemaB);
-			// boot().microschemaContainerRoot().addMicroschema(container);
+			versionB = createMicroschemaVersion(tx, container, v -> {
+				MicroschemaModelImpl microschemaB = new MicroschemaModelImpl();
+				microschemaB.setName("migratedSchema");
+				microschemaB.setVersion("2.0");
+				FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
+				microschemaB.addField(newField);
+				v.setName("migratedSchema");
+				v.setSchema(microschemaB);
+			});
 
 			// link the schemas with the changes in between
 			HibUpdateFieldChange updateFieldChange = (HibUpdateFieldChange) microschemaDao.createPersistedChange(versionA, SchemaChangeOperation.UPDATEFIELD);
@@ -1197,15 +1197,15 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			microschemaDao.mergeIntoPersisted(container);
 
 			// create version 2 of the microschema (with the field renamed)
-			versionB = createMicroschemaVersion(tx, container);
-			MicroschemaModelImpl microschemaB = new MicroschemaModelImpl();
-			microschemaB.setName("migratedSchema");
-			microschemaB.setVersion("2.0");
-			FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
-			microschemaB.addField(newField);
-			versionB.setName("migratedSchema");
-			versionB.setSchema(microschemaB);
-			// boot().microschemaContainerRoot().addMicroschema(container);
+			versionB = createMicroschemaVersion(tx, container, v -> {
+				MicroschemaModelImpl microschemaB = new MicroschemaModelImpl();
+				microschemaB.setName("migratedSchema");
+				microschemaB.setVersion("2.0");
+				FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
+				microschemaB.addField(newField);
+				v.setName("migratedSchema");
+				v.setSchema(microschemaB);
+			});
 
 			// link the schemas with the changes in between
 			HibUpdateFieldChange updateFieldChange = (HibUpdateFieldChange) microschemaDao.createPersistedChange(versionA, SchemaChangeOperation.UPDATEFIELD);
@@ -1307,23 +1307,24 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		versionA.setSchema(schemaA);
 		
 		// create version 2 of the schema (with the field renamed)
-		HibSchemaVersion versionB = createSchemaVersion(Tx.get(), container);
-		SchemaVersionModel schemaB = new SchemaModelImpl();
-		schemaB.setName("migratedSchema");
-		schemaB.setVersion("2.0");
-		FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
-		if (setAddRaw) {
-			newField.setElasticsearch(IndexOptionHelper.getRawFieldOption());
-		}
-		schemaB.addField(newField);
-		schemaB.addField(FieldUtil.createStringFieldSchema("name"));
-		schemaB.setDisplayField("name");
-		schemaB.setSegmentField("name");
-		schemaB.setContainer(false);
-		schemaB.validate();
-		versionB.setName("migratedSchema");
-		versionB.setSchema(schemaB);
-		versionB.setSchemaContainer(container);
+		HibSchemaVersion versionB = createSchemaVersion(Tx.get(), container, v -> {
+			SchemaVersionModel schemaB = new SchemaModelImpl();
+			schemaB.setName("migratedSchema");
+			schemaB.setVersion("2.0");
+			FieldSchema newField = FieldUtil.createStringFieldSchema(newFieldName);
+			if (setAddRaw) {
+				newField.setElasticsearch(IndexOptionHelper.getRawFieldOption());
+			}
+			schemaB.addField(newField);
+			schemaB.addField(FieldUtil.createStringFieldSchema("name"));
+			schemaB.setDisplayField("name");
+			schemaB.setSegmentField("name");
+			schemaB.setContainer(false);
+			schemaB.validate();
+			v.setName("migratedSchema");
+			v.setSchema(schemaB);
+			v.setSchemaContainer(container);
+		});
 
 		// link the schemas with the changes in between
 		HibUpdateFieldChange updateFieldChange = (HibUpdateFieldChange) schemaDao.createPersistedChange(versionA, SchemaChangeOperation.UPDATEFIELD);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -491,10 +491,10 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		String schemaUuid = tx(() -> node.getSchemaContainer().getUuid());
 
 		int nFieldContainers = tx(tx -> {
-			
+			ContentDao contentDao = tx.contentDao();
 			HibSchemaVersion schemaVersion = node.getSchemaContainer().getLatestVersion();
 			return Long.valueOf(tx.<CommonTx>unwrap().schemaDao().getFieldContainers(schemaVersion, initialBranchUuid())
-				.filter(c -> c.isPublished() || c.isPublished())
+				.filter(contentDao::isPublished)
 				.count()).intValue();
 		});
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaChangeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaChangeTest.java
@@ -37,8 +37,8 @@ public class SchemaChangeTest extends AbstractMeshTest {
 			HibSchema container = schemaDao.createPersisted(UUIDUtil.randomUUID());
 
 			HibSchemaVersion versionA = container.getLatestVersion();
-			HibSchemaVersion versionB = createSchemaVersion(ctx, container);
-			HibSchemaVersion versionC = createSchemaVersion(ctx, container);
+			HibSchemaVersion versionB = createSchemaVersion(ctx, container, v -> {});
+			HibSchemaVersion versionC = createSchemaVersion(ctx, container, v -> {});
 
 			HibRemoveFieldChange change = (HibRemoveFieldChange) schemaDao.createPersistedChange(versionA, SchemaChangeOperation.REMOVEFIELD);
 			// Not true anymore, since version initialization is now the part of container initialization, as no container can exist without a version.
@@ -72,11 +72,11 @@ public class SchemaChangeTest extends AbstractMeshTest {
 			CommonTx ctx = (CommonTx) tx;
 			HibMicroschema container = createMicroschema(ctx);
 			HibMicroschemaVersion versionA = container.getLatestVersion();
-			HibMicroschemaVersion versionB = createMicroschemaVersion(ctx, container);
+			HibMicroschemaVersion versionB = createMicroschemaVersion(ctx, container, v -> {});
 			container.setLatestVersion(versionB);
 			HibSchemaChange<?> oldChange = chainChanges(versionA, versionB,
 					version ->  ctx.microschemaDao().createPersistedChange((HibMicroschemaVersion) version, SchemaChangeOperation.REMOVEFIELD));
-			validate(container, versionA, versionB, oldChange, container1 -> createMicroschemaVersion(CommonTx.get(), (HibMicroschema) container1));
+			validate(container, versionA, versionB, oldChange, container1 -> createMicroschemaVersion(CommonTx.get(), (HibMicroschema) container1, v -> {}));
 		}
 	}
 
@@ -86,11 +86,11 @@ public class SchemaChangeTest extends AbstractMeshTest {
 			CommonTx ctx = (CommonTx) tx;
 			HibSchema container = createSchema(ctx);
 			HibSchemaVersion versionA = container.getLatestVersion();
-			HibSchemaVersion versionB = createSchemaVersion(ctx, container);
+			HibSchemaVersion versionB = createSchemaVersion(ctx, container, v -> {});
 			container.setLatestVersion(versionA);
 			HibSchemaChange<?> oldChange = chainChanges(versionA, versionB, 
 					version ->  ctx.schemaDao().createPersistedChange((HibSchemaVersion) version, SchemaChangeOperation.REMOVEFIELD));
-			validate(container, versionA, versionB, oldChange, container1 -> createSchemaVersion(CommonTx.get(), (HibSchema) container1));
+			validate(container, versionA, versionB, oldChange, container1 -> createSchemaVersion(CommonTx.get(), (HibSchema) container1, v -> {}));
 		}
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/AbstractChangeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/AbstractChangeTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractChangeTest extends AbstractMeshTest {
 				SCV extends HibFieldSchemaVersionElement<R, RM, RE, SC, SCV>
 			> SCV createVersion(PersistingContainerDao<R, RM, RE, SC, SCV, ?> dao) {
 		SC container = dao.createPersisted(null);
-		SCV version = dao.createPersistedVersion(container);
+		SCV version = dao.createPersistedVersion(container, v -> {});
 		return version;
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/FieldSchemaContainerMutatorTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/FieldSchemaContainerMutatorTest.java
@@ -60,8 +60,7 @@ public class FieldSchemaContainerMutatorTest extends AbstractMeshTest {
 			CommonTx ctx = tx.unwrap();
 			SchemaModelImpl schemaModel = new SchemaModelImpl();
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
-			version.setSchema(schemaModel);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> v.setSchema(schemaModel));
 			SchemaModel updatedSchema = mutator.apply(version);
 			assertNotNull(updatedSchema);
 			assertEquals("No changes were specified. No modification should happen.", schemaModel, updatedSchema);
@@ -76,15 +75,15 @@ public class FieldSchemaContainerMutatorTest extends AbstractMeshTest {
 			// 1. Create schema
 			SchemaModelImpl schemaModel = new SchemaModelImpl("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {
+				NumberFieldSchema numberField = new NumberFieldSchemaImpl();
+				numberField.setName("testField");
+				numberField.setRequired(true);
+				numberField.setLabel("originalLabel");
+				schemaModel.addField(numberField);
 
-			NumberFieldSchema numberField = new NumberFieldSchemaImpl();
-			numberField.setName("testField");
-			numberField.setRequired(true);
-			numberField.setLabel("originalLabel");
-			schemaModel.addField(numberField);
-
-			version.setSchema(schemaModel);
+				v.setSchema(schemaModel);
+			});
 
 			HibFieldTypeChange fieldTypeChange = (HibFieldTypeChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.CHANGEFIELDTYPE);
 			fieldTypeChange.setFieldName("testField");
@@ -109,16 +108,16 @@ public class FieldSchemaContainerMutatorTest extends AbstractMeshTest {
 			// 1. Create schema
 			SchemaModelImpl schemaModel = new SchemaModelImpl("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {
+				StringFieldSchema stringField = new StringFieldSchemaImpl();
+				stringField.setAllowedValues("blub");
+				stringField.setName("stringField");
+				stringField.setRequired(true);
+				stringField.setLabel("originalLabel");
+				schemaModel.addField(stringField);
 
-			StringFieldSchema stringField = new StringFieldSchemaImpl();
-			stringField.setAllowedValues("blub");
-			stringField.setName("stringField");
-			stringField.setRequired(true);
-			stringField.setLabel("originalLabel");
-			schemaModel.addField(stringField);
-
-			version.setSchema(schemaModel);
+				v.setSchema(schemaModel);
+			});
 
 			HibUpdateFieldChange stringFieldUpdate = (HibUpdateFieldChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.UPDATEFIELD);
 			stringFieldUpdate.setFieldName("stringField");
@@ -142,59 +141,59 @@ public class FieldSchemaContainerMutatorTest extends AbstractMeshTest {
 			// 1. Create schema
 			SchemaModelImpl schemaModel = new SchemaModelImpl("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {
+				BinaryFieldSchema binaryField = new BinaryFieldSchemaImpl();
+				binaryField.setName("binaryField");
+				binaryField.setAllowedMimeTypes("oldTypes");
+				binaryField.setRequired(true);
+				schemaModel.addField(binaryField);
 
-			BinaryFieldSchema binaryField = new BinaryFieldSchemaImpl();
-			binaryField.setName("binaryField");
-			binaryField.setAllowedMimeTypes("oldTypes");
-			binaryField.setRequired(true);
-			schemaModel.addField(binaryField);
+				StringFieldSchema stringField = new StringFieldSchemaImpl();
+				stringField.setAllowedValues("blub");
+				stringField.setName("stringField");
+				stringField.setRequired(true);
+				schemaModel.addField(stringField);
 
-			StringFieldSchema stringField = new StringFieldSchemaImpl();
-			stringField.setAllowedValues("blub");
-			stringField.setName("stringField");
-			stringField.setRequired(true);
-			schemaModel.addField(stringField);
+				NodeFieldSchema nodeField = new NodeFieldSchemaImpl();
+				nodeField.setAllowedSchemas("blub");
+				nodeField.setName("nodeField");
+				nodeField.setRequired(true);
+				schemaModel.addField(nodeField);
 
-			NodeFieldSchema nodeField = new NodeFieldSchemaImpl();
-			nodeField.setAllowedSchemas("blub");
-			nodeField.setName("nodeField");
-			nodeField.setRequired(true);
-			schemaModel.addField(nodeField);
+				MicronodeFieldSchema micronodeField = new MicronodeFieldSchemaImpl();
+				micronodeField.setAllowedMicroSchemas("blub");
+				micronodeField.setName("micronodeField");
+				micronodeField.setRequired(true);
+				schemaModel.addField(micronodeField);
 
-			MicronodeFieldSchema micronodeField = new MicronodeFieldSchemaImpl();
-			micronodeField.setAllowedMicroSchemas("blub");
-			micronodeField.setName("micronodeField");
-			micronodeField.setRequired(true);
-			schemaModel.addField(micronodeField);
+				NumberFieldSchema numberField = new NumberFieldSchemaImpl();
+				numberField.setName("numberField");
+				numberField.setRequired(true);
+				schemaModel.addField(numberField);
 
-			NumberFieldSchema numberField = new NumberFieldSchemaImpl();
-			numberField.setName("numberField");
-			numberField.setRequired(true);
-			schemaModel.addField(numberField);
+				HtmlFieldSchema htmlField = new HtmlFieldSchemaImpl();
+				htmlField.setName("htmlField");
+				htmlField.setRequired(true);
+				schemaModel.addField(htmlField);
 
-			HtmlFieldSchema htmlField = new HtmlFieldSchemaImpl();
-			htmlField.setName("htmlField");
-			htmlField.setRequired(true);
-			schemaModel.addField(htmlField);
+				BooleanFieldSchema booleanField = new BooleanFieldSchemaImpl();
+				booleanField.setName("booleanField");
+				booleanField.setRequired(true);
+				schemaModel.addField(booleanField);
 
-			BooleanFieldSchema booleanField = new BooleanFieldSchemaImpl();
-			booleanField.setName("booleanField");
-			booleanField.setRequired(true);
-			schemaModel.addField(booleanField);
+				DateFieldSchema dateField = new DateFieldSchemaImpl();
+				dateField.setName("dateField");
+				dateField.setRequired(true);
+				schemaModel.addField(dateField);
 
-			DateFieldSchema dateField = new DateFieldSchemaImpl();
-			dateField.setName("dateField");
-			dateField.setRequired(true);
-			schemaModel.addField(dateField);
+				ListFieldSchema listField = new ListFieldSchemaImpl();
+				listField.setName("listField");
+				listField.setListType("micronode");
+				listField.setRequired(true);
+				schemaModel.addField(listField);
 
-			ListFieldSchema listField = new ListFieldSchemaImpl();
-			listField.setName("listField");
-			listField.setListType("micronode");
-			listField.setRequired(true);
-			schemaModel.addField(listField);
-
-			version.setSchema(schemaModel);
+				v.setSchema(schemaModel);
+			});
 
 			// 2. Create schema field update change
 			HibUpdateFieldChange binaryFieldUpdate = (HibUpdateFieldChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.UPDATEFIELD);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/FieldTypeChangeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/FieldTypeChangeTest.java
@@ -34,7 +34,7 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 			CommonTx ctx = tx.unwrap();
 			SchemaModelImpl schemaModel = new SchemaModelImpl("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {});
 
 			HibFieldTypeChange change = (HibFieldTypeChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.CHANGEFIELDTYPE);
 			change.setFieldName("name");
@@ -54,12 +54,13 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 			SchemaModelImpl schemaModel = new SchemaModelImpl();
 			schemaModel.setName("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
-
-			StringFieldSchema stringField = new StringFieldSchemaImpl();
-			stringField.setName("stringField");
-			stringField.setRequired(true);
-			schemaModel.addField(stringField);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {
+				StringFieldSchema stringField = new StringFieldSchemaImpl();
+				stringField.setName("stringField");
+				stringField.setRequired(true);
+				schemaModel.addField(stringField);
+				v.setSchema(schemaModel);
+			});
 
 			HibFieldTypeChange fieldTypeUpdate = (HibFieldTypeChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.CHANGEFIELDTYPE);
 			fieldTypeUpdate.setFieldName("stringField");
@@ -67,7 +68,6 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 
 			// 3. Apply the changes
 			version.setNextChange(fieldTypeUpdate);
-			version.setSchema(schemaModel);
 
 			SchemaModel updatedSchema = mutator.apply(version);
 			assertNotNull(updatedSchema);
@@ -86,13 +86,14 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 			SchemaModelImpl schemaModel = new SchemaModelImpl();
 			schemaModel.setName("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
-
-			StringFieldSchema stringField = new StringFieldSchemaImpl();
-			stringField.setName("stringField");
-			stringField.setRequired(true);
-			stringField.setLabel("test123");
-			schemaModel.addField(stringField);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {
+				StringFieldSchema stringField = new StringFieldSchemaImpl();
+				stringField.setName("stringField");
+				stringField.setRequired(true);
+				stringField.setLabel("test123");
+				schemaModel.addField(stringField);
+				v.setSchema(schemaModel);
+			});
 
 			HibFieldTypeChange fieldTypeUpdate = (HibFieldTypeChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.CHANGEFIELDTYPE);
 			fieldTypeUpdate.setFieldName("stringField");
@@ -100,7 +101,6 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 			fieldTypeUpdate.setListType("html");
 
 			version.setNextChange(fieldTypeUpdate);
-			version.setSchema(schemaModel);
 
 			// 3. Apply the changes
 			SchemaModel updatedSchema = mutator.apply(version);
@@ -123,7 +123,7 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 			SchemaModelImpl schemaModel = new SchemaModelImpl();
 			schemaModel.setName("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {});
 
 			SchemaChangeModel model = SchemaChangeModel.createChangeFieldTypeChange("testField", "list");
 			model.setProperty(SchemaChangeModel.LIST_TYPE_KEY, "html");
@@ -147,7 +147,7 @@ public class FieldTypeChangeTest extends AbstractChangeTest {
 			SchemaModelImpl schemaModel = new SchemaModelImpl();
 			schemaModel.setName("testschema");
 			HibSchema schema = ctx.schemaDao().create(schemaModel, user());
-			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema);
+			HibSchemaVersion version = ctx.schemaDao().createPersistedVersion(schema, v -> {});
 
 			HibFieldTypeChange change = (HibFieldTypeChange) ctx.schemaDao().createPersistedChange(version, SchemaChangeOperation.CHANGEFIELDTYPE);
 			change.setFieldName("test");

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/UpdateMicroschemaChangeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/UpdateMicroschemaChangeTest.java
@@ -30,7 +30,7 @@ public class UpdateMicroschemaChangeTest extends AbstractChangeTest {
 		try (Tx tx = tx()) {
 			PersistingMicroschemaDao microschemaDao = tx.<CommonTx>unwrap().microschemaDao();
 			HibMicroschema microschema = microschemaDao.createPersisted(null);
-			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema);
+			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema, v -> {});
 			HibUpdateMicroschemaChange change = (HibUpdateMicroschemaChange) microschemaDao.createPersistedChange(version, SchemaChangeOperation.UPDATEMICROSCHEMA);
 			change.setDescription("test");
 			assertEquals("test", change.getDescription());
@@ -43,7 +43,7 @@ public class UpdateMicroschemaChangeTest extends AbstractChangeTest {
 		try (Tx tx = tx()) {
 			PersistingMicroschemaDao microschemaDao = tx.<CommonTx>unwrap().microschemaDao();
 			HibMicroschema microschema = microschemaDao.createPersisted(null);
-			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema);
+			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema, v -> {});
 			
 			MicroschemaModelImpl schema = new MicroschemaModelImpl();
 
@@ -71,7 +71,7 @@ public class UpdateMicroschemaChangeTest extends AbstractChangeTest {
 		try (Tx tx = tx()) {
 			PersistingMicroschemaDao microschemaDao = tx.<CommonTx>unwrap().microschemaDao();
 			HibMicroschema microschema = microschemaDao.createPersisted(null);
-			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema);
+			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema, v -> {});
 			
 			SchemaChangeModel model = SchemaChangeModel.createUpdateMicroschemaChange();
 			model.setProperty(SchemaChangeModel.NAME_KEY, "someName");
@@ -88,7 +88,7 @@ public class UpdateMicroschemaChangeTest extends AbstractChangeTest {
 		try (Tx tx = tx()) {
 			PersistingMicroschemaDao microschemaDao = tx.<CommonTx>unwrap().microschemaDao();
 			HibMicroschema microschema = microschemaDao.createPersisted(null);
-			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema);
+			HibMicroschemaVersion version = microschemaDao.createPersistedVersion(microschema, v -> {});
 			HibUpdateMicroschemaChange change = (HibUpdateMicroschemaChange) microschemaDao.createPersistedChange(version, SchemaChangeOperation.UPDATEMICROSCHEMA);
 			change.setName("vcard");
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/AbstractFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/AbstractFieldMigrationTest.java
@@ -1016,7 +1016,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @return schema container
 	 */
 	protected HibSchemaVersion createSchemaVersion(HibSchema container, String name, String version, FieldSchema... fields) {
-		return fillSchemaVersion(CommonTx.get().schemaDao().createPersistedVersion(container), container, name, version, fields);
+		return CommonTx.get().schemaDao().createPersistedVersion(container, v -> fillSchemaVersion(v, container, name, name, fields));
 	}
 
 	protected HibSchemaVersion fillSchemaVersion(HibSchemaVersion containerVersion, HibSchema container, String name, String versionName, FieldSchema... fields) {
@@ -1056,12 +1056,12 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		for (FieldSchema field : fields) {
 			schema.addField(field);
 		}
-		HibMicroschemaVersion containerVersion = CommonTx.get().microschemaDao().createPersistedVersion(container);
-		containerVersion.setSchema(schema);
-		containerVersion.setName(name);
-		containerVersion.setSchemaContainer(container);
-		container.setLatestVersion(containerVersion);
-		return containerVersion;
+		return CommonTx.get().microschemaDao().createPersistedVersion(container, containerVersion -> {
+			containerVersion.setSchema(schema);
+			containerVersion.setName(name);
+			containerVersion.setSchemaContainer(container);
+			container.setLatestVersion(containerVersion);
+		});
 	}
 
 	/**

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootEndpointETagTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootEndpointETagTest.java
@@ -99,12 +99,13 @@ public class WebRootEndpointETagTest extends AbstractMeshTest {
 	public void testReadOne() {
 		String path = "/News/2015/News_2015.en.html";
 		try (Tx tx = tx()) {
+			ContentDao contentDao = tx.contentDao();
 			HibNode node = content("news_2015");
 			// Inject the reference node field
-			SchemaVersionModel schema = boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema();
+			SchemaVersionModel schema = contentDao.getSchemaContainerVersion(contentDao.getFieldContainer(node, "en")).getSchema();
 			schema.addField(FieldUtil.createNodeFieldSchema("reference"));
-			boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().setSchema(schema);
-			boot().contentDao().getFieldContainer(node, "en").createNode("reference", folder("2015"));
+			contentDao.getSchemaContainerVersion(contentDao.getFieldContainer(node, "en")).setSchema(schema);
+			contentDao.getFieldContainer(node, "en").createNode("reference", folder("2015"));
 			tx.success();
 		}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webrootfield/WebRootFieldEndpointETagTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webrootfield/WebRootFieldEndpointETagTest.java
@@ -99,12 +99,13 @@ public class WebRootFieldEndpointETagTest extends AbstractMeshTest {
 	public void testReadOne() {
 		String path = "/News/2015/News_2015.en.html";
 		try (Tx tx = tx()) {
+			ContentDao contentDao = tx.contentDao();
 			HibNode node = content("news_2015");
 			// Inject the reference node field
-			SchemaVersionModel schema = boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema();
+			SchemaVersionModel schema = contentDao.getSchemaContainerVersion(contentDao.getFieldContainer(node, "en")).getSchema();
 			schema.addField(FieldUtil.createNodeFieldSchema("reference"));
-			boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().setSchema(schema);
-			boot().contentDao().getFieldContainer(node, "en").createNode("reference", folder("2015"));
+			contentDao.getSchemaContainerVersion(contentDao.getFieldContainer(node, "en")).setSchema(schema);
+			contentDao.getFieldContainer(node, "en").createNode("reference", folder("2015"));
 			tx.success();
 		}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
@@ -571,7 +571,7 @@ public class TestDataProvider {
 			HibNodeFieldContainer germanContainer = contentDao.createFieldContainer(folderNode, german,
 				branch, userInfo.getUser());
 			germanContainer.createString("slug").setString(germanName);
-			germanContainer.updateDisplayFieldValue();
+			contentDao.updateDisplayFieldValue(germanContainer);
 			contentCount++;
 			contentDao.publish(folderNode, ac, getGerman(), branch, getUserInfo().getUser());
 		}
@@ -580,7 +580,7 @@ public class TestDataProvider {
 				branch, userInfo.getUser());
 			englishContainer.createString("name").setString(englishName);
 			englishContainer.createString("slug").setString(englishName);
-			englishContainer.updateDisplayFieldValue();
+			contentDao.updateDisplayFieldValue(englishContainer);
 			contentCount++;
 			contentDao.publish(folderNode, ac, getEnglish(), branch, getUserInfo().getUser());
 		}
@@ -635,7 +635,7 @@ public class TestDataProvider {
 			englishContainer.createString("title").setString(name + " english title");
 			englishContainer.createString("slug").setString(name + ".en.html");
 			englishContainer.createHTML("content").setHtml(englishContent);
-			englishContainer.updateDisplayFieldValue();
+			contentDao.updateDisplayFieldValue(englishContainer);
 			contentCount++;
 			contentDao.publish(node, ac, getEnglish(), branch, getUserInfo().getUser());
 		}
@@ -647,7 +647,7 @@ public class TestDataProvider {
 			germanContainer.createString("title").setString(name + " german title");
 			germanContainer.createString("slug").setString(name + ".de.html");
 			germanContainer.createHTML("content").setHtml(germanContent);
-			germanContainer.updateDisplayFieldValue();
+			contentDao.updateDisplayFieldValue(germanContainer);
 			contentCount++;
 			contentDao.publish(node, ac, getGerman(), branch, getUserInfo().getUser());
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/WrapperHelper.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/WrapperHelper.java
@@ -1,5 +1,7 @@
 package com.gentics.mesh.test.context;
 
+import java.util.function.Consumer;
+
 import com.gentics.mesh.core.data.schema.HibMicroschema;
 import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
 import com.gentics.mesh.core.data.schema.HibSchema;
@@ -18,8 +20,8 @@ public interface WrapperHelper {
 		return schema;
 	}
 
-	default HibSchemaVersion createSchemaVersion(Tx tx, HibSchema schema) {
-		HibSchemaVersion version = ((CommonTx) tx).schemaDao().createPersistedVersion(schema);
+	default HibSchemaVersion createSchemaVersion(Tx tx, HibSchema schema, Consumer<HibSchemaVersion> inflater) {
+		HibSchemaVersion version = ((CommonTx) tx).schemaDao().createPersistedVersion(schema, inflater);
 		return version;
 	}
 
@@ -29,8 +31,8 @@ public interface WrapperHelper {
 		return schema;
 	}
 
-	default HibMicroschemaVersion createMicroschemaVersion(Tx tx, HibMicroschema schema) {
-		HibMicroschemaVersion version = ((CommonTx) tx).microschemaDao().createPersistedVersion(schema);
+	default HibMicroschemaVersion createMicroschemaVersion(Tx tx, HibMicroschema schema, Consumer<HibMicroschemaVersion> inflater) {
+		HibMicroschemaVersion version = ((CommonTx) tx).microschemaDao().createPersistedVersion(schema, inflater);
 		return version;
 	}
 }

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/context/impl/GraphQLContextImpl.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/context/impl/GraphQLContextImpl.java
@@ -61,7 +61,7 @@ public class GraphQLContextImpl extends InternalRoutingActionContextImpl impleme
 			return true;
 		}
 
-		boolean isPublished = container.isPublished(tx.getBranch(this).getUuid());
+		boolean isPublished = contentDao.isPublished(container, tx.getBranch(this).getUuid());
 		if (isPublished && userDao.hasPermissionForId(getUser(), nodeId, InternalPermission.READ_PUBLISHED_PERM)) {
 			return true;
 		}

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/model/NodeReferenceIn.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/model/NodeReferenceIn.java
@@ -42,10 +42,10 @@ public class NodeReferenceIn {
 		return contentDao.getInboundReferences(content.getNode())
 			.flatMap(ref -> ref.getReferencingContents()
 				.filter(container -> {
-					if (type == DRAFT && container.isDraft(branchUuid)) {
+					if (type == DRAFT && contentDao.isDraft(container, branchUuid)) {
 						return true;
 					}
-					if (type == PUBLISHED && container.isPublished(branchUuid)) {
+					if (type == PUBLISHED && contentDao.isPublished(container, branchUuid)) {
 						return true;
 					}
 					return false;

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
@@ -487,7 +487,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 					if (container == null) {
 						return null;
 					}
-					return container.isPublished(tx.getBranch(gc).getUuid());
+					return tx.contentDao().isPublished(container, tx.getBranch(gc).getUuid());
 				}).build(),
 
 			// .isDraft
@@ -500,7 +500,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 					if (container == null) {
 						return null;
 					}
-					return container.isDraft(tx.getBranch(gc).getUuid());
+					return tx.contentDao().isDraft(container, tx.getBranch(gc).getUuid());
 				}).build(),
 
 			// .version
@@ -531,7 +531,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 					return contentDao.getFieldContainers(node, tx.getBranch(gc), DRAFT).stream().filter(c -> {
 						String lang = c.getLanguageTag();
 						return lang.equals(languageTag);
-					}).findFirst().map(HibNodeFieldContainer::versions).orElse(null);
+					}).findFirst().map(contentDao::versions).orElse(null);
 				}).build(),
 
 			// .language
@@ -595,7 +595,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 				GraphQLContext gc = env.getContext();
 				String branchUuid = tx.getBranch(gc).getUuid();
 				HibNodeFieldContainer version = env.getSource();
-				return version.isDraft(branchUuid);
+				return tx.contentDao().isDraft(version, branchUuid);
 			}));
 
 		// .published
@@ -605,7 +605,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 				GraphQLContext gc = env.getContext();
 				String branchUuid = tx.getBranch(gc).getUuid();
 				HibNodeFieldContainer version = env.getSource();
-				return version.isPublished(branchUuid);
+				return tx.contentDao().isPublished(version, branchUuid);
 			}));
 
 		// .branchRoot
@@ -613,7 +613,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 			.description("Flag that indicates whether the version is used as a branch root version for a branch.").type(GraphQLBoolean)
 			.dataFetcher((env) -> {
 				HibNodeFieldContainer version = env.getSource();
-				return version.isInitial();
+				return Tx.get().contentDao().isInitial(version);
 			}));
 
 		// .created


### PR DESCRIPTION
## Abstract

After the new version is created, it should remain unchangeable, as changing the schema means a new schema version. So when the version is created, it should be already filled with the schema data, so a some sort of version record inflation code should be introduced, which runs right before the version record actual storage.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
