### PR TITLE
Change defaults for disk quota checker

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,6 +26,9 @@ icon:check[] Search: When a schema contained a field of type "micronode" or "lis
 hash as part of the search index name failed with a NullPointerException.
 This has been fixed, so that the microschema version hash will now be null in such cases (like if "allow" was set to an empty array).
 
+icon:check[] Core: The default values for the periodic disk quota check have been changed to absolute values:
+the default for `storage.diskQuota.warnThreshold` is now `3G` and the default for `storage.diskQuota.readOnlyThreshold` is `1G`.
+
 [[v1.6.28]]
 == 1.6.28 (10.05.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/DiskQuotaOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/DiskQuotaOptions.java
@@ -22,8 +22,8 @@ public class DiskQuotaOptions implements Option {
 	public final static Pattern QUOTA_PATTERN_ABSOLUTE = Pattern.compile("(?<value>[0-9]+)(?<unit>b|B|k|K|m|M|g|G|t|T)");
 
 	public final static int DEFAULT_CHECK_INTERVAL = 10_000;
-	public final static String DEFAULT_WARN_THRESHOLD = "15%";
-	public final static String DEFAULT_READ_ONLY_THRESHOLD = "10%";
+	public final static String DEFAULT_WARN_THRESHOLD = "3G";
+	public final static String DEFAULT_READ_ONLY_THRESHOLD = "1G";
 
 	public final static String MESH_STORAGE_DISK_QUOTA_CHECK_INTERVAL_ENV = "MESH_STORAGE_DISK_QUOTA_CHECK_INTERVAL";
 	public final static String MESH_STORAGE_DISK_QUOTA_WARN_THRESHOLD_ENV = "MESH_STORAGE_DISK_QUOTA_WARN_THRESHOLD";


### PR DESCRIPTION
## Abstract

The default threshold values for the disk quota checker have been made absolute (3G for warn and 1G for read-only).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
