### PR TITLE
Fix blocking handlers for reading request to not be executed ordered

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,11 @@ include::content/docs/variables.adoc-include[]
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.17`.
 
+icon:check[] Rest: Many reading request were implemented in a way that they would never be executed concurrently with other reading requests.
+So would e.g. a long running graphql request cause webroot requests executed at the same time to be queued until the graphql request was done.
+The behaviour has been changed, so that reading requests will only be queued, if the worker pool has been exhausted.
+
+
 [[v1.8.3]]
 == 1.8.3 (08.04.2022)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,10 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] OrientDB: The included OrientDB version has been updated to version `3.1.17`.
 
+icon:check[] Rest: Many reading request were implemented in a way that they would never be executed concurrently with other reading requests.
+So would e.g. a long running graphql request cause webroot requests executed at the same time to be queued until the graphql request was done.
+The behaviour has been changed, so that reading requests will only be queued, if the worker pool has been exhausted.
+
 [[v1.6.27]]
 == 1.6.27 (08.04.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminEndpoint.java
@@ -160,7 +160,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("uuid");
 			pluginHandler.handleRead(ac, uuid);
-		});
+		}, false);
 
 		InternalEndpointRoute readAllEndpoint = createRoute();
 		readAllEndpoint.path("/plugins");
@@ -170,7 +170,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		readAllEndpoint.exampleResponse(OK, adminExamples.createPluginListResponse(), "Plugin list response.");
 		readAllEndpoint.blockingHandler(rc -> {
 			pluginHandler.handleReadList(wrap(rc));
-		});
+		}, false);
 	}
 
 	/**
@@ -186,7 +186,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		endpoint.exampleResponse(OK, adminExamples.createClusterStatusResponse(), "Cluster status.");
 		endpoint.blockingHandler(rc -> {
 			adminHandler.handleClusterStatus(wrap(rc));
-		});
+		}, false);
 	}
 
 	private void addClusterConfigHandler() {
@@ -198,7 +198,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		endpoint.exampleResponse(OK, adminExamples.createClusterConfigResponse(), "Currently active cluster configuration.");
 		endpoint.blockingHandler(rc -> {
 			adminHandler.handleLoadClusterConfig(wrap(rc));
-		});
+		}, false);
 
 		InternalEndpointRoute updateEndpoint = createRoute();
 		updateEndpoint.path("/cluster/config");
@@ -248,7 +248,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		endpoint.events(GRAPH_EXPORT_START, GRAPH_EXPORT_FINISHED);
 		endpoint.blockingHandler(rc -> {
 			adminHandler.handleExport(wrap(rc));
-		});
+		}, false);
 	}
 
 	private void addImportHandler() {
@@ -339,7 +339,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 		readJobList.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			jobHandler.handleReadList(ac);
-		});
+		}, false);
 
 		InternalEndpointRoute readJob = createRoute();
 		readJob.path("/jobs/:jobUuid");
@@ -352,7 +352,7 @@ public class AdminEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("jobUuid");
 			jobHandler.handleRead(ac, uuid);
-		});
+		}, false);
 
 		InternalEndpointRoute deleteJob = createRoute();
 		deleteJob.path("/jobs/:jobUuid");

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/auth/AuthenticationEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/auth/AuthenticationEndpoint.java
@@ -74,7 +74,7 @@ public class AuthenticationEndpoint extends AbstractInternalEndpoint {
 		loginEndpoint.exampleResponse(OK, miscExamples.getAuthTokenResponse(), "Generated login token.");
 		loginEndpoint.blockingHandler(rc -> {
 			authRestHandler.handleLoginJWT(wrap(rc));
-		});
+		}, false);
 
 		// Only secure logout
 		if (chain != null) {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/branch/BranchEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/branch/BranchEndpoint.java
@@ -82,7 +82,7 @@ public class BranchEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = rc.request().getParam("branchUuid");
 			crudHandler.handleGetMicroschemaVersions(ac, uuid);
-		});
+		}, false);
 
 	}
 
@@ -99,7 +99,7 @@ public class BranchEndpoint extends AbstractProjectEndpoint {
 			String uuid = rc.request().getParam("branchUuid");
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleGetSchemaVersions(ac, uuid);
-		});
+		}, false);
 	}
 
 	private void addNodeMigrationHandler() {
@@ -167,7 +167,7 @@ public class BranchEndpoint extends AbstractProjectEndpoint {
 				InternalActionContext ac = wrap(rc);
 				crudHandler.handleRead(ac, uuid);
 			}
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -180,7 +180,7 @@ public class BranchEndpoint extends AbstractProjectEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadList(ac);
-		});
+		}, false);
 	}
 
 	private void addUpdateHandler() {
@@ -264,7 +264,7 @@ public class BranchEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String branchUuid = ac.getParameter("branchUuid");
 			crudHandler.readTags(ac, branchUuid);
-		});
+		}, false);
 
 		InternalEndpointRoute bulkUpdate = createRoute();
 		bulkUpdate.path("/:branchUuid/tags");

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/group/GroupEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/group/GroupEndpoint.java
@@ -79,7 +79,7 @@ public class GroupEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String groupUuid = ac.getParameter("groupUuid");
 			crudHandler.handleGroupRolesList(ac, groupUuid);
-		});
+		}, false);
 
 		InternalEndpointRoute addRole = createRoute();
 		addRole.path("/:groupUuid/roles/:roleUuid");
@@ -127,7 +127,7 @@ public class GroupEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String groupUuid = ac.getParameter("groupUuid");
 			crudHandler.handleGroupUserList(ac, groupUuid);
-		});
+		}, false);
 
 		InternalEndpointRoute addUser = createRoute();
 		addUser.path("/:groupUuid/users/:userUuid");
@@ -211,7 +211,7 @@ public class GroupEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("groupUuid");
 			crudHandler.handleRead(ac, uuid);
-		});
+		}, false);
 
 		/*
 		 * List all groups when no parameter was specified
@@ -227,7 +227,7 @@ public class GroupEndpoint extends AbstractInternalEndpoint {
 		readAll.addQueryParameters(GenericParametersImpl.class);
 		readAll.blockingHandler(rc -> {
 			crudHandler.handleReadList(wrap(rc));
-		});
+		}, false);
 	}
 
 	// TODO handle conflicting group name: group_conflicting_name

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/microschema/MicroschemaEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/microschema/MicroschemaEndpoint.java
@@ -77,7 +77,7 @@ public class MicroschemaEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String schemaUuid = ac.getParameter("microschemaUuid");
 			crudHandler.handleDiff(ac, schemaUuid);
-		});
+		}, false);
 	}
 
 	private void addChangesHandler() {
@@ -127,7 +127,7 @@ public class MicroschemaEndpoint extends AbstractInternalEndpoint {
 			} else {
 				crudHandler.handleRead(wrap(rc), uuid);
 			}
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -138,7 +138,7 @@ public class MicroschemaEndpoint extends AbstractInternalEndpoint {
 		readAll.produces(APPLICATION_JSON);
 		readAll.blockingHandler(rc -> {
 			crudHandler.handleReadList(wrap(rc));
-		});
+		}, false);
 	}
 
 	private void addDeleteHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/navroot/NavRootEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/navroot/NavRootEndpoint.java
@@ -50,6 +50,6 @@ public class NavRootEndpoint extends AbstractProjectEndpoint {
 		endpoint.addQueryParameters(NavigationParametersImpl.class);
 		endpoint.produces(APPLICATION_JSON);
 		endpoint.exampleResponse(OK, nodeExamples.getNavigationResponse(), "Loaded navigation.");
-		endpoint.blockingHandler(rc -> handler.handleGetPath(rc));
+		endpoint.blockingHandler(rc -> handler.handleGetPath(rc), false);
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/NodeEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/NodeEndpoint.java
@@ -123,7 +123,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("nodeUuid");
 			crudHandler.handleNavigation(ac, uuid);
-		});
+		}, false);
 	}
 
 	private void addVersioningHandlers() {
@@ -140,7 +140,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("nodeUuid");
 			crudHandler.handleListVersions(ac, uuid);
-		});
+		}, false);
 	}
 
 	private void addLanguageHandlers() {
@@ -213,7 +213,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			String uuid = rc.request().getParam("nodeUuid");
 			String fieldName = rc.request().getParam("fieldName");
 			binaryDownloadHandler.handleReadBinaryField(rc, uuid, fieldName);
-		});
+		}, false);
 
 	}
 
@@ -292,7 +292,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("nodeUuid");
 			crudHandler.handleReadChildren(ac, uuid);
-		});
+		}, false);
 	}
 
 	// TODO filtering, sorting
@@ -311,7 +311,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("nodeUuid");
 			crudHandler.readTags(ac, uuid);
-		});
+		}, false);
 
 		InternalEndpointRoute bulkUpdate = createRoute();
 		bulkUpdate.path("/:nodeUuid/tags");
@@ -405,7 +405,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 				InternalActionContext ac = wrap(rc);
 				crudHandler.handleRead(ac, uuid);
 			}
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -421,7 +421,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadList(ac);
-		});
+		}, false);
 
 	}
 
@@ -483,7 +483,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = rc.request().getParam("nodeUuid");
 			crudHandler.handleGetPublishStatus(ac, uuid);
-		});
+		}, false);
 
 		InternalEndpointRoute putEndpoint = createRoute();
 		putEndpoint.description("Publish all language specific contents of the node with the given uuid.");
@@ -533,7 +533,7 @@ public class NodeEndpoint extends AbstractProjectEndpoint {
 			String uuid = rc.request().getParam("nodeUuid");
 			String lang = rc.request().getParam("language");
 			crudHandler.handleGetPublishStatus(ac, uuid, lang);
-		});
+		}, false);
 
 		InternalEndpointRoute putLanguageRoute = createRoute();
 		putLanguageRoute.path("/:nodeUuid/languages/:language/published").method(POST).produces(APPLICATION_JSON);

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectEndpoint.java
@@ -115,7 +115,7 @@ public class ProjectEndpoint extends AbstractInternalEndpoint {
 				InternalActionContext ac = wrap(rc);
 				crudHandler.handleRead(ac, uuid);
 			}
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -128,7 +128,7 @@ public class ProjectEndpoint extends AbstractInternalEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadList(ac);
-		});
+		}, false);
 	}
 
 	private void addDeleteHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectInfoEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectInfoEndpoint.java
@@ -53,7 +53,7 @@ public class ProjectInfoEndpoint extends AbstractInternalEndpoint {
 			String projectName = rc.request().params().get("project");
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadByName(ac, projectName);
-		});
+		}, false);
 	}
 
 	@Override

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/role/RoleEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/role/RoleEndpoint.java
@@ -94,7 +94,7 @@ public class RoleEndpoint extends AbstractInternalEndpoint {
 			String roleUuid = ac.getParameter("param0");
 			String pathToElement = ac.getParameter("param1");
 			crudHandler.handlePermissionRead(ac, roleUuid, pathToElement);
-		});
+		}, false);
 	}
 
 	private void addDeleteHandler() {
@@ -142,7 +142,7 @@ public class RoleEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("roleUuid");
 			crudHandler.handleRead(ac, uuid);
-		});
+		}, false);
 
 		/*
 		 * List all roles when no parameter was specified
@@ -158,7 +158,7 @@ public class RoleEndpoint extends AbstractInternalEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadList(ac);
-		});
+		}, false);
 	}
 
 	private void addCreateHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/schema/ProjectSchemaEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/schema/ProjectSchemaEndpoint.java
@@ -66,7 +66,7 @@ public class ProjectSchemaEndpoint extends AbstractProjectEndpoint {
 				InternalActionContext ac = wrap(rc);
 				crudHandler.handleRead(ac, uuid);
 			}
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -77,7 +77,7 @@ public class ProjectSchemaEndpoint extends AbstractProjectEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadProjectList(ac);
-		});
+		}, false);
 	}
 
 	private void addAssignHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/schema/SchemaEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/schema/SchemaEndpoint.java
@@ -124,7 +124,7 @@ public class SchemaEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("schemaUuid");
 			crudHandler.handleDiff(ac, uuid);
-		});
+		}, false);
 	}
 
 	private void addUpdateHandler() {
@@ -183,7 +183,7 @@ public class SchemaEndpoint extends AbstractInternalEndpoint {
 				InternalActionContext ac = wrap(rc);
 				crudHandler.handleRead(ac, uuid);
 			}
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -196,7 +196,7 @@ public class SchemaEndpoint extends AbstractInternalEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadList(ac);
-		});
+		}, false);
 
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/tagfamily/TagFamilyEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/tagfamily/TagFamilyEndpoint.java
@@ -136,7 +136,7 @@ public class TagFamilyEndpoint extends AbstractProjectEndpoint {
 			String tagFamilyUuid = PathParameters.getTagFamilyUuid(rc);
 			String uuid = PathParameters.getTagUuid(rc);
 			tagCrudHandler.handleRead(ac, tagFamilyUuid, uuid);
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/:tagFamilyUuid/tags");
@@ -151,7 +151,7 @@ public class TagFamilyEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String tagFamilyUuid = PathParameters.getTagFamilyUuid(rc);
 			tagCrudHandler.handleReadTagList(ac, tagFamilyUuid);
-		});
+		}, false);
 
 	}
 
@@ -189,7 +189,7 @@ public class TagFamilyEndpoint extends AbstractProjectEndpoint {
 			String tagFamilyUuid = PathParameters.getTagFamilyUuid(rc);
 			String uuid = PathParameters.getTagUuid(rc);
 			tagCrudHandler.handleTaggedNodesList(ac, tagFamilyUuid, uuid);
-		});
+		}, false);
 	}
 
 	private void addTagFamilyDeleteHandler() {
@@ -220,7 +220,7 @@ public class TagFamilyEndpoint extends AbstractProjectEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String tagFamilyUuid = PathParameters.getTagFamilyUuid(rc);
 			tagFamilyCrudHandler.handleRead(ac, tagFamilyUuid);
-		});
+		}, false);
 
 		InternalEndpointRoute readAll = createRoute();
 		readAll.path("/");
@@ -232,7 +232,7 @@ public class TagFamilyEndpoint extends AbstractProjectEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			tagFamilyCrudHandler.handleReadList(ac);
-		});
+		}, false);
 	}
 
 	private void addTagFamilyCreateHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/user/UserEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/user/UserEndpoint.java
@@ -114,7 +114,7 @@ public class UserEndpoint extends AbstractInternalEndpoint {
 			String userUuid = ac.getParameter("param0");
 			String pathToElement = ac.getParameter("param1");
 			crudHandler.handlePermissionRead(ac, userUuid, pathToElement);
-		});
+		}, false);
 	}
 
 	private void addResetTokenHandler() {
@@ -150,7 +150,7 @@ public class UserEndpoint extends AbstractInternalEndpoint {
 			InternalActionContext ac = wrap(rc);
 			String uuid = ac.getParameter("userUuid");
 			crudHandler.handleRead(ac, uuid);
-		});
+		}, false);
 
 		/*
 		 * List all users when no parameter was specified
@@ -169,7 +169,7 @@ public class UserEndpoint extends AbstractInternalEndpoint {
 		readAll.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			crudHandler.handleReadList(ac);
-		});
+		}, false);
 	}
 
 	private void addDeleteHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/utility/UtilityEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/utility/UtilityEndpoint.java
@@ -69,7 +69,7 @@ public class UtilityEndpoint extends AbstractInternalEndpoint {
 		endpoint.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			utilityHandler.validateMicroschema(ac);
-		});
+		}, false);
 	}
 
 	/**
@@ -88,6 +88,6 @@ public class UtilityEndpoint extends AbstractInternalEndpoint {
 		endpoint.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			utilityHandler.handleResolveLinks(ac);
-		});
+		}, false);
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/webroot/WebRootEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/webroot/WebRootEndpoint.java
@@ -59,7 +59,7 @@ public class WebRootEndpoint extends AbstractProjectEndpoint {
 		endpoint.addQueryParameters(ImageManipulationParametersImpl.class);
 		endpoint.blockingHandler(rc -> {
 			handler.handleGetPath(rc);
-		});
+		}, false);
 	}
 
 	private void addPathUpdateCreateHandler() {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/webrootfield/WebRootFieldEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/webrootfield/WebRootFieldEndpoint.java
@@ -62,7 +62,7 @@ public class WebRootFieldEndpoint extends AbstractProjectEndpoint {
 			"Download the field with the given name from the given path. You can use image query parameters for crop and resize if the binary data represents an image.");
 		fieldGet.blockingHandler(rc -> {
 			handler.handleGetPathField(rc);
-		});
+		}, false);
 
 	}
 

--- a/core/src/main/java/com/gentics/mesh/search/SearchEndpointImpl.java
+++ b/core/src/main/java/com/gentics/mesh/search/SearchEndpointImpl.java
@@ -150,7 +150,7 @@ public class SearchEndpointImpl extends AbstractInternalEndpoint implements Sear
 		statusEndpoint.blockingHandler(rc -> {
 			InternalActionContext ac = wrap(rc);
 			adminHandler.handleStatus(ac);
-		});
+		}, false);
 
 		// Endpoint createMappings = createEndpoint();
 		// createMappings.path("/createMappings");

--- a/mdm/common/src/main/java/com/gentics/mesh/rest/InternalEndpointRoute.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/rest/InternalEndpointRoute.java
@@ -175,8 +175,11 @@ public interface InternalEndpointRoute extends Comparable<InternalEndpointRoute>
 
 	/**
 	 * Create a blocking handler for the endpoint.
+	 * The handler will be created "ordered", which means that handlers will not be called concurrently.
+	 * This should only be used, when absolutely necessary and only for mutating requests.
+	 * In all other cases, {@link #blockingHandler(Handler, boolean)} with ordered: false should be used.
 	 * 
-	 * @param requestHandler
+	 * @param requestHandler request handler
 	 * @return Fluent API
 	 */
 	InternalEndpointRoute blockingHandler(Handler<RoutingContext> requestHandler);
@@ -184,8 +187,8 @@ public interface InternalEndpointRoute extends Comparable<InternalEndpointRoute>
 	/**
 	 * Create a blocking handler for the endpoint.
 	 * 
-	 * @param requestHandler
-	 * @param ordered
+	 * @param requestHandler request handler
+	 * @param ordered if the handlers should be called in order or may be called concurrently
 	 * @return Fluent API
 	 */
 	InternalEndpointRoute blockingHandler(Handler<RoutingContext> requestHandler, boolean ordered);


### PR DESCRIPTION
## Abstract

Blocking handlers can be added to vert.x "ordered" (which is the default) and "unordered". If the blocking handlers are added "ordered", they will be queued, if other handlers ("ordered" or "unordered") are currently executed.
Many blocking handlers for read-only request were added by default as "ordered", but this is unnecessary and just gets too many requests being queued.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
