### PR TITLE
Mdm schema migration

### DIFF
--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandlerImpl.java
@@ -260,119 +260,117 @@ public class BinaryUploadHandlerImpl extends AbstractHandler implements BinaryUp
 		String hash = context.getHash();
 		String binaryUuid = context.getBinaryUuid();
 
-		return db.singleTxWriteLock(tx -> {
+		return db.singleTxWriteLock((batch, tx) -> {
 			ContentDao contentDao = tx.contentDao();
 			HibProject project = tx.getProject(ac);
 			HibBranch branch = tx.getBranch(ac);
 			NodeDao nodeDao = tx.nodeDao();
 			HibNode node = nodeDao.loadObjectByUuid(project, ac, nodeUuid, UPDATE_PERM);
 
-			utils.eventAction(batch -> {
+			// We need to check whether someone else has stored the binary in the meanwhile
+			HibBinary binary = binaries.findByHash(hash).runInExistingTx(tx);
+			if (binary == null) {
+				binary = binaries.create(binaryUuid, hash, upload.size()).runInExistingTx(tx);
+			}
+			HibLanguage language = tx.languageDao().findByLanguageTag(languageTag);
+			if (language == null) {
+				throw error(NOT_FOUND, "error_language_not_found", languageTag);
+			}
 
-				// We need to check whether someone else has stored the binary in the meanwhile
-				HibBinary binary = binaries.findByHash(hash).runInExistingTx(tx);
-				if (binary == null) {
-					binary = binaries.create(binaryUuid, hash, upload.size()).runInExistingTx(tx);
-				}
-				HibLanguage language = tx.languageDao().findByLanguageTag(languageTag);
-				if (language == null) {
-					throw error(NOT_FOUND, "error_language_not_found", languageTag);
-				}
+			// Load the current latest draft
+			HibNodeFieldContainer latestDraftVersion = contentDao.getFieldContainer(node, languageTag, branch, ContainerType.DRAFT);
 
-				// Load the current latest draft
-				HibNodeFieldContainer latestDraftVersion = contentDao.getFieldContainer(node, languageTag, branch, ContainerType.DRAFT);
+			if (latestDraftVersion == null) {
+				// latestDraftVersion = node.createGraphFieldContainer(language, branch, ac.getUser());
+				// TODO Maybe it would be better to just create a new field container for the language?
+				// In that case we would also need to:
+				// * check for segment field conflicts
+				// * update display name
+				// * fail if mandatory fields are missing
+				throw error(NOT_FOUND, "error_language_not_found", languageTag);
+			}
 
-				if (latestDraftVersion == null) {
-					// latestDraftVersion = node.createGraphFieldContainer(language, branch, ac.getUser());
-					// TODO Maybe it would be better to just create a new field container for the language?
-					// In that case we would also need to:
-					// * check for segment field conflicts
-					// * update display name
-					// * fail if mandatory fields are missing
-					throw error(NOT_FOUND, "error_language_not_found", languageTag);
-				}
+			// Load the base version field container in order to create the diff
+			HibNodeFieldContainer baseVersionContainer = contentDao.findVersion(node, languageTag, branch.getUuid(), nodeVersion);
+			if (baseVersionContainer == null) {
+				throw error(BAD_REQUEST, "node_error_draft_not_found", nodeVersion, languageTag);
+			}
 
-				// Load the base version field container in order to create the diff
-				HibNodeFieldContainer baseVersionContainer = contentDao.findVersion(node, languageTag, branch.getUuid(), nodeVersion);
-				if (baseVersionContainer == null) {
-					throw error(BAD_REQUEST, "node_error_draft_not_found", nodeVersion, languageTag);
-				}
+			List<FieldContainerChange> baseVersionDiff = contentDao.compareTo(baseVersionContainer, latestDraftVersion);
+			List<FieldContainerChange> requestVersionDiff = Arrays.asList(new FieldContainerChange(fieldName, FieldChangeTypes.UPDATED));
 
-				List<FieldContainerChange> baseVersionDiff = contentDao.compareTo(baseVersionContainer, latestDraftVersion);
-				List<FieldContainerChange> requestVersionDiff = Arrays.asList(new FieldContainerChange(fieldName, FieldChangeTypes.UPDATED));
+			// Compare both sets of change sets
+			List<FieldContainerChange> intersect = baseVersionDiff.stream().filter(requestVersionDiff::contains)
+				.collect(Collectors.toList());
 
-				// Compare both sets of change sets
-				List<FieldContainerChange> intersect = baseVersionDiff.stream().filter(requestVersionDiff::contains)
-					.collect(Collectors.toList());
+			// Check whether the update was not based on the latest draft version. In that case a conflict check needs to occur.
+			if (!latestDraftVersion.getVersion().equals(nodeVersion)) {
 
-				// Check whether the update was not based on the latest draft version. In that case a conflict check needs to occur.
-				if (!latestDraftVersion.getVersion().equals(nodeVersion)) {
-
-					// Check whether a conflict has been detected
-					if (intersect.size() > 0) {
-						NodeVersionConflictException conflictException = new NodeVersionConflictException("node_error_conflict_detected");
-						conflictException.setOldVersion(baseVersionContainer.getVersion().toString());
-						conflictException.setNewVersion(latestDraftVersion.getVersion().toString());
-						for (FieldContainerChange fcc : intersect) {
-							conflictException.addConflict(fcc.getFieldCoordinates());
-						}
-						throw conflictException;
+				// Check whether a conflict has been detected
+				if (intersect.size() > 0) {
+					NodeVersionConflictException conflictException = new NodeVersionConflictException("node_error_conflict_detected");
+					conflictException.setOldVersion(baseVersionContainer.getVersion().toString());
+					conflictException.setNewVersion(latestDraftVersion.getVersion().toString());
+					for (FieldContainerChange fcc : intersect) {
+						conflictException.addConflict(fcc.getFieldCoordinates());
 					}
+					throw conflictException;
 				}
+			}
 
-				FieldSchema fieldSchema = latestDraftVersion.getSchemaContainerVersion().getSchema().getField(fieldName);
-				if (fieldSchema == null) {
-					throw error(BAD_REQUEST, "error_schema_definition_not_found", fieldName);
+			FieldSchema fieldSchema = latestDraftVersion.getSchemaContainerVersion().getSchema().getField(fieldName);
+			if (fieldSchema == null) {
+				throw error(BAD_REQUEST, "error_schema_definition_not_found", fieldName);
+			}
+			if (!(fieldSchema instanceof BinaryFieldSchema)) {
+				// TODO Add support for other field types
+				throw error(BAD_REQUEST, "error_found_field_is_not_binary", fieldName);
+			}
+
+			// Create a new node version field container to store the upload
+			HibNodeFieldContainer newDraftVersion = contentDao.createFieldContainer(node, languageTag, branch, ac.getUser(),
+				latestDraftVersion,
+				true);
+
+			// Get the potential existing field
+			HibBinaryField oldField = newDraftVersion.getBinary(fieldName);
+
+			// Create the new field
+			HibBinaryField field = newDraftVersion.createBinary(fieldName, binary);
+
+			// Reuse the existing properties
+			if (oldField != null) {
+				oldField.copyTo(field);
+
+				// If the old field was an image and the current upload is not an image we need to reset the custom image specific attributes.
+				if (oldField.hasProcessableImage() && !NodeUtil.isProcessableImage(upload.contentType())) {
+					field.setImageDominantColor(null);
 				}
-				if (!(fieldSchema instanceof BinaryFieldSchema)) {
-					// TODO Add support for other field types
-					throw error(BAD_REQUEST, "error_found_field_is_not_binary", fieldName);
-				}
+			}
 
-				// Create a new node version field container to store the upload
-				HibNodeFieldContainer newDraftVersion = contentDao.createFieldContainer(node, languageTag, branch, ac.getUser(),
-					latestDraftVersion,
-					true);
+			// Now set the field infos. This will override any copied values as well.
+			field.setFileName(upload.fileName());
+			field.setMimeType(upload.contentType());
+			field.getBinary().setSize(upload.size());
 
-				// Get the potential existing field
-				HibBinaryField oldField = newDraftVersion.getBinary(fieldName);
+			for (Consumer<HibBinaryField> modifier : fieldModifier) {
+				modifier.accept(field);
+			}
 
-				// Create the new field
-				HibBinaryField field = newDraftVersion.createBinary(fieldName, binary);
+			// Now get rid of the old field
+			newDraftVersion.removeField(oldField);
 
-				// Reuse the existing properties
-				if (oldField != null) {
-					oldField.copyTo(field);
+			// If the binary field is the segment field, we need to update the webroot info in the node
+			if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
+				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
+			}
 
-					// If the old field was an image and the current upload is not an image we need to reset the custom image specific attributes.
-					if (oldField.hasProcessableImage() && !NodeUtil.isProcessableImage(upload.contentType())) {
-						field.setImageDominantColor(null);
-					}
-				}
+			if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
+				contentDao.purge(latestDraftVersion);
+			}
 
-				// Now set the field infos. This will override any copied values as well.
-				field.setFileName(upload.fileName());
-				field.setMimeType(upload.contentType());
-				field.getBinary().setSize(upload.size());
+			batch.add(contentDao.onUpdated(newDraftVersion, branch.getUuid(), DRAFT));
 
-				for (Consumer<HibBinaryField> modifier : fieldModifier) {
-					modifier.accept(field);
-				}
-
-				// Now get rid of the old field
-				newDraftVersion.removeField(oldField);
-
-				// If the binary field is the segment field, we need to update the webroot info in the node
-				if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
-					contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
-				}
-
-				if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
-					contentDao.purge(latestDraftVersion);
-				}
-
-				batch.add(contentDao.onUpdated(newDraftVersion, branch.getUuid(), DRAFT));
-			});
 			return nodeDao.transformToRestSync(node, ac, 0);
 		});
 	}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryMetadataExtractionHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryMetadataExtractionHandlerImpl.java
