### PR TITLE
Add max form attribute setting (default: unlimited)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,11 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.8.2]]
+== 1.8.2 (29.03.2022)
+
+icon:check[] Core: The max form attribute size can now be configured and is set to unlimited by default. This limit became relevant for multipart requests after the update to Vert.x 3.9.12.
+
 [[v1.8.1]]
 == 1.8.1 (24.03.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/HttpServerConfig.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/HttpServerConfig.java
@@ -38,6 +38,7 @@ public class HttpServerConfig implements Option {
 	public static final String DEFAULT_KEY_PATH = "config/key.pem";
 	public static final ClientAuth DEFAULT_CLIENT_AUTH_MODE = ClientAuth.NONE;
 	public static final boolean DEFAULT_SERVER_TOKENS = true;
+	public static final int DEFAULT_MAX_FORM_ATTRIBUTE_SIZE = -1;
 
 	public static final String MESH_HTTP_PORT_ENV = "MESH_HTTP_PORT";
 	public static final String MESH_HTTPS_PORT_ENV = "MESH_HTTPS_PORT";
@@ -54,6 +55,7 @@ public class HttpServerConfig implements Option {
 	public static final String MESH_HTTP_SSL_TRUSTED_CERTS_ENV = "MESH_HTTP_SSL_TRUSTED_CERTS";
 	public static final String MESH_HTTP_CORS_ALLOW_CREDENTIALS_ENV = "MESH_HTTP_CORS_ALLOW_CREDENTIALS";
 	public static final String MESH_HTTP_SERVER_TOKENS_ENV = "MESH_HTTP_SERVER_TOKENS";
+	public static final String MESH_HTTP_SERVER_MAX_FORM_ATTRIBUTE_SIZE_ENV = "MESH_HTTP_SERVER_MAX_FORM_ATTRIBUTE_SIZE";
 
 	public static final int DEFAULT_VERTICLE_AMOUNT = 2 * Runtime.getRuntime().availableProcessors();
 
@@ -126,6 +128,11 @@ public class HttpServerConfig implements Option {
 	@JsonPropertyDescription("Set the http server tokens flag which controls whether the server should expose version information via headers, REST endpoints and GraphQL. Default is true")
 	@EnvironmentVariable(name = MESH_HTTP_SERVER_TOKENS_ENV, description = "Override the http server tokens flag.")
 	private boolean serverTokens = DEFAULT_SERVER_TOKENS;
+
+	@JsonProperty(defaultValue = "" + DEFAULT_MAX_FORM_ATTRIBUTE_SIZE)
+	@JsonPropertyDescription("Set the maximum size of a form attribute, set to -1 for unlimited.")
+	@EnvironmentVariable(name = MESH_HTTP_SERVER_MAX_FORM_ATTRIBUTE_SIZE_ENV, description = "Override the max form attribute size")
+	private int maxFormAttributeSize;
 
 	public HttpServerConfig() {
 	}
@@ -272,6 +279,16 @@ public class HttpServerConfig implements Option {
 	@Setter
 	public HttpServerConfig setServerTokens(boolean flag) {
 		this.serverTokens = flag;
+		return this;
+	}
+
+	public int getMaxFormAttributeSize() {
+		return maxFormAttributeSize;
+	}
+
+	@Setter
+	public HttpServerConfig setMaxFormAttributeSize(int maxFormAttributeSize) {
+		this.maxFormAttributeSize = maxFormAttributeSize;
 		return this;
 	}
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/HttpServerConfig.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/HttpServerConfig.java
@@ -132,7 +132,7 @@ public class HttpServerConfig implements Option {
 	@JsonProperty(defaultValue = "" + DEFAULT_MAX_FORM_ATTRIBUTE_SIZE)
 	@JsonPropertyDescription("Set the maximum size of a form attribute, set to -1 for unlimited.")
 	@EnvironmentVariable(name = MESH_HTTP_SERVER_MAX_FORM_ATTRIBUTE_SIZE_ENV, description = "Override the max form attribute size")
-	private int maxFormAttributeSize;
+	private int maxFormAttributeSize = DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
 
 	public HttpServerConfig() {
 	}

--- a/core/src/main/java/com/gentics/mesh/rest/RestAPIVerticle.java
+++ b/core/src/main/java/com/gentics/mesh/rest/RestAPIVerticle.java
@@ -174,7 +174,7 @@ public class RestAPIVerticle extends AbstractVerticle {
 			if (log.isDebugEnabled()) {
 				log.debug("Setting http server options..");
 			}
-			applyCommonSettings(httpOptions);
+			applyCommonSettings(httpOptions, meshServerOptions);
 			httpOptions.setPort(meshServerOptions.getPort());
 			httpOptions.setSsl(false);
 
@@ -187,7 +187,7 @@ public class RestAPIVerticle extends AbstractVerticle {
 			if (log.isDebugEnabled()) {
 				log.debug("Setting ssl server options..");
 			}
-			applyCommonSettings(httpsOptions);
+			applyCommonSettings(httpsOptions, meshServerOptions);
 			httpsOptions.setPort(meshServerOptions.getSslPort());
 			httpsOptions.setSsl(true);
 			PemKeyCertOptions keyOptions = new PemKeyCertOptions();
@@ -241,7 +241,7 @@ public class RestAPIVerticle extends AbstractVerticle {
 
 	}
 
-	private void applyCommonSettings(HttpServerOptions options) {
+	private void applyCommonSettings(HttpServerOptions options, HttpServerConfig serverConfig) {
 		String host = config().getString("host");
 		options.setHost(host);
 		options.setCompressionSupported(true);
@@ -252,6 +252,8 @@ public class RestAPIVerticle extends AbstractVerticle {
 		options.setTcpFastOpen(true)
 			.setTcpNoDelay(true)
 			.setTcpQuickAck(true);
+
+		options.setMaxFormAttributeSize(serverConfig.getMaxFormAttributeSize());
 	}
 
 	@Override
@@ -267,7 +269,7 @@ public class RestAPIVerticle extends AbstractVerticle {
 
 	/**
 	 * Register the API endpoints and bind them to the given router.
-	 * 
+	 *
 	 * @param storage
 	 * @throws Exception
 	 */


### PR DESCRIPTION
## Abstract

With the update to Vert.x 3.9.12 came a change that sets a size limit on the parts of a multipart requests, which causes trouble for Mesh plugins which accept multipart form requests.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
