### PR TITLE
Test improvements

### DIFF
--- a/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
@@ -78,9 +78,11 @@ public class ProjectCrudHandler extends AbstractCrudHandler<HibProject, ProjectR
 				} else {
 					boot.jobDao().enqueueVersionPurge(user, project);
 				}
-				MeshEvent.triggerJobWorker(boot.mesh());
 				return message(ac, "project_version_purge_enqueued");
-			}, message -> ac.send(message, OK));
+			}, message -> {
+				MeshEvent.triggerJobWorker(boot.mesh());
+				ac.send(message, OK);
+			});
 		}
 	}
 

--- a/tests/api/src/main/java/com/gentics/mesh/test/MeshProviderOrder.java
+++ b/tests/api/src/main/java/com/gentics/mesh/test/MeshProviderOrder.java
@@ -6,8 +6,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation for adding an order to instances of {@link MeshOptionsProvider}, so that that automatic
+ * selection of the implementation can be controlled
+ */
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface MeshProviderOrder {
+	/**
+	 * Order of the implementation (smaller numbers take precedence over higher numbers)
+	 * @return order
+	 */
 	int value();
 }

--- a/tests/api/src/main/java/com/gentics/mesh/test/MeshProviderOrder.java
+++ b/tests/api/src/main/java/com/gentics/mesh/test/MeshProviderOrder.java
@@ -1,0 +1,13 @@
+package com.gentics.mesh.test;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface MeshProviderOrder {
+	int value();
+}


### PR DESCRIPTION
## Abstract

This adds the possibilities to support multiple implementations of MeshOptionsProvider for tests. The classes can be annotated with MeshProviderOrder (for defining, in which order the provider implementations will be checked) and can have a static method "isEligible", which should return true, if the implementation can be used.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