@@ -192,119 +192,117 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 		String s3ObjectKey = context.getS3ObjectKey();
 		String fileName = context.getFileName();
 
-		return db.singleTxWriteLock(tx -> {
+		return db.singleTxWriteLock((batch, tx) -> {
 			ContentDao contentDao = tx.contentDao();
 			HibProject project = tx.getProject(ac);
 			HibBranch branch = tx.getBranch(ac);
 			NodeDao nodeDao = tx.nodeDao();
 			HibNode node = nodeDao.loadObjectByUuid(project, ac, nodeUuid, UPDATE_PERM);
 
-			utils.eventAction(batch -> {
+			// We need to check whether someone else has stored the binary in the meanwhile
+			S3HibBinary s3binary = s3binaries.findByS3ObjectKey(s3ObjectKey).runInExistingTx(tx);
+			if (s3binary == null) {
+				s3binary = s3binaries.create(nodeUuid, s3ObjectKey, fileName).runInExistingTx(tx);
+			}
+			HibLanguage language = tx.languageDao().findByLanguageTag(languageTag);
+			if (language == null) {
+				throw error(NOT_FOUND, "error_language_not_found", languageTag);
+			}
 
-				// We need to check whether someone else has stored the binary in the meanwhile
-				S3HibBinary s3binary = s3binaries.findByS3ObjectKey(s3ObjectKey).runInExistingTx(tx);
-				if (s3binary == null) {
-					s3binary = s3binaries.create(nodeUuid, s3ObjectKey, fileName).runInExistingTx(tx);
-				}
-				HibLanguage language = tx.languageDao().findByLanguageTag(languageTag);
-				if (language == null) {
-					throw error(NOT_FOUND, "error_language_not_found", languageTag);
-				}
+			// Load the current latest draft
+			HibNodeFieldContainer latestDraftVersion = contentDao.getFieldContainer(node, languageTag, branch, ContainerType.DRAFT);
 
-				// Load the current latest draft
-				HibNodeFieldContainer latestDraftVersion = contentDao.getFieldContainer(node, languageTag, branch, ContainerType.DRAFT);
+			if (latestDraftVersion == null) {
+				// latestDraftVersion = node.createGraphFieldContainer(language, branch, ac.getUser());
+				// TODO Maybe it would be better to just create a new field container for the language?
+				// In that case we would also need to:
+				// * check for segment field conflicts
+				// * update display name
+				// * fail if mandatory fields are missing
+				throw error(NOT_FOUND, "error_language_not_found", languageTag);
+			}
 
-				if (latestDraftVersion == null) {
-					// latestDraftVersion = node.createGraphFieldContainer(language, branch, ac.getUser());
-					// TODO Maybe it would be better to just create a new field container for the language?
-					// In that case we would also need to:
-					// * check for segment field conflicts
-					// * update display name
-					// * fail if mandatory fields are missing
-					throw error(NOT_FOUND, "error_language_not_found", languageTag);
-				}
+			// Load the base version field container in order to create the diff
+			HibNodeFieldContainer baseVersionContainer = contentDao.findVersion(node, languageTag, branch.getUuid(), nodeVersion);
+			if (baseVersionContainer == null) {
+				throw error(BAD_REQUEST, "node_error_draft_not_found", nodeVersion, languageTag);
+			}
 
-				// Load the base version field container in order to create the diff
-				HibNodeFieldContainer baseVersionContainer = contentDao.findVersion(node, languageTag, branch.getUuid(), nodeVersion);
-				if (baseVersionContainer == null) {
-					throw error(BAD_REQUEST, "node_error_draft_not_found", nodeVersion, languageTag);
-				}
+			List<FieldContainerChange> baseVersionDiff = contentDao.compareTo(baseVersionContainer, latestDraftVersion);
+			List<FieldContainerChange> requestVersionDiff = Arrays.asList(new FieldContainerChange(fieldName, FieldChangeTypes.UPDATED));
 
-				List<FieldContainerChange> baseVersionDiff = contentDao.compareTo(baseVersionContainer, latestDraftVersion);
-				List<FieldContainerChange> requestVersionDiff = Arrays.asList(new FieldContainerChange(fieldName, FieldChangeTypes.UPDATED));
+			// Compare both sets of change sets
+			List<FieldContainerChange> intersect = baseVersionDiff.stream().filter(requestVersionDiff::contains)
+					.collect(Collectors.toList());
 
-				// Compare both sets of change sets
-				List<FieldContainerChange> intersect = baseVersionDiff.stream().filter(requestVersionDiff::contains)
-						.collect(Collectors.toList());
+			// Check whether the update was not based on the latest draft version. In that case a conflict check needs to occur.
+			if (!latestDraftVersion.getVersion().equals(nodeVersion)) {
 
-				// Check whether the update was not based on the latest draft version. In that case a conflict check needs to occur.
-				if (!latestDraftVersion.getVersion().equals(nodeVersion)) {
-
-					// Check whether a conflict has been detected
-					if (intersect.size() > 0) {
-						NodeVersionConflictException conflictException = new NodeVersionConflictException("node_error_conflict_detected");
-						conflictException.setOldVersion(baseVersionContainer.getVersion().toString());
-						conflictException.setNewVersion(latestDraftVersion.getVersion().toString());
-						for (FieldContainerChange fcc : intersect) {
-							conflictException.addConflict(fcc.getFieldCoordinates());
-						}
-						throw conflictException;
+				// Check whether a conflict has been detected
+				if (intersect.size() > 0) {
+					NodeVersionConflictException conflictException = new NodeVersionConflictException("node_error_conflict_detected");
+					conflictException.setOldVersion(baseVersionContainer.getVersion().toString());
+					conflictException.setNewVersion(latestDraftVersion.getVersion().toString());
+					for (FieldContainerChange fcc : intersect) {
+						conflictException.addConflict(fcc.getFieldCoordinates());
 					}
+					throw conflictException;
 				}
+			}
 
-				FieldSchema fieldSchema = latestDraftVersion.getSchemaContainerVersion().getSchema().getField(fieldName);
-				if (fieldSchema == null) {
-					throw error(BAD_REQUEST, "error_schema_definition_not_found", fieldName);
+			FieldSchema fieldSchema = latestDraftVersion.getSchemaContainerVersion().getSchema().getField(fieldName);
+			if (fieldSchema == null) {
+				throw error(BAD_REQUEST, "error_schema_definition_not_found", fieldName);
+			}
+			if (!(fieldSchema instanceof S3BinaryFieldSchema)) {
+				// TODO Add support for other field types
+				throw error(BAD_REQUEST, "error_found_field_is_not_binary", fieldName);
+			}
+
+			// Create a new node version field container to store the upload
+			HibNodeFieldContainer newDraftVersion = contentDao.createFieldContainer(node, languageTag, branch, ac.getUser(),
+					latestDraftVersion,
+					true);
+
+			// Get the potential existing field
+			S3HibBinaryField oldField = newDraftVersion.getS3Binary(fieldName);
+
+			// Create the new field
+			S3HibBinaryField field = newDraftVersion.createS3Binary(fieldName, s3binary);
+
+			// Reuse the existing properties
+			if (oldField != null) {
+				oldField.copyTo(field);
+
+				// If the old field was an image and the current upload is not an image we need to reset the custom image specific attributes.
+				if (oldField.hasProcessableImage() && !NodeUtil.isProcessableImage(upload.contentType())) {
+					field.setImageDominantColor(null);
 				}
-				if (!(fieldSchema instanceof S3BinaryFieldSchema)) {
-					// TODO Add support for other field types
-					throw error(BAD_REQUEST, "error_found_field_is_not_binary", fieldName);
-				}
+			}
 
-				// Create a new node version field container to store the upload
-				HibNodeFieldContainer newDraftVersion = contentDao.createFieldContainer(node, languageTag, branch, ac.getUser(),
-						latestDraftVersion,
-						true);
+			// Now set the field infos. This will override any copied values as well.
+			field.setMimeType(upload.contentType());
+			field.setFileSize(upload.size());
 
-				// Get the potential existing field
-				S3HibBinaryField oldField = newDraftVersion.getS3Binary(fieldName);
+			for (Consumer<S3HibBinaryField> modifier : fieldModifier) {
+				modifier.accept(field);
+			}
 
-				// Create the new field
-				S3HibBinaryField field = newDraftVersion.createS3Binary(fieldName, s3binary);
+			// Now get rid of the old field
+			newDraftVersion.removeField(oldField);
 
-				// Reuse the existing properties
-				if (oldField != null) {
-					oldField.copyTo(field);
+			// If the binary field is the segment field, we need to update the webroot info in the node
+			if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
+				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
+			}
 
-					// If the old field was an image and the current upload is not an image we need to reset the custom image specific attributes.
-					if (oldField.hasProcessableImage() && !NodeUtil.isProcessableImage(upload.contentType())) {
-						field.setImageDominantColor(null);
-					}
-				}
+			if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
+				contentDao.purge(latestDraftVersion);
+			}
 
-				// Now set the field infos. This will override any copied values as well.
-				field.setMimeType(upload.contentType());
-				field.setFileSize(upload.size());
+			batch.add(contentDao.onUpdated(newDraftVersion, branch.getUuid(), DRAFT));
+			batch.add(s3binary.onMetadataExtracted(nodeUuid,s3ObjectKey));
 
-				for (Consumer<S3HibBinaryField> modifier : fieldModifier) {
-					modifier.accept(field);
-				}
-
-				// Now get rid of the old field
-				newDraftVersion.removeField(oldField);
-
-				// If the binary field is the segment field, we need to update the webroot info in the node
-				if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
-					contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
-				}
-
-				if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
-					contentDao.purge(latestDraftVersion);
-				}
-
-				batch.add(contentDao.onUpdated(newDraftVersion, branch.getUuid(), DRAFT));
-				batch.add(s3binary.onMetadataExtracted(nodeUuid,s3ObjectKey));
-			});
 			return nodeDao.transformToRestSync(node, ac, 0);
 		});
 	}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
