### PR TITLE
Add periodic liveness check for vert.x eventBus.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,6 +26,10 @@ icon:check[] Rest: Many reading request were implemented in a way that they woul
 So would e.g. a long running graphql request cause webroot requests executed at the same time to be queued until the graphql request was done.
 The behaviour has been changed, so that reading requests will only be queued, if the worker pool has been exhausted.
 
+icon:check[] Core: A periodic check for the EventBus has been added, which can be configured via the configuration settings `vertxOptions.eventBus.checkInterval`,
+`vertxOptions.eventBus.warnThreshold` and `vertxOptions.eventBus.errorThreshold`. If enabled (which is the default), and the periodically sent ping event is not
+received within the given error threshold, the Mesh instance which be considered unhealthy (liveness check will fail).
+
 [[v1.6.27]]
 == 1.6.27 (07.04.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
@@ -517,6 +517,9 @@ public class MeshOptions implements Option {
 		if (getS3Options() != null) {
 			getS3Options().validate(this);
 		}
+		if (getVertxOptions() != null) {
+			getVertxOptions().validate(this);
+		}
 		Objects.requireNonNull(getNodeName(), "The node name must be specified.");
 		if (getVersionPurgeMaxBatchSize() <= 0) {
 			throw new IllegalArgumentException("versionPurgeMaxBatchSize must be positive.");

--- a/api/src/main/java/com/gentics/mesh/etc/config/VertxEventBusOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/VertxEventBusOptions.java
@@ -1,0 +1,90 @@
+package com.gentics.mesh.etc.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.gentics.mesh.doc.GenerateDocumentation;
+import com.gentics.mesh.etc.config.env.EnvironmentVariable;
+import com.gentics.mesh.etc.config.env.Option;
+
+/**
+ * Options for the vert.x eventbus
+ */
+@GenerateDocumentation
+public class VertxEventBusOptions implements Option {
+	public final static int DEFAULT_CHECK_INTERVAL = 30_000;
+
+	public final static int DEFAULT_WARN_THRESHOLD = 60_000;
+
+	public final static int DEFAULT_ERROR_THRESHOLD = 120_000;
+
+	public final static String MESH_VERTX_EVENT_BUS_CHECK_INTERVAL_ENV = "MESH_VERTX_EVENT_BUS_CHECK_INTERVAL";
+
+	public final static String MESH_VERTX_EVENT_BUS_WARN_THRESHOLD_ENV = "MESH_VERTX_EVENT_BUS_WARN_THRESHOLD";
+
+	public final static String MESH_VERTX_EVENT_BUS_ERROR_THRESHOLD_ENV = "MESH_VERTX_EVENT_BUS_ERROR_THRESHOLD";
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Configure the check interval for the Vert.x eventBus in ms. If set to a positive value, "
+			+ "Mesh will regularly send test events over the eventBus. Default is: " + DEFAULT_CHECK_INTERVAL + " ms.")
+	@EnvironmentVariable(name = MESH_VERTX_EVENT_BUS_CHECK_INTERVAL_ENV, description = "Override the Vert.x eventBus check interval in ms.")
+	private int checkInterval = DEFAULT_CHECK_INTERVAL;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Configure the warn threshold for the Vert.x eventBus check in ms. If this and the check interval are set to positive values, "
+			+ "and the last test events was received longer than the configured threshold ago, a warn message will be logged. Default is: "
+			+ DEFAULT_WARN_THRESHOLD + " ms.")
+	@EnvironmentVariable(name = MESH_VERTX_EVENT_BUS_WARN_THRESHOLD_ENV, description = "Override the Vert.x eventBus warn threshold in ms.")
+	private int warnThreshold = DEFAULT_WARN_THRESHOLD;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Configure the error threshold for the Vert.x eventBus check in ms. If this and the check interval are set to positive values, "
+			+ "and the last test events was received longer than the configured threshold ago, an error message will be logged, and the liveness of the instance will be set to false. Default is: "
+			+ DEFAULT_ERROR_THRESHOLD)
+	@EnvironmentVariable(name = MESH_VERTX_EVENT_BUS_ERROR_THRESHOLD_ENV, description = "Override the Vert.x eventBus error threshold in ms.")
+	private int errorThreshold = DEFAULT_ERROR_THRESHOLD;
+
+	public int getCheckInterval() {
+		return checkInterval;
+	}
+
+	public VertxEventBusOptions setCheckInterval(int checkInterval) {
+		this.checkInterval = checkInterval;
+		return this;
+	}
+
+	public int getWarnThreshold() {
+		return warnThreshold;
+	}
+
+	public VertxEventBusOptions setWarnThreshold(int warnThreshold) {
+		this.warnThreshold = warnThreshold;
+		return this;
+	}
+
+	public int getErrorThreshold() {
+		return errorThreshold;
+	}
+
+	public VertxEventBusOptions setErrorThreshold(int errorThreshold) {
+		this.errorThreshold = errorThreshold;
+		return this;
+	}
+
+	@Override
+	public void validate(MeshOptions options) {
+		if (checkInterval > 0) {
+			if (warnThreshold > 0 && warnThreshold < checkInterval) {
+				throw new IllegalArgumentException("vertxOptions.eventBus.warnThreshold (set to " + warnThreshold
+						+ ") must be greater than vertxOptions.eventBus.checkInterval (set to " + checkInterval + ")");
+			}
+			if (errorThreshold > 0 && errorThreshold < checkInterval) {
+				throw new IllegalArgumentException("vertxOptions.eventBus.errorThreshold (set to " + errorThreshold
+						+ ") must be greater than vertxOptions.eventBus.checkInterval (set to " + checkInterval + ")");
+			}
+			if (warnThreshold > 0 && errorThreshold > 0 && (errorThreshold <= warnThreshold)) {
+				throw new IllegalArgumentException("vertxOptions.eventBus.errorThreshold (set to " + errorThreshold
+						+ ") must be greater than vertxOptions.eventBus.warnThreshld (set to " + warnThreshold + ")");
+			}
+		}
+	}
+}

