### PR TITLE
Update commons-codec to fix errors in Tika

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -32,6 +32,8 @@ icon:plus[] Rest: The endpoint `/api/v1/admin/jobs` now supports query parameter
 icon:check[] Search: The periodic check for correctness of the indices in Elasticsearch created temporary indices, which did not start with the installation prefix,
 and thus were sometimes not cleaned up. The naming of those temporary indices has now been changed to also start with the installation prefix.
 
+icon:check[] Core: The 'commons-codec' libary has been updated. This fixes possible internal errors when parsing uploaded files using tika.
+
 [[v1.6.24]]
 == 1.6.24 (01.12.2021)
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -104,7 +104,7 @@
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.10</version>
+				<version>1.15</version>
 			</dependency>
 
 			<!-- HTTP Client -->


### PR DESCRIPTION
## Abstract

Uploading documents could fail with an error, if the document contents was parsed with tika, due to incompatilities between tika and the included commons-codec.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
