### PR TITLE
Fix interval in startPings

### DIFF
--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/OkHttpWebsocket.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/OkHttpWebsocket.java
@@ -118,7 +118,7 @@ public class OkHttpWebsocket implements MeshWebsocket {
 	}
 
 	private void startPings() {
-		pingInterval = Observable.interval(config.getWebsocketReconnectInterval().toMillis(), TimeUnit.MILLISECONDS)
+		pingInterval = Observable.interval(config.getWebsocketPingInterval().toMillis(), TimeUnit.MILLISECONDS)
 			.subscribe(ignore -> send(eventbusMessage(EventbusMessageType.PING)));
 	}
 


### PR DESCRIPTION
The startPings method should use getWebsocketPingInterval and not getWebsocketReconnectInterval

## Abstract

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