--- a/api/src/main/java/com/gentics/mesh/etc/config/VertxOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/VertxOptions.java
@@ -30,6 +30,10 @@ public class VertxOptions implements Option {
 	@EnvironmentVariable(name = MESH_VERTX_EVENT_POOL_SIZE_ENV, description = "Override the configured Vert.x event pool size.")
 	private int eventPoolSize = DEFAULT_EVENT_POOL_SIZE;
 
+	@JsonProperty("eventBus")
+	@JsonPropertyDescription("EventBus options")
+	private VertxEventBusOptions eventBusOptions = new VertxEventBusOptions();
+
 	public int getEventPoolSize() {
 		return eventPoolSize;
 	}
@@ -48,4 +52,22 @@ public class VertxOptions implements Option {
 		return this;
 	}
 
+	public VertxEventBusOptions getEventBusOptions() {
+		return eventBusOptions;
+	}
+
+	public VertxOptions setEventBusOptions(VertxEventBusOptions eventbusCheckOptions) {
+		this.eventBusOptions = eventbusCheckOptions;
+		if (this.eventBusOptions == null) {
+			this.eventBusOptions = new VertxEventBusOptions();
+		}
+		return this;
+	}
+
+	@Override
+	public void validate(MeshOptions options) {
+		if (getEventBusOptions() != null) {
+			getEventBusOptions().validate(options);
+		}
+	}
 }

