### PR TITLE
add possibility to deploy maven artifact

### DIFF
--- a/Jenkinsfile.split
+++ b/Jenkinsfile.split
@@ -17,7 +17,8 @@ properties([
 		booleanParam(name: 'runDeploy',           defaultValue: false, description: "Whether to run the deploy steps."),
 		booleanParam(name: 'runDocker',           defaultValue: false, description: "Whether to run the docker steps."),
 		booleanParam(name: 'runMavenBuild',       defaultValue: false, description: "Whether to run the maven build steps."),
-		booleanParam(name: 'runIntegrationTests', defaultValue: false, description: "Whether to run integration tests.")
+		booleanParam(name: 'runIntegrationTests', defaultValue: false, description: "Whether to run integration tests."),
+		booleanParam(name: 'runMavenDeploy',      defaultValue: false, description: "Whether to deploy the maven artifact during the maven build step.")
 	])
 ])
 
@@ -143,7 +144,7 @@ stage("Setup Build Environment") {
 			stage("Maven Build") {
 				if (Boolean.valueOf(params.runMavenBuild)) {
 					sshagent(["git"]) {
-						if (Boolean.valueOf(params.runDeploy)) {
+						if (Boolean.valueOf(params.runDeploy) || Boolean.valueOf(params.runMavenDeploy)) {
 							echo "Setup of GPG"
 							sh "gpg --no-tty --batch --import /mnt/credentials/gpg/gpg-public-key.asc"
 							sh "gpg --no-tty --batch --import /mnt/credentials/gpg/gpg-secret-key.asc"


### PR DESCRIPTION
## Abstract
Currently it's not possible to deploy a maven artifact without other causing other side effects (additional commits, updated pom versions, etc.). However, in the context of mdm, it's useful to be able to deploy snapshots artifacts

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
