### PR TITLE
Fix permission check for creating user with admin set to false.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -24,6 +24,10 @@ icon:check[] Clustering: When starting an instance of Gentics Mesh with the comm
 `admin` user, starting would fail if the write quorum of OrientDB was not reached. The startup behaviour has been changed now, so that resetting the
 password is delayed until the write quorum is reached.
 
+icon:check[] Rest: When creating a new user and setting the admin flag to `false`, this failed if the request user did not have the admin flag set
+to `true`. The permission check has been fixed now, so that the admin flag is only required for the requesting user, if the new user should also
+have the admin flag set to `true`.
+
 [[v1.6.26]]
 == 1.6.26 (23.03.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/root/impl/UserRootImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/root/impl/UserRootImpl.java
@@ -161,7 +161,7 @@ public class UserRootImpl extends AbstractRootVertex<User> implements UserRoot {
 		}
 
 		Boolean adminFlag = requestModel.getAdmin();
-		if (adminFlag != null) {
+		if (adminFlag != null && adminFlag.booleanValue()) {
 			if (requestUser.isAdmin()) {
 				user.setAdmin(adminFlag);
 			} else {

--- a/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -447,6 +447,29 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 	}
 
 	@Test
+	public void testCreateAdminUserAsNonAdmin() {
+		UserCreateRequest createRequest = new UserCreateRequest();
+		createRequest.setUsername("test1234");
+		createRequest.setAdmin(true);
+		createRequest.setPassword("finger");
+
+		runAsNonAdmin(() -> {
+			return call(() -> client().createUser(createRequest), FORBIDDEN, "user_error_admin_privilege_needed_for_admin_flag");
+		});
+	}
+
+	@Test
+	public void testCreateNonAdminUserAsNonAdmin() {
+		UserCreateRequest createRequest = new UserCreateRequest();
+		createRequest.setUsername("test1234");
+		createRequest.setAdmin(false);
+		createRequest.setPassword("finger");
+
+		UserResponse response = nonAdminCall(() -> client().createUser(createRequest));
+		assertThat(response).isNotAdmin();
+	}
+
+	@Test
 	@Override
 	public void testReadMultiple() throws Exception {
 		final int intialUserCount = users().size();

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/ClientHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/ClientHelper.java
@@ -155,4 +155,10 @@ public interface ClientHelper extends EventHelper {
 		});
 	}
 
+	default <T> T nonAdminCall(ClientHandler<T> handler) {
+		return runAsNonAdmin(() -> {
+			return com.gentics.mesh.test.ClientHelper.call(handler);
+		});
+	}
+
 }

--- a/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/helper/EventHelper.java
@@ -258,6 +258,44 @@ public interface EventHelper extends BaseHelper {
 	}
 
 	/**
+	 * Run the given action without admin permissions enabled.
+	 * 
+	 * @param action
+	 * @return result
+	 * @throws Exception
+	 */
+	default <T> T runAsNonAdmin(Supplier<T> action) {
+		boolean isAdmin = tx(() -> user().isAdmin());
+		// Revoke perms to check the job
+		if (isAdmin) {
+			revokeAdmin();
+		}
+		T t = action.get();
+		if (isAdmin) {
+			grantAdmin();
+		}
+		return t;
+	}
+
+	/**
+	 * Run the given action without admin permissions enabled.
+	 * 
+	 * @param action
+	 * @throws Exception
+	 */
+	default void runAsNonAdmin(Runnable action) {
+		boolean isAdmin = tx(() -> user().isAdmin());
+		// Revoke perms to check the job
+		if (isAdmin) {
+			revokeAdmin();
+		}
+		action.run();
+		if (isAdmin) {
+			grantAdmin();
+		}
+	}
+
+	/**
 	 * Execute the action and check that the jobs are executed and yields the given status.
 	 *
 	 * @param action


### PR DESCRIPTION
## Abstract

Creation of a new user should only fail for "non-admin" users, if setting the admin flag to "true", but not when setting it to "false".

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
