### PR TITLE
Fix micronode migration of published nodes

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,10 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] Security: The 'spring-security', 'jsoup', 'commons-io', 'guava', 'jackson-databind'  libraries have been updated.
 
+icon:check[] Core: When changing a microschema, the following migration of nodes containing micronodes of the microschema would incorrectly generate the
+new published version from the old draft version, instead of the old published version.
+This has been fixed now.
+
 [[v1.6.24]]
 == 1.6.24 (01.12.2021)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/migration/micronode/MicronodeMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/migration/micronode/MicronodeMigrationHandler.java
@@ -205,7 +205,7 @@ public class MicronodeMigrationHandler extends AbstractMigrationHandler {
 				VersionNumber nextDraftVersion = null;
 				// 1. Check whether there is any other published container which we need to handle separately
 				if (oldPublished != null && !oldPublished.equals(container)) {
-					nextDraftVersion = migratePublishedContainer(ac, batch, branch, node, container, fromVersion, toVersion, touchedFields);
+					nextDraftVersion = migratePublishedContainer(ac, batch, branch, node, oldPublished, fromVersion, toVersion, touchedFields);
 					nextDraftVersion = nextDraftVersion.nextDraft();
 				}
 


### PR DESCRIPTION
## Abstract

Micronode migrations of nodes, which have different published and draft versions should migrate the old published into the new published, and the old draft into the new draft version.
Before this fix, the new published version was based on the old draft version instead.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
