### PR TITLE
Fix rendering links from url fields: prepend with branch pathPrefix

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -34,6 +34,9 @@ one of the nodes in the node structure was not published. This has been fixed.
 
 icon:check[] Documentation: The misleading `image` mentions in the Micronode documentation have been removed.
 
+icon:check[] Core: If a link to a node was rendered from a url field, the path prefix of the used branch was ignored. This has been changed now,
+so that links to nodes will always contain the path prefix, regardless of whether the link is rendered from a url field or from segment fields.
+
 [[v1.6.29]]
 == 1.6.29 (31.05.2022)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -37,6 +37,9 @@ icon:check[] Documentation: The misleading `image` mentions in the Micronode doc
 icon:check[] Core: If a link to a node was rendered from a url field, the path prefix of the used branch was ignored. This has been changed now,
 so that links to nodes will always contain the path prefix, regardless of whether the link is rendered from a url field or from segment fields.
 
+icon:check[] Core: When the pathPrefix of a branch was changed, node could possibly still be access using the old pathPrefix due to an internal
+cache, which was not invalidated. The cache will now be cleared when a branch is modified.
+
 [[v1.6.29]]
 == 1.6.29 (31.05.2022)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -40,6 +40,8 @@ so that links to nodes will always contain the path prefix, regardless of whethe
 icon:check[] Core: When the pathPrefix of a branch was changed, node could possibly still be access using the old pathPrefix due to an internal
 cache, which was not invalidated. The cache will now be cleared when a branch is modified.
 
+icon:check[] GraphQL: The fields `hostname`, `ssl` and `pathPrefix` have been added to the type `branch`.
+
 [[v1.6.29]]
 == 1.6.29 (31.05.2022)
 

--- a/core/src/main/java/com/gentics/mesh/cache/WebrootPathCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/WebrootPathCacheImpl.java
@@ -1,5 +1,6 @@
 package com.gentics.mesh.cache;
 
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_UPDATED;
 import static com.gentics.mesh.core.rest.MeshEvent.CLEAR_PATH_STORE;
 import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_DATABASE_CHANGE_STATUS;
 import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_NODE_JOINED;
@@ -46,7 +47,8 @@ public class WebrootPathCacheImpl extends AbstractMeshCache<String, Path> implem
 		NODE_CONTENT_DELETED,
 		CLUSTER_NODE_JOINED,
 		CLUSTER_DATABASE_CHANGE_STATUS,
