### PR TITLE
Fix clearing the project name cache when a project is renamed.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -28,6 +28,12 @@ icon:check[] Rest: When creating a new user and setting the admin flag to `false
 to `true`. The permission check has been fixed now, so that the admin flag is only required for the requesting user, if the new user should also
 have the admin flag set to `true`.
 
+icon:check[] Core: When a project was renamed, deleted and then recreated with the same name, an internal cache was not cleared and caused
+subsequent errors in calls to the project, until the Mesh instance was restarted.
+This has been fixed now. The internal caches will be properly cleared.
+
+icon:plus[] Rest: The new endpoint `DELETE /api/v1/admin/cache` will clear all internal caches (cluster wide).
+
 [[v1.6.26]]
 == 1.6.26 (23.03.2022)
 

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -322,3 +322,5 @@ webroot_error_prefix_invalid=Der Pfad {0} beginnt nicht mit dem erforderlichem P
 
 cluster_coordination_master_set=Der neue Master Server wurde eingestellt.
 cluster_coordination_master_set_error_not_electable=Der node "{0}" kann nicht zum master werden.
+
+cache_clear_invoked=Das Leeren der Caches wurde gestartet.

--- a/common/src/main/resources/i18n/translations_en.properties
+++ b/common/src/main/resources/i18n/translations_en.properties
@@ -320,3 +320,5 @@ webroot_error_prefix_invalid=The request path {0} did not start with the require
 
 cluster_coordination_master_set=The coordination master has been set.
 cluster_coordination_master_set_error_not_electable=The node "{0}" is not electable.
+
+cache_clear_invoked=Clearing the caches has been invoked.

--- a/core/src/main/java/com/gentics/mesh/cache/ProjectNameCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/ProjectNameCacheImpl.java
@@ -32,12 +32,7 @@ public class ProjectNameCacheImpl extends AbstractMeshCache<String, Project> imp
 		return factory.<String, Project>builder()
 			.events(EVENTS)
 			.action((event, cache) -> {
-				String name = event.body().getString("name");
-				if (name != null) {
-					cache.invalidate(name);
-				} else {
-					cache.invalidate();
-				}
+				cache.invalidate();
 			})
 			.name("projectname")
 			.maxSize(CACHE_SIZE)

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminEndpoint.java
@@ -106,6 +106,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		addRuntimeConfigHandler();
 		addShutdownHandler();
 		addCoordinatorHandler();
+		addCacheHandler();
 	}
 
 	private void addSecurityLogger() {
@@ -456,4 +457,17 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		updateConfig.handler(rc -> adminHandler.handleUpdateCoordinationConfig(wrap(rc)));
 	}
 
+	private void addCacheHandler() {
+		InternalEndpointRoute endpoint = createRoute();
+		endpoint.path("/cache");
+		endpoint.method(DELETE);
+		endpoint.setMutating(false);
+		endpoint.description(
+			"Clear all internal caches (cluster wide).");
+		endpoint.produces(APPLICATION_JSON);
+		endpoint.exampleResponse(OK, miscExamples.createMessageResponse(), "Clearing the caches has been invoked.");
+		endpoint.handler(rc -> {
+			adminHandler.handleCacheClear(wrap(rc));
+		});
+	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminHandler.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.core.endpoint.admin;
 
+import static com.gentics.mesh.core.rest.MeshEvent.CLEAR_CACHES;
 import static com.gentics.mesh.core.rest.MeshEvent.GRAPH_BACKUP_FINISHED;
 import static com.gentics.mesh.core.rest.MeshEvent.GRAPH_BACKUP_START;
 import static com.gentics.mesh.core.rest.MeshEvent.GRAPH_EXPORT_FINISHED;
@@ -29,6 +30,7 @@ import javax.naming.InvalidNameException;
 
 import com.gentics.mesh.Mesh;
 import com.gentics.mesh.MeshStatus;
+import com.gentics.mesh.cache.CacheRegistry;
 import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.Project;
@@ -91,10 +93,12 @@ public class AdminHandler extends AbstractHandler {
 
 	private final ConsistencyCheckHandler consistencyCheckHandler;
 
+	private final CacheRegistry cacheRegistry;
+
 	@Inject
 	public AdminHandler(Vertx vertx, Database db, RouterStorage routerStorage, BootstrapInitializer boot, SearchProvider searchProvider,
 		HandlerUtilities utils,
-		MeshOptions options, RouterStorageRegistry routerStorageRegistry, Coordinator coordinator, WriteLock writeLock, ConsistencyCheckHandler consistencyCheckHandler) {
+		MeshOptions options, RouterStorageRegistry routerStorageRegistry, Coordinator coordinator, WriteLock writeLock, ConsistencyCheckHandler consistencyCheckHandler, CacheRegistry cacheRegistry) {
 		this.vertx = vertx;
 		this.db = db;
 		this.routerStorage = routerStorage;
@@ -106,6 +110,7 @@ public class AdminHandler extends AbstractHandler {
 		this.coordinator = coordinator;
 		this.writeLock = writeLock;
 		this.consistencyCheckHandler = consistencyCheckHandler;
+		this.cacheRegistry = cacheRegistry;
 	}
 
 	public void handleMeshStatus(InternalActionContext ac) {
@@ -409,5 +414,23 @@ public class AdminHandler extends AbstractHandler {
 				return coordinator.loadConfig();
 			}, model -> ac.send(model, OK));
 		}
+	}
+
+	/**
+	 * Clear all internal caches locally and trigger an event to clear the caches cluster wide.
+	 * @param ac
+	 */
+	public void handleCacheClear(InternalActionContext ac) {
+		utils.syncTx(ac, tx -> {
+			User user = ac.getUser();
+			if (user != null && !user.isAdmin()) {
+				throw error(FORBIDDEN, "error_admin_permission_required");
+			}
+
+			cacheRegistry.clear();
+			vertx.eventBus().publish(CLEAR_CACHES.address, null);
+
+			return message(ac, "cache_clear_invoked");
+		}, model -> ac.send(model, OK));
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/rest/MeshLocalClientImpl.java
+++ b/core/src/main/java/com/gentics/mesh/rest/MeshLocalClientImpl.java
@@ -1842,4 +1842,9 @@ public class MeshLocalClientImpl implements MeshRestClient {
 	public MeshRequest<EmptyResponse> writable() {
 		return null;
 	}
+
+	@Override
+	public MeshRequest<GenericMessageResponse> clearCache() {
+		return null;
+	}
 }

--- a/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/admin/AdminEndpointTest.java
@@ -4,12 +4,17 @@ import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.TestSize.PROJECT;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
 
 import org.junit.Test;
 
 import com.gentics.mesh.MeshStatus;
+import com.gentics.mesh.core.data.i18n.I18NUtil;
 import com.gentics.mesh.core.rest.admin.status.MeshStatusResponse;
+import com.gentics.mesh.core.rest.common.GenericMessageResponse;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 import com.gentics.mesh.test.context.MeshTestSetting;
 
@@ -32,4 +37,24 @@ public class AdminEndpointTest extends AbstractMeshTest {
 		call(() -> client().clusterStatus(), BAD_REQUEST, "error_cluster_status_only_available_in_cluster_mode");
 	}
 
+	/**
+	 * Test clearing the internal caches
+	 */
+	@Test
+	public void testClearCache() {
+		// create project named "project"
+		createProject("project");
+
+		// get tag families of project (this will put project into cache)
+		call(() -> client().findTagFamilies("project"));
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(1);
+
+		call(() -> client().clearCache(), FORBIDDEN, "error_admin_permission_required");
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(1);
+		grantAdmin();
+
+		GenericMessageResponse response = call(() -> client().clearCache());
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(0);
+		assertThat(response.getMessage()).as("Response Message").isEqualTo(I18NUtil.get(Locale.ENGLISH, "cache_clear_invoked"));
+	}
 }

--- a/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
@@ -828,4 +828,37 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 		list = call(() -> client().findProjects());
 		assertThat(list.getData().stream().map(ProjectResponse::getName)).as("List of projects").containsOnly("dummy");
 	}
+
+	/**
+	 * Test renaming, deleting and re-creating a project (together with project name cache)
+	 */
+	@Test
+	public void testRenameDeleteCreateProject() {
+		// create project named "project"
+		ProjectResponse project = createProject("project");
+
+		// get tag families of project (this will put project into cache)
+		call(() -> client().findTagFamilies("project"));
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(1);
+
+		// rename project to "newproject"
+		project = updateProject(project.getUuid(), "newproject");
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(0);
+
+		// get tag families of newproject (this will put project into cache)
+		call(() -> client().findTagFamilies("newproject"));
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(1);
+
+		// delete "newproject"
+		deleteProject(project.getUuid());
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(0);
+
+		// create (again)
+		project = createProject("project");
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(0);
+
+		// get tag families of project
+		call(() -> client().findTagFamilies("project"));
+		assertThat(mesh().projectNameCache().size()).as("Project name cache size").isEqualTo(1);
+	}
 }

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestHttpClientImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestHttpClientImpl.java
@@ -1529,6 +1529,11 @@ public abstract class MeshRestHttpClientImpl extends AbstractMeshRestHttpClient 
 	}
 
 	@Override
+	public MeshRequest<GenericMessageResponse> clearCache() {
+		return prepareRequest(DELETE, "/admin/cache", GenericMessageResponse.class);
+	}
+
+	@Override
 	public MeshRequest<EmptyResponse> ready() {
 		return prepareRequest(GET, "/health/ready", EmptyResponse.class);
 	}

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/method/AdminClientMethods.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/method/AdminClientMethods.java
@@ -134,4 +134,10 @@ public interface AdminClientMethods {
 	 * @return
 	 */
 	MeshRequest<CoordinatorConfig> updateCoordinationConfig(CoordinatorConfig coordinatorConfig);
+
+	/**
+	 * Clear the caches (cluster wide)
+	 * @return
+	 */
+	MeshRequest<GenericMessageResponse> clearCache();
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/MeshEvent.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/MeshEvent.java
@@ -199,6 +199,13 @@ public enum MeshEvent {
 		null,
 		"Event which will clear the path stores."),
 
+	/**
+	 * Event which is sent to clear all internal caches
+	 */
+	CLEAR_CACHES("mesh.clear-caches",
+		null,
+		"Event which will clear the internal caches."),
+
 	/* User */
 
 	USER_CREATED("mesh.user.created",


### PR DESCRIPTION
Add REST Endpoint to clear all internal caches

## Abstract

The internal project name cache needs to be properly invalidated if the project is renamed.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