--- a/common/src/main/java/com/gentics/mesh/event/EventBusLivenessManagerImpl.java
+++ b/common/src/main/java/com/gentics/mesh/event/EventBusLivenessManagerImpl.java
@@ -1,0 +1,174 @@
+package com.gentics.mesh.event;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.core.rest.admin.cluster.ClusterInstanceInfo;
+import com.gentics.mesh.core.rest.admin.cluster.ClusterStatusResponse;
+import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.graphdb.cluster.ClusterManager;
+import com.gentics.mesh.monitor.liveness.EventBusLivenessManager;
+import com.gentics.mesh.monitor.liveness.LivenessManager;
+
+import dagger.Lazy;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * Implementation of the {@link EventBusLivenessManager}, which will regularly publish events, which are consumed both
+ * locally and in the cluster to check, whether the eventBus works.
+ */
+@Singleton
+public final class EventBusLivenessManagerImpl implements EventBusLivenessManager {
+	/**
+	 * Name of the thread
+	 */
+	private static final String MESH_EVENTBUS_CHECKER_THREAD_NAME = "mesh-eventbus-checker";
+
+	/**
+	 * Logger
+	 */
+	private static Logger log = LoggerFactory.getLogger(EventBusLivenessManagerImpl.class);
+
+	/**
+	 * Timestamp of the last received ping
+	 */
+	private long lastPingTimestamp = -1;
+
+	/**
+	 * Map of timestamps for last received pings from cluster members
+	 */
+	private Map<String, Long> lastClusterPingTimestamps = Collections.synchronizedMap(new HashMap<>());
+
+	/**
+	 * Vert.x
+	 */
+	private final Lazy<Vertx> vertx;
+
+	/**
+	 * Liveness Manager
+	 */
+	private final LivenessManager livenessManager;
+
+	/**
+	 * Cluster Manager
+	 */
+	private final ClusterManager clusterManager;
+
+	/**
+	 * options
+	 */
+	private final MeshOptions options;
+
+	/**
+	 * Executor service for running the eventBus check
+	 */
+	private ScheduledExecutorService eventBusCheckerService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+		@Override
+		public Thread newThread(Runnable r) {
+			return new Thread(r, MESH_EVENTBUS_CHECKER_THREAD_NAME);
+		}
+	});
+
+	/**
+	 * Create the instance
+	 * @param vertx vertx
+	 * @param livenessManager liveness manager
+	 * @param clusterManager cluster manager
+	 * @param options options
+	 */
+	@Inject
+	public EventBusLivenessManagerImpl(Lazy<Vertx> vertx, LivenessManager livenessManager, ClusterManager clusterManager, MeshOptions options) {
+		this.vertx = vertx;
+		this.livenessManager = livenessManager;
+		this.clusterManager = clusterManager;
+		this.options = options;
+	}
+
+	@Override
+	public void startRegularChecks() {
+		int checkInterval = options.getVertxOptions().getEventBusOptions().getCheckInterval();
+		if (checkInterval <= 0) {
+			return;
+		}
+
+		EventBus eb = vertx.get().eventBus();
+		eb.localConsumer(MeshEvent.PING_LOCAL.address, message -> {
+			log.debug("Handling local ping");
+			lastPingTimestamp = System.currentTimeMillis();
+		});
+
+		if (options.getClusterOptions().isEnabled()) {
+			eb.consumer(MeshEvent.PING_CLUSTER.address, message -> {
+				String sender = message.headers().get(EventQueueBatch.SENDER_HEADER);
+				if (sender != null) {
+					log.debug("Handling cluster ping from {}", sender);
+					lastClusterPingTimestamps.put(sender, System.currentTimeMillis());
+				}
+			});
+		}
+
+		eventBusCheckerService.scheduleAtFixedRate(() -> {
+			log.debug("Sending local ping");
+			eb.publish(MeshEvent.PING_LOCAL.address, null);
+
+			int errorThreshold = options.getVertxOptions().getEventBusOptions().getErrorThreshold();
+			int warnThreshold = options.getVertxOptions().getEventBusOptions().getWarnThreshold();
+
+			// when we already received a local ping, check when this happened
+			if (lastPingTimestamp > 0) {
+				long sinceLastPing = System.currentTimeMillis() - lastPingTimestamp;
+				if (errorThreshold > 0 && sinceLastPing > errorThreshold) {
+					log.error("Last local ping received {} ms ago", sinceLastPing);
+					livenessManager.setLive(false, "Last local ping received " + sinceLastPing + " ms ago");
+				} else if (warnThreshold > 0 && sinceLastPing > warnThreshold) {
+					log.warn("Last local ping received {} ms ago", sinceLastPing);
+				} else {
+					log.debug("Last local ping received {} ms ago", sinceLastPing);
+				}
+			}
+
+			if (options.getClusterOptions().isEnabled()) {
+				log.debug("Sending cluster ping");
+				eb.publish(MeshEvent.PING_CLUSTER.address, null,
+						new DeliveryOptions().addHeader(EventQueueBatch.SENDER_HEADER, options.getNodeName()));
+
+				// get the currently known cluster node names
+				ClusterStatusResponse clusterStatus = clusterManager.getClusterStatus();
+				Set<String> nodeNames = clusterStatus.getInstances().stream().map(ClusterInstanceInfo::getName).collect(Collectors.toSet());
+
+				// remove all unknown cluster nodes from the map of pings
+				lastClusterPingTimestamps.keySet().retainAll(nodeNames);
+
+				nodeNames.forEach(nodeName -> {
+					// when we already received a cluster ping from the node, check when this happened
+					long lastNodePingTimestamp = lastClusterPingTimestamps.getOrDefault(nodeName, -1L);
+					if (lastNodePingTimestamp > 0) {
+						long sinceLastPing = System.currentTimeMillis() - lastNodePingTimestamp;
+						if (errorThreshold > 0 && sinceLastPing > errorThreshold) {
+							log.error("Last ping from {} received {} ms ago", nodeName, sinceLastPing);
+						} else if (warnThreshold > 0 && sinceLastPing > warnThreshold) {
+							log.warn("Last ping from {} received {} ms ago", nodeName, sinceLastPing);
+						} else {
+							log.debug("Last ping from {} received {} ms ago", nodeName, sinceLastPing);
+						}
+					}
+				});
+			}
+		}, 0, checkInterval, TimeUnit.MILLISECONDS);
+	}
+}