@@ -73,13 +73,11 @@ public class ProjectCrudHandler extends AbstractCrudHandler<HibProject, ProjectR
 				HibUser user = ac.getUser();
 				ProjectDao projectDao = tx.projectDao();
 				HibProject project = projectDao.loadObjectByUuid(ac, uuid, DELETE_PERM);
-				db.tx(() -> {
-					if (before.isPresent()) {
-						boot.jobDao().enqueueVersionPurge(user, project, before.get());
-					} else {
-						boot.jobDao().enqueueVersionPurge(user, project);
-					}
-				});
+				if (before.isPresent()) {
+					boot.jobDao().enqueueVersionPurge(user, project, before.get());
+				} else {
+					boot.jobDao().enqueueVersionPurge(user, project);
+				}
 				MeshEvent.triggerJobWorker(boot.mesh());
 				return message(ac, "project_version_purge_enqueued");
 			}, message -> ac.send(message, OK));

--- a/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
@@ -104,7 +104,7 @@ public abstract class AbstractMigrationHandler extends AbstractHandler implement
 		HibFieldSchemaVersionElement<?,?,?,?,?> newVersion, Set<String> touchedFields) throws Exception {
 
 		// Remove all touched fields (if necessary, they will be readded later)
-		newContainer.getFields().stream().filter(f -> touchedFields.contains(f.getFieldKey())).forEach(newContainer::removeField);
+		newContainer.getFields(fromVersion).stream().filter(f -> touchedFields.contains(f.getFieldKey())).forEach(newContainer::removeField);
 		newContainer.setSchemaContainerVersion(newVersion);
 
 		FieldMap fields = newContent.getFields();

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
@@ -240,7 +240,7 @@ public class NodeMigrationImpl extends AbstractMigrationHandler implements NodeM
 		NodeResponse restModel = nodeDao.transformToRestSync(node, ac, 0, languageTag);
 
 		// Actual migration - Create the new version
-		HibNodeFieldContainer migrated = contentDao.createFieldContainer(node, container.getLanguageTag(), branch, container.getEditor(),
+		HibNodeFieldContainer migrated = contentDao.createFieldContainer(toVersion, node, container.getLanguageTag(), branch, container.getEditor(),
 			container, true);
 
 		// Ensure that the migrated version is also published since the old version was
@@ -298,7 +298,7 @@ public class NodeMigrationImpl extends AbstractMigrationHandler implements NodeM
 		NodeResponse restModel = nodeDao.transformToRestSync(node, ac, 0, languageTag);
 
 		HibBranch branchForUpdate = branchDao.findByUuid(branch.getProject(), branch.getUuid());
-		HibNodeFieldContainer migrated = contentDao.createFieldContainer(node, content.getLanguageTag(), branchForUpdate, content.getEditor(),
+		HibNodeFieldContainer migrated = contentDao.createFieldContainer(toVersion, node, content.getLanguageTag(), branchForUpdate, content.getEditor(),
 			content, true);
 
 		contentDao.setVersion(migrated, content.getVersion().nextPublished());

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
@@ -76,13 +76,24 @@ public interface HibFieldContainer extends HibBasicFieldContainer {
 	 * @return
 	 */
 	ReferenceType getReferenceType();
+
 	/**
-	 * List the fields of this container
+	 * List the fields of this container for the current schema container version
 	 * 
 	 * @return
 	 */
 	default List<HibField> getFields() {
-		FieldSchemaContainer schema = getSchemaContainerVersion().getSchema();
+		return getFields(getSchemaContainerVersion());
+	}
+
+	/**
+	 * List the fields of this container for the provided schema container version
+	 * During a migraiton, the container might temporary have fields for an older schema version
+	 * @param schemaContainerVersion
+	 * @return
+	 */
+	default List<HibField> getFields(HibFieldSchemaVersionElement<?, ?, ?, ?, ?> schemaContainerVersion) {
+		FieldSchemaContainer schema = schemaContainerVersion.getSchema();
 		List<HibField> fields = new ArrayList<>();
 		for (FieldSchema fieldSchema : schema.getFields()) {
 			HibField field = getField(fieldSchema);

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/ContentDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/ContentDao.java
@@ -290,6 +290,24 @@ public interface ContentDao {
 		boolean handleDraftEdge);
 
 	/**
+	 * Like {@link #createFieldContainer(HibNode, String, HibBranch, HibUser)}, but let the new field container be a clone of the given original (if not
+	 * null) and pass the schema version
+	 *
+	 * @param version
+	 * @param languageTag
+	 * @param branch
+	 * @param editor
+	 *            User which will be set as editor
+	 * @param original
+	 *            Container to be used as a source for the new container
+	 * @param handleDraftEdge
+	 *            Whether to move the existing draft edge or create a new draft edge to the new container
+	 * @return Created container
+	 */
+	HibNodeFieldContainer createFieldContainer(HibSchemaVersion version, HibNode node, String languageTag, HibBranch branch, HibUser editor, HibNodeFieldContainer original,
+											   boolean handleDraftEdge);
+
+	/**
 	 * Return the draft field containers of the node in the latest branch.
 	 *
 	 * @return

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/RootDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/RootDao.java
@@ -295,10 +295,6 @@ public interface RootDao<R extends HibCoreElement<? extends RestModel>, L extend
 	 * @return
 	 */
 	default boolean contains(R root, L element) {
-		if (findByUuid(root, element.getUuid()) == null) {
-			return false;
-		} else {
-			return true;
-		}
+		return findByUuid(root, element.getUuid()) != null;
 	}
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/node/HibNode.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/node/HibNode.java
@@ -101,14 +101,6 @@ public interface HibNode extends HibCoreElement<NodeResponse>, HibCreatorTrackin
 	HibNode getParentNode(String branchUuid);
 
 	/**
-	 * Set the parent node of this node.
-	 *
-	 * @param branchUuid
-	 * @param parentNode
-	 */
-	void setParentNode(String branchUuid, HibNode parentNode);
-
-	/**
 	 * Returns the i18n display name for the node. The display name will be determined by loading the i18n field value for the display field parameter of the
 	 * node's schema. It may be possible that no display name can be returned since new nodes may not have any values.
 	 *

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibSchemaChange.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibSchemaChange.java
@@ -1,5 +1,9 @@
 package com.gentics.mesh.core.data.schema;
 
+import static com.gentics.mesh.core.rest.error.Errors.error;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.ELASTICSEARCH_KEY;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -141,7 +145,19 @@ public interface HibSchemaChange<T extends FieldSchemaContainer> extends HibBase
 	 *
 	 * @return
 	 */
-	JsonObject getIndexOptions();
+	default JsonObject getIndexOptions() {
+		Object obj = getRestProperty(ELASTICSEARCH_KEY);
+		if (obj != null) {
+			if (obj instanceof String) {
+				return new JsonObject((String) obj);
+			} else if (obj instanceof JsonObject) {
+				return (JsonObject) obj;
+			} else {
+				throw error(INTERNAL_SERVER_ERROR, "Type was not expected {" + obj.getClass().getName() + "}");
+			}
+		}
+		return null;
+	}
 
 	/**
 	 * Set the index options for the schema / field.

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/Tx.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/Tx.java
@@ -48,24 +48,6 @@ public interface Tx extends BaseTransaction, DaoCollection, CacheCollection, Sec
 		return getActive();
 	}
 
-	//
-	// /**
-	// * Mark the transaction as succeeded. The autoclosable will invoke a commit when completing.
-	// */
-	// void success();
-	//
-	// /**
-	// * Mark the transaction as failed. The autoclosable will invoke a rollback when completing.
-	// */
-	// void failure();
-	//
-	//
-	// /**
-	// * Invoke rollback or commit when closing the autoclosable. By default a rollback will be invoked.
-	// */
-	// @Override
-	// void close();
-
 	/**
 	 * Return the latest branch of the project.
 	 *

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction.java
@@ -1,0 +1,10 @@
+package com.gentics.mesh.core.db;
+
+import com.gentics.mesh.event.EventQueueBatch;
+
+@FunctionalInterface
+public interface TxEventAction<T> {
+
+	T handle(EventQueueBatch batch, Tx tx) throws Exception;
+
+}

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction.java
@@ -3,8 +3,18 @@ package com.gentics.mesh.core.db;
 import com.gentics.mesh.event.EventQueueBatch;
 
 @FunctionalInterface
+/**
+ * like {@link java.util.function.BiFunction<EventQueueBatch, Tx, T>}, but it can throw checked exceptions
+ */
 public interface TxEventAction<T> {
 
+	/**
+	 * Applies the function to the given arguments
+	 * @param batch
+	 * @param tx
+	 * @return the function result
+	 * @throws Exception
+	 */
 	T handle(EventQueueBatch batch, Tx tx) throws Exception;
 
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction0.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction0.java
@@ -1,0 +1,10 @@
+package com.gentics.mesh.core.db;
+
+import com.gentics.mesh.event.EventQueueBatch;
+
+@FunctionalInterface
+public interface TxEventAction0 {
+
+	void handle(EventQueueBatch batch, Tx tx) throws Exception;
+
+}

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction0.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/TxEventAction0.java
@@ -2,9 +2,18 @@ package com.gentics.mesh.core.db;
 
 import com.gentics.mesh.event.EventQueueBatch;
 
+/**
+ * like {@link java.util.function.BiConsumer<EventQueueBatch, Tx>}, but it can throw checked exceptions
+ */
 @FunctionalInterface
 public interface TxEventAction0 {
 
+	/**
+	 * Applies the function to the given arguments
+	 * @param batch
+	 * @param tx
+	 * @throws Exception
+	 */
 	void handle(EventQueueBatch batch, Tx tx) throws Exception;
 
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
@@ -607,7 +607,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			throw error(BAD_REQUEST, "node_move_error_same_nodes");
 		}
 
-		sourceNode.setParentNode(branchUuid, targetNode);
+		setParentNode(sourceNode, branchUuid, targetNode);
 
 		// Update published graph field containers
 		contentDao.getFieldContainers(sourceNode, branchUuid, PUBLISHED).stream().forEach(container -> {

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
@@ -1777,13 +1777,13 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 						ContainerType type = edge.getType();
 						// Only handle published or draft contents
 						if (type.equals(DRAFT) || type.equals(PUBLISHED)) {
-							HibNode parent = edge.getNode();
-							String uuid = node.getUuid();
+							HibNode referencingNode = edge.getNode();
+							String uuid = referencingNode.getUuid();
 							String languageTag = nodeContainer.getLanguageTag();
 							String branchUuid = edge.getBranchUuid();
 							String key = uuid + languageTag + branchUuid + type.getCode();
 							if (!handledNodeUuids.contains(key)) {
-								bac.add(onReferenceUpdated(node, node.getUuid(), node.getSchemaContainer(), branchUuid, type, languageTag));
+								bac.add(onReferenceUpdated(referencingNode, referencingNode.getUuid(), referencingNode.getSchemaContainer(), branchUuid, type, languageTag));
 								handledNodeUuids.add(key);
 							}
 						}

--- a/mdm/common/src/main/java/com/gentics/mesh/core/jobs/VersionPurgeJobProcessor.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/jobs/VersionPurgeJobProcessor.java
@@ -46,8 +46,6 @@ public class VersionPurgeJobProcessor implements SingleJobProcessor {
 			return tx.<CommonTx>unwrap().data().mesh().projectVersionPurgeHandler();
 		});
 		HibProject project = db.tx(purgeJob::getProject);
-		String projectName = project.getName();
-		String projectUuid = project.getUuid();
 		Optional<ZonedDateTime> maxAge = db.tx(purgeJob::getMaxAge);
 		return handler.purgeVersions(project, maxAge.orElse(null))
 				.doOnComplete(() -> {
@@ -57,8 +55,8 @@ public class VersionPurgeJobProcessor implements SingleJobProcessor {
 						jobDao.mergeIntoPersisted(purgeJob);
 					});
 					db.tx(tx -> {
-						log.info("Version purge job {" + purgeJob.getUuid() + "} for project {" + projectName + "} completed.");
-						tx.createBatch().add(createEvent(PROJECT_VERSION_PURGE_FINISHED, COMPLETED, projectName, projectUuid))
+						log.info("Version purge job {" + purgeJob.getUuid() + "} for project {" + project.getName() + "} completed.");
+						tx.createBatch().add(createEvent(PROJECT_VERSION_PURGE_FINISHED, COMPLETED, project.getName(), project.getUuid()))
 								.dispatch();
 					});
 				}).doOnError(error -> {
@@ -69,8 +67,8 @@ public class VersionPurgeJobProcessor implements SingleJobProcessor {
 						jobDao.mergeIntoPersisted(purgeJob);
 					});
 					db.tx(tx -> {
-						log.info("Version purge job {" + purgeJob.getUuid() + "} for project {" + projectName + "} failed.", error);
-						tx.createBatch().add(createEvent(PROJECT_VERSION_PURGE_FINISHED, FAILED, projectName, projectUuid))
+						log.info("Version purge job {" + purgeJob.getUuid() + "} for project {" + project.getName() + "} failed.", error);
+						tx.createBatch().add(createEvent(PROJECT_VERSION_PURGE_FINISHED, FAILED, project.getName(), project.getUuid()))
 								.dispatch();
 					});
 				});

--- a/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
@@ -53,7 +53,9 @@ public class MigrationStatusHandlerImpl implements MigrationStatusHandler {
 			status = job.getStatus();
 		}
 		if (versionEdge != null) {
+			versionEdge = CommonTx.get().load(versionEdge.getId(), versionEdge.getClass());
 			versionEdge.setMigrationStatus(status);
+			CommonTx.get().persist(versionEdge, versionEdge.getClass());
 		}
 		job.setCompletionCount(completionCount);
 		job.setStatus(status);

--- a/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
@@ -55,12 +55,10 @@ public class MigrationStatusHandlerImpl implements MigrationStatusHandler {
 		if (versionEdge != null) {
 			versionEdge = CommonTx.get().load(versionEdge.getId(), versionEdge.getClass());
 			versionEdge.setMigrationStatus(status);
-			CommonTx.get().persist(versionEdge, versionEdge.getClass());
 		}
 		job.setCompletionCount(completionCount);
 		job.setStatus(status);
 
-		CommonTx.get().jobDao().mergeIntoPersisted(job);
 		Database db = CommonTx.get().data().mesh().database();
 		db.tx().commit();
 		return this;

--- a/mdm/common/src/main/java/com/gentics/mesh/core/verticle/handler/HandlerUtilities.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/verticle/handler/HandlerUtilities.java
@@ -416,20 +416,6 @@ public class HandlerUtilities {
 	}
 
 	/**
-	 * Invoke an event action.
-	 * 
-	 * @param function
-	 */
-	public void eventAction(Consumer<EventQueueBatch> function) {
-		EventQueueBatch b = database.tx(tx -> {
-			EventQueueBatch batch = queueProvider.get();
-			function.accept(batch);
-			return batch;
-		});
-		b.dispatch();
-	}
-
-	/**
 	 * Invoke an event action which returns a result.
 	 *
 	 * @param function

--- a/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/node/Node.java
+++ b/mdm/orientdb-api/src/main/java/com/gentics/mesh/core/data/node/Node.java
@@ -4,7 +4,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.CreatorTrackingVertex;
 import com.gentics.mesh.core.data.GraphFieldContainerEdge;
@@ -25,7 +24,6 @@ import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.node.NodeResponse;
 import com.gentics.mesh.core.result.Result;
 import com.gentics.mesh.parameter.PagingParameters;
-import com.gentics.mesh.path.Path;
 
 /**
  * The Node Domain Model interface.
@@ -203,4 +201,12 @@ public interface Node extends MeshCoreVertex<NodeResponse>, CreatorTrackingVerte
 	 * @return
 	 */
 	long getFieldContainerCount();
+
+	/**
+	 * Set the parent node of this node.
+	 *
+	 * @param branchUuid
+	 * @param parentNode
+	 */
+	void setParentNode(String branchUuid, HibNode parentNode);
 }

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
@@ -55,6 +55,7 @@ import com.gentics.mesh.core.data.node.field.nesting.MicronodeGraphField;
 import com.gentics.mesh.core.data.node.field.nesting.NodeGraphField;
 import com.gentics.mesh.core.data.node.impl.MicronodeImpl;
 import com.gentics.mesh.core.data.s3binary.S3HibBinary;
+import com.gentics.mesh.core.data.schema.HibFieldSchemaVersionElement;
 import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
 import com.gentics.mesh.core.rest.error.GenericRestException;
 import com.gentics.mesh.core.rest.node.FieldMap;
@@ -78,7 +79,7 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 	@Override
 	public void removeField(HibField field) {
 		if (field != null) {
-			toGraph(getField(field.getFieldKey())).removeField(new DummyBulkActionContext(), this);
+			toGraph(field).removeField(new DummyBulkActionContext(), this);
 		}
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractSchemaChange.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractSchemaChange.java
@@ -99,21 +99,6 @@ public abstract class AbstractSchemaChange<T extends FieldSchemaContainer> exten
 	}
 
 	@Override
-	public JsonObject getIndexOptions() {
-		Object obj = getRestProperty(ELASTICSEARCH_KEY);
-		if (obj != null) {
-			if (obj instanceof String) {
-				return new JsonObject((String) obj);
-			} else if (obj instanceof JsonObject) {
-				return (JsonObject) obj;
-			} else {
-				throw error(INTERNAL_SERVER_ERROR, "Type was not expected {" + obj.getClass().getName() + "}");
-			}
-		}
-		return null;
-	}
-
-	@Override
 	public void setIndexOptions(JsonObject options) {
 		setRestProperty(ELASTICSEARCH_KEY, options.encode());
 	}

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateSchemaChangeImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/UpdateSchemaChangeImpl.java
@@ -139,16 +139,6 @@ public class UpdateSchemaChangeImpl extends AbstractFieldSchemaContainerUpdateCh
 	}
 
 	@Override
-	public List<String> getURLFields() {
-		Object[] value = getRestProperty(URLFIELDS_KEY);
-		if (value == null) {
-			return null;
-		}
-		String[] stringArray = Arrays.copyOf(value, value.length, String[].class);
-		return Arrays.asList(stringArray);
-	}
-
-	@Override
 	public void setURLFields(String... keys) {
 		setRestProperty(URLFIELDS_KEY, keys);
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -10,7 +10,6 @@ import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.ElasticsearchTestMode.TRACKING;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -178,6 +177,8 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		triggerAndWaitForAllJobs(COMPLETED);
 
 		try (Tx tx = tx()) {
+			assignment1 = CommonTx.get().load(assignment1.getId(), assignment1.getClass());
+			assignment2 = CommonTx.get().load(assignment2.getId(), assignment2.getClass());
 			assertNotNull(assignment2.getJobUuid());
 			assertEquals(COMPLETED, assignment2.getMigrationStatus());
 			assertTrue("The assignment should be active.", assignment2.isActive());
@@ -247,6 +248,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		waitForSearchIdleEvent();
 
 		try (Tx tx = tx()) {
+			edge3 = CommonTx.get().load(edge3.getId(), edge3.getClass());
 			PersistingSchemaDao schemaDao = tx.<CommonTx>unwrap().schemaDao();
 			assertNotNull(edge3.getJobUuid());
 			assertEquals(COMPLETED, edge3.getMigrationStatus());
@@ -1340,6 +1342,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		// Link everything together
 		container.setLatestVersion(versionB);
 		versionA.setNextVersion(versionB);
+		versionB.setPreviousVersion(versionA);
 		schemaDao.mergeIntoPersisted(container);
 		return container;
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
@@ -31,7 +31,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaTest.java
@@ -186,10 +186,11 @@ public class SchemaTest extends AbstractMeshTest implements BasicObjectTestcases
 			BulkActionContext context = createBulkContext();
 			String uuid = getSchemaContainer().getUuid();
 			NodeDao nodeDao = tx.nodeDao();
-			for (HibNode node : schemaDao.getNodes(getSchemaContainer())) {
+			HibSchema schema = tx.schemaDao().findByUuid(uuid);
+			for (HibNode node : schemaDao.getNodes(schema)) {
 				nodeDao.delete(node, context, false, true);
 			}
-			schemaDao.delete(getSchemaContainer(), context);
+			schemaDao.delete(schema, context);
 			assertNull("The schema should have been deleted", tx.schemaDao().findByUuid(uuid));
 		}
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/AbstractFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/AbstractFieldMigrationTest.java
@@ -151,6 +151,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		change.setPreviousContainerVersion(versionA);
 		change.setNextSchemaContainerVersion(versionB);
 		versionA.setNextVersion(versionB);
+		versionA.setNextChange(change);
 
 		// create a node based on the old schema
 		EventQueueBatch batch = createBatch();
@@ -534,6 +535,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		change.setPreviousContainerVersion(versionA);
 		change.setNextSchemaContainerVersion(versionB);
 		versionA.setNextVersion(versionB);
+		versionA.setNextChange(change);
 
 		// create a node based on the old schema
 		EventQueueBatch batch = createBatch();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/BooleanFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/BooleanFieldMigrationTest.java
@@ -266,12 +266,12 @@ public class BooleanFieldMigrationTest extends AbstractFieldMigrationTest implem
 	public void testChangeToNumber() throws Exception {
 		changeType(CREATEBOOLEAN, FILLTRUE, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(1);
+			assertThat(container.getNumber(name).getNumber().intValue()).as(NEWFIELDVALUE).isEqualTo(1);
 		});
 
 		changeType(CREATEBOOLEAN, FILLFALSE, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(0);
+			assertThat(container.getNumber(name).getNumber().intValue()).as(NEWFIELDVALUE).isEqualTo(0);
 		});
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/DateFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/DateFieldMigrationTest.java
@@ -219,7 +219,7 @@ public class DateFieldMigrationTest extends AbstractFieldMigrationTest implement
 	public void testChangeToNumber() throws Exception {
 		changeType(CREATEDATE, FILL, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(DATEVALUE);
+			assertThat(container.getNumber(name).getNumber().longValue()).as(NEWFIELDVALUE).isEqualTo(DATEVALUE);
 		});
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/HtmlFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/HtmlFieldMigrationTest.java
@@ -287,12 +287,12 @@ public class HtmlFieldMigrationTest extends AbstractFieldMigrationTest implement
 	public void testChangeToNumber() throws Exception {
 		changeType(CREATEHTML, FILL0, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(0L);
+			assertThat(container.getNumber(name).getNumber().longValue()).as(NEWFIELDVALUE).isEqualTo(0L);
 		});
 
 		changeType(CREATEHTML, FILL1, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(1L);
+			assertThat(container.getNumber(name).getNumber().longValue()).as(NEWFIELDVALUE).isEqualTo(1L);
 		});
 
 		changeType(CREATEHTML, FILLTEXT, FETCH, CREATENUMBER, (container, name) -> {
@@ -374,7 +374,7 @@ public class HtmlFieldMigrationTest extends AbstractFieldMigrationTest implement
 			name -> FieldUtil.createHtmlFieldSchema(name).setElasticsearch(IndexOptionHelper.getRawFieldOption()),
 			(container, name) -> {
 				HibHtmlField htmlField = container.getHtml(name);
-				assertEquals("The html field should not be truncted.", 40_000, htmlField.getHTML().length());
+				assertEquals("The html field should not be truncated.", 40_000, htmlField.getHTML().length());
 				waitForSearchIdleEvent();
 				assertThat(trackingSearchProvider()).recordedStoreEvents(1);
 			});

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/NumberFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/NumberFieldMigrationTest.java
@@ -239,7 +239,7 @@ public class NumberFieldMigrationTest extends AbstractFieldMigrationTest impleme
 	public void testChangeToNumber() throws Exception {
 		changeType(CREATENUMBER, FILL, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(NUMBERVALUE);
+			assertThat(container.getNumber(name).getNumber().intValue()).as(NEWFIELDVALUE).isEqualTo(NUMBERVALUE);
 		});
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/StringFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/StringFieldMigrationTest.java
@@ -285,12 +285,12 @@ public class StringFieldMigrationTest extends AbstractFieldMigrationTest impleme
 	public void testChangeToNumber() throws Exception {
 		changeType(CREATESTRING, FILL0, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(0L);
+			assertThat(container.getNumber(name).getNumber().longValue()).as(NEWFIELDVALUE).isEqualTo(0L);
 		});
 
 		changeType(CREATESTRING, FILL1, FETCH, CREATENUMBER, (container, name) -> {
 			assertThat(container.getNumber(name)).as(NEWFIELD).isNotNull();
-			assertThat(container.getNumber(name).getNumber()).as(NEWFIELDVALUE).isEqualTo(1L);
+			assertThat(container.getNumber(name).getNumber().longValue()).as(NEWFIELDVALUE).isEqualTo(1L);
 		});
 
 		changeType(CREATESTRING, FILLTEXT, FETCH, CREATENUMBER, (container, name) -> {


### PR DESCRIPTION
## Abstract
This merge requests contain the following changes:

* rework crud handlers to only run within a single "mesh transaction". This is because mdm transaction implementation doesn't handle "nested transactions" commit, so we had a few instances in which an event was sent and the consumer was reading stale data (since the parent transaction was not committed already)
* rework schema migration to set the new schema version immediately (also needed for mdm)
* bug fixes (mostly about tests which are not behaving well in mdm)

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