-		SCHEMA_MIGRATION_FINISHED };
+		SCHEMA_MIGRATION_FINISHED,
+		BRANCH_UPDATED};
 
 	@Inject
 	public WebrootPathCacheImpl(EventAwareCacheFactory factory, CacheRegistry registry, MeshOptions options) {

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
@@ -42,6 +42,7 @@ import com.gentics.mesh.core.data.node.field.list.StringGraphFieldList;
 import com.gentics.mesh.core.data.node.field.nesting.MicronodeGraphField;
 import com.gentics.mesh.core.data.schema.MicroschemaContainer;
 import com.gentics.mesh.core.data.schema.SchemaContainer;
+import com.gentics.mesh.core.rest.branch.BranchUpdateRequest;
 import com.gentics.mesh.core.rest.graphql.GraphQLResponse;
 import com.gentics.mesh.core.rest.microschema.impl.MicroschemaCreateRequest;
 import com.gentics.mesh.core.rest.microschema.impl.MicroschemaResponse;
@@ -107,6 +108,8 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 
 	private final boolean withMicroschema;
 
+	private final boolean withBranchPathPrefix;
+
 	private final String version;
 	private final String apiVersion;
 
@@ -124,70 +127,72 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 	 *
 	 * @param queryName The filename of the GraphQL query to use
 	 * @param withMicroschema Whether to use micro schemas
+	 * @param withBranchPathPrefix whether the branch should have a path prefix set
 	 * @param version Whether to use the <code>draft</code> or <code>published</code> version
 	 * @param assertion A custom assertion to be applied on the GraphQL query result
 	 */
-	public GraphQLEndpointTest(String queryName, boolean withMicroschema, String version, Consumer<JsonObject> assertion, String apiVersion) {
+	public GraphQLEndpointTest(String queryName, boolean withMicroschema, boolean withBranchPathPrefix, String version, Consumer<JsonObject> assertion, String apiVersion) {
 		this.queryName = queryName;
 		this.withMicroschema = withMicroschema;
+		this.withBranchPathPrefix = withBranchPathPrefix;
 		this.version = version;
 		this.assertion = assertion;
 		this.apiVersion = apiVersion;
 	}
 
-	@Parameters(name = "query={0},version={2},apiVersion={4}")
+	@Parameters(name = "query={0},version={3},apiVersion={5}")
 	public static Collection<Object[]> paramData() {
 		return Stream.<List<Object>>of(
-			Arrays.asList("full-query", true, "draft"),
-			Arrays.asList("role-user-group-query", true, "draft"),
-			Arrays.asList("group-query", true, "draft"),
-			Arrays.asList("schema-query", true, "draft"),
-			// Arrays.asList("schema-projects-query", true, "draft"),
-			Arrays.asList("microschema-query", true, "draft"),
-			Arrays.asList("paging-query", true, "draft"),
-			Arrays.asList("tagFamily-query", true, "draft"),
-			Arrays.asList("node-query", true, "draft"),
-			Arrays.asList("node-tag-query", true, "draft"),
-			Arrays.asList("nodes-query", true, "draft"),
-			Arrays.asList("nodes-query-by-uuids", true, "draft"),
-			Arrays.asList("node-breadcrumb-query", true, "draft"),
-			Arrays.asList("node-breadcrumb-query-with-lang", true, "draft"),
-			Arrays.asList("node-language-fallback-query", true, "draft"),
-			Arrays.asList("node-languages-query", true, "draft", (Consumer<JsonObject>) GraphQLEndpointTest::checkNodeLanguageContent),
-			Arrays.asList("node-not-found-webroot-query", true, "draft"),
-			Arrays.asList("node-webroot-query", true, "draft"),
-			Arrays.asList("node-webroot-urlfield-query", true, "draft"),
-			Arrays.asList("node-relations-query", true, "draft"),
-			Arrays.asList("node-fields-query", true, "draft"),
-			Arrays.asList("node-fields-no-microschema-query", false, "draft"),
-			Arrays.asList("node/link/webroot", true, "draft"),
-			Arrays.asList("node/link/children", true, "draft", (Consumer<JsonObject>) GraphQLEndpointTest::checkNodeLinkChildrenResponse),
-			Arrays.asList("node/link/webroot-language", true, "draft"),
-			Arrays.asList("node/link/reference", true, "draft"),
-			Arrays.asList("node-field-list-path-query", true, "draft"),
-			Arrays.asList("project-query", true, "draft"),
-			Arrays.asList("tag-query", true, "draft"),
-			Arrays.asList("branch-query", true, "draft"),
-			Arrays.asList("user-query", true, "draft"),
-			Arrays.asList("microschema-projects-query", true, "draft"),
-			Arrays.asList("node-version-published-query", true, "published"),
-			Arrays.asList("filtering/children", true, "draft"),
-			Arrays.asList("filtering/nodes", true, "draft"),
-			Arrays.asList("filtering/nodes-en", true, "draft"),
-			Arrays.asList("filtering/nodes-jp", true, "draft"),
-			Arrays.asList("filtering/nodes-creator-editor", true, "draft"),
-			Arrays.asList("filtering/users", true, "draft"),
-			Arrays.asList("filtering/groups", true, "draft"),
-			Arrays.asList("filtering/roles", true, "draft"),
-			Arrays.asList("node/breadcrumb-root", true, "draft"),
-			Arrays.asList("node/versionslist", true, "draft"),
-			Arrays.asList("permissions", true, "draft"),
-			Arrays.asList("user-node-reference", true, "draft")
+			Arrays.asList("full-query", true, false, "draft"),
+			Arrays.asList("role-user-group-query", true, false, "draft"),
+			Arrays.asList("group-query", true, false, "draft"),
+			Arrays.asList("schema-query", true, false, "draft"),
+			// Arrays.asList("schema-projects-query", true, false, "draft"),
+			Arrays.asList("microschema-query", true, false, "draft"),
+			Arrays.asList("paging-query", true, false, "draft"),
+			Arrays.asList("tagFamily-query", true, false, "draft"),
+			Arrays.asList("node-query", true, false, "draft"),
+			Arrays.asList("node-tag-query", true, false, "draft"),
+			Arrays.asList("nodes-query", true, false, "draft"),
+			Arrays.asList("nodes-query-by-uuids", true, false, "draft"),
+			Arrays.asList("node-breadcrumb-query", true, false, "draft"),
+			Arrays.asList("node-breadcrumb-query-with-lang", true, false, "draft"),
+			Arrays.asList("node-language-fallback-query", true, false, "draft"),
+			Arrays.asList("node-languages-query", true, false, "draft", (Consumer<JsonObject>) GraphQLEndpointTest::checkNodeLanguageContent),
+			Arrays.asList("node-not-found-webroot-query", true, false, "draft"),
+			Arrays.asList("node-webroot-query", true, false, "draft"),
+			Arrays.asList("node-webroot-urlfield-query", true, false, "draft"),
+			Arrays.asList("node-relations-query", true, false, "draft"),
+			Arrays.asList("node-fields-query", true, false, "draft"),
+			Arrays.asList("node-fields-no-microschema-query", false, false, "draft"),
+			Arrays.asList("node/link/webroot", true, false, "draft"),
+			Arrays.asList("node/link/children", true, false, "draft", (Consumer<JsonObject>) GraphQLEndpointTest::checkNodeLinkChildrenResponse),
+			Arrays.asList("node/link/webroot-language", true, false, "draft"),
+			Arrays.asList("node/link/reference", true, false, "draft"),
+			Arrays.asList("node-field-list-path-query", true, false, "draft"),
+			Arrays.asList("project-query", true, false, "draft"),
+			Arrays.asList("tag-query", true, false, "draft"),
+			Arrays.asList("branch-query", true, true, "draft"),
+			Arrays.asList("user-query", true, false, "draft"),
+			Arrays.asList("microschema-projects-query", true, false, "draft"),
+			Arrays.asList("node-version-published-query", true, false, "published"),
+			Arrays.asList("filtering/children", true, false, "draft"),
+			Arrays.asList("filtering/nodes", true, false, "draft"),
+			Arrays.asList("filtering/nodes-en", true, false, "draft"),
+			Arrays.asList("filtering/nodes-jp", true, false, "draft"),
+			Arrays.asList("filtering/nodes-creator-editor", true, false, "draft"),
+			Arrays.asList("filtering/users", true, false, "draft"),
+			Arrays.asList("filtering/groups", true, false, "draft"),
+			Arrays.asList("filtering/roles", true, false, "draft"),
+			Arrays.asList("node/breadcrumb-root", true, false, "draft"),
+			Arrays.asList("node/versionslist", true, false, "draft"),
+			Arrays.asList("permissions", true, false, "draft"),
+			Arrays.asList("user-node-reference", true, false, "draft")
 		)
 		.flatMap(testCase -> IntStream.rangeClosed(1, CURRENT_API_VERSION).mapToObj(version -> {
-			// Make sure all testData entries have five parts.
-			Object[] array = testCase.toArray(new Object[5]);
-			array[4] = "v" + version;
+			// Make sure all testData entries have six parts.
+			Object[] array = testCase.toArray(new Object[6]);
+			array[5] = "v" + version;
 			return array;
 		})).collect(Collectors.toList());
 	}
@@ -217,6 +222,12 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 				}
 				tx.success();
 			}