--- a/common/src/main/java/com/gentics/mesh/monitor/liveness/EventBusLivenessManager.java
+++ b/common/src/main/java/com/gentics/mesh/monitor/liveness/EventBusLivenessManager.java
@@ -1,0 +1,14 @@
+package com.gentics.mesh.monitor.liveness;
+
+/**
+ * Liveness manager for the vert.x eventBus.
+ * If enabled, this will do regular checks for the eventBus by publishing events, which are handled locally (and cluster-wide if clustering is enabled).
+ * The regular check will log warn or error messages, if the last ping was received longer than warnThreshold or errorThreshold ago.
+ * If the last ping was received longer than errorThreshold ago, the liveness will also be set to "false".
+ */
+public interface EventBusLivenessManager {
+	/**
+	 * Start the regular checks, if checkInterval is greater than 0
+	 */
+	void startRegularChecks();
+}

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -88,7 +88,9 @@ import com.gentics.mesh.etc.config.DebugInfoOptions;
 import com.gentics.mesh.etc.config.GraphStorageOptions;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.etc.config.MonitoringConfig;
+import com.gentics.mesh.event.EventBusLivenessManagerImpl;
 import com.gentics.mesh.graphdb.spi.Database;
+import com.gentics.mesh.monitor.liveness.EventBusLivenessManager;
 import com.gentics.mesh.monitor.liveness.LivenessManager;
 import com.gentics.mesh.plugin.manager.MeshPluginManager;
 import com.gentics.mesh.router.RouterStorageRegistry;
@@ -189,6 +191,9 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 
 	@Inject
 	public LivenessManager liveness;
+
+	@Inject
+	public EventBusLivenessManager eventbusLiveness;
 
 	private MeshRoot meshRoot;
 
