### PR TITLE
Allow root filesystem access for the static handler, if necessary

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,10 @@ include::content/docs/variables.adoc-include[]
 
 icon:check[] Core: The included Mesh UI has been updated to version `1.3.3`.
 
+icon:check[] Plugins: Creating a static handler for files in the plugin's classpath using the new method RestPlugin::addStaticHandlerFromClasspath did not
+work, if the plugin directory was configured with an absolute path. Plugin initialization would fail, because the static handler could not be created.
+This has been fixed by allowing root filesystem access to the static handler, if the plugin directory is configured with an absolute path.
+
 [[v1.8.2]]
 == 1.8.2 (29.03.2022)
 

--- a/plugin-api/src/main/java/com/gentics/mesh/plugin/RestPlugin.java
+++ b/plugin-api/src/main/java/com/gentics/mesh/plugin/RestPlugin.java
@@ -97,7 +97,18 @@ public interface RestPlugin extends MeshPlugin {
 		long handlerCreationTime = System.currentTimeMillis();
 
 		// create and prepare (configure) the static handler to handle files from storage/[base]
-		StaticHandler staticHandler = StaticHandler.create(new File(getStorageDir(), base).getPath());
+		String webRoot = new File(getStorageDir(), base).getPath();
+
+		// if the storage directory is absolute, we need to allow root filesystem access for the static handler
+		boolean allowRootAccess = false;
+		for (File root : File.listRoots()) {
+			if (webRoot.startsWith(root.getAbsolutePath())) {
+				allowRootAccess = true;
+				break;
+			}
+		}
+		StaticHandler staticHandler = StaticHandler.create().setAllowRootFileSystemAccess(allowRootAccess)
+				.setWebRoot(webRoot);
 		if (prepareStaticHandler != null) {
 			prepareStaticHandler.handle(staticHandler);
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/admin/AdminPluginEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/admin/AdminPluginEndpointTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
@@ -216,6 +217,25 @@ public class AdminPluginEndpointTest extends AbstractPluginTest {
 		assertThat(httpGet(CURRENT_API_BASE_PATH + "/plugins/static/static/removed.txt").execute().code())
 			.as("Response code for removed.txt").isEqualTo(404);
 		assertEquals("added", httpGetNow(CURRENT_API_BASE_PATH + "/plugins/static/static/added.txt"));
+	}
+
+	/**
+	 * Test static file delivery, when the plugin directory is configured with an absolute path.
+	 * @throws IOException
+	 * @throws TimeoutException
+	 */
+	@Test
+	public void testStaticHandlerAbsolutePluginDir() throws IOException, TimeoutException {
+		grantAdmin();
+
+		// make the configured plugin dir absolute
+		File pluginDir = new File(pluginDir());
+		setPluginBaseDir(pluginDir.getAbsolutePath());
+
+		try (ExpectedEvent ee = expectEvent(MeshEvent.PLUGIN_REGISTERED, 10_000)) {
+			copyAndDeploy(STATIC_PATH, "plugin.jar");
+		}
+		assertEquals("before change", httpGetNow(CURRENT_API_BASE_PATH + "/plugins/static/static/changed.txt"));
 	}
 
 	@Test


### PR DESCRIPTION
## Abstract

Vert.x's StaticHandler will fail to be created with an absolute path, if root filesystem access is not allowed.
Because the StaticHandler for serving files from the plugin's classpath will use the configured plugin directory as base,
the flag to allow root filesystem access will be set, if the plugin directory is absolute.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