+		}
+
+		// update branch
+		if (withBranchPathPrefix) {
+			call(() -> client.updateBranch(PROJECT_NAME, initialBranchUuid(),
+					new BranchUpdateRequest().setHostname("getmesh.io").setSsl(false).setPathPrefix("/base/path")));
 		}
 
 		try (Tx tx = tx()) {

--- a/core/src/test/resources/graphql/branch-query
+++ b/core/src/test/resources/graphql/branch-query
@@ -6,6 +6,14 @@
 		name
 		# [$.data.branch.latest=true]
 		latest
+		# [$.data.branch.migrated=true]
+		migrated
+		# [$.data.branch.hostname=getmesh.io]
+		hostname
+		# [$.data.branch.ssl=false]
+		ssl
+		# [$.data.branch.pathPrefix=/base/path]
+		pathPrefix
 		tags {
 			# [$.data.branch.tags.totalCount=0]
 			totalCount

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/BranchTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/BranchTypeProvider.java
@@ -45,6 +45,15 @@ public class BranchTypeProvider extends AbstractTypeProvider {
 		// .latest
 		branchType.field(newFieldDefinition().name("latest").type(GraphQLBoolean));
 
+		// .hostname
+		branchType.field(newFieldDefinition().name("hostname").type(GraphQLString));
+
+		// .ssl
+		branchType.field(newFieldDefinition().name("ssl").type(GraphQLBoolean));
+
+		// .pathPrefix
+		branchType.field(newFieldDefinition().name("pathPrefix").type(GraphQLString));
+
 		// .schema
 		branchType.field(
 			newFieldDefinition().name("schema").description("Load schema by name or uuid.")


### PR DESCRIPTION
## Abstract

If a branch has a pathPrefix set, it must be used for all links, regardless of how the link is rendered (using segment fields or a url field).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