@@ -397,6 +402,8 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 		if (initialPasswordInfo != null) {
 			System.out.println(initialPasswordInfo);
 		}
+
+		eventbusLiveness.startRegularChecks();
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/dagger/MeshComponent.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/MeshComponent.java
@@ -41,6 +41,7 @@ import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.event.MeshEventSender;
 import com.gentics.mesh.graphdb.spi.Database;
 import com.gentics.mesh.metric.MetricsService;
+import com.gentics.mesh.monitor.liveness.EventBusLivenessManager;
 import com.gentics.mesh.monitor.liveness.LivenessManager;
 import com.gentics.mesh.plugin.env.PluginEnvironment;
 import com.gentics.mesh.plugin.manager.MeshPluginManager;
@@ -189,6 +190,8 @@ public interface MeshComponent {
 	MeshEventSender eventSender();
 
 	LivenessManager livenessManager();
+
+	EventBusLivenessManager eventbusLivenessManager();
 
 	@Component.Builder
 	interface Builder {

--- a/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/module/BindModule.java
@@ -31,6 +31,7 @@ import com.gentics.mesh.distributed.TopologyChangeReadonlyHandler;
 import com.gentics.mesh.distributed.TopologyChangeReadonlyHandlerImpl;
 import com.gentics.mesh.distributed.coordinator.proxy.RequestDelegatorImpl;
 import com.gentics.mesh.event.EventQueueBatch;
+import com.gentics.mesh.event.EventBusLivenessManagerImpl;
 import com.gentics.mesh.event.impl.EventQueueBatchImpl;
 import com.gentics.mesh.graphdb.OrientDBDatabase;
 import com.gentics.mesh.graphdb.cluster.ClusterManager;
@@ -40,6 +41,7 @@ import com.gentics.mesh.handler.RangeRequestHandler;
 import com.gentics.mesh.handler.impl.RangeRequestHandlerImpl;
 import com.gentics.mesh.metric.MetricsService;
 import com.gentics.mesh.metric.MetricsServiceImpl;
+import com.gentics.mesh.monitor.liveness.EventBusLivenessManager;
 import com.gentics.mesh.monitor.liveness.LivenessManager;
 import com.gentics.mesh.monitor.liveness.LivenessManagerImpl;
 import com.gentics.mesh.plugin.env.PluginEnvironment;
@@ -143,6 +145,9 @@ public abstract class BindModule {
 
 	@Binds
 	abstract LivenessManager bindLivenessManager(LivenessManagerImpl e);
+
+	@Binds
+	abstract EventBusLivenessManager bindEventbusLivenessManager(EventBusLivenessManagerImpl e);
 
 	@Binds
 	abstract SearchMappingsCache searchMappingsCache(SearchMappingsCacheImpl e);

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/MeshEvent.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/MeshEvent.java
@@ -186,6 +186,20 @@ public enum MeshEvent {
 		"Emitted when the database status changes. (e.g. offline, online, backup, syncing)"),
 
 	/**
+	 * Event, which is emitted regularly to check whether local eventbus works
+	 */
+	PING_LOCAL("mesh.ping.local",
+		null,
+		"Event, which is emitted regularly to check whether local eventbus works"),
+
+	/**
+	 * Event, which is emitted regularly to check whether clustered eventbus works
+	 */
+	PING_CLUSTER("mesh.ping.cluster",
+		null,
+		"Event, which is emitted regularly to check whether clustered eventbus works"),
+
+	/**
 	 * Event which is send to update the permission stores.
 	 */
 	CLEAR_PERMISSION_STORE("mesh.clear-permission-store",


### PR DESCRIPTION
## Abstract

Some errors seen on different installations might be caused by the vert.x eventBus, which seem to stop working (event handlers are not called any more). Therefore, a periodic check has been added, which will log warn or error messages, if regular ping events are not handled within a given threshold time.
If ping events are not handled within the given error threshold time, the mesh instance will be considered unhealthy (liveness check will fail).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
