### PR TITLE
No DAOs in BootstrapInitializer. No BootstrapInitializer in most of c…

### DIFF
--- a/common/src/main/java/com/gentics/mesh/auth/provider/MeshJWTAuthProvider.java
+++ b/common/src/main/java/com/gentics/mesh/auth/provider/MeshJWTAuthProvider.java
@@ -31,11 +31,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.KeyStoreOptions;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
-import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.web.Cookie;
 
 /**
@@ -60,8 +60,6 @@ public class MeshJWTAuthProvider implements AuthProvider, JWTAuth {
 
 	private BCryptPasswordEncoder passwordEncoder;
 
-	private BootstrapInitializer boot;
-
 	private final MeshOptions meshOptions;
 
 	@Inject
@@ -70,7 +68,6 @@ public class MeshJWTAuthProvider implements AuthProvider, JWTAuth {
 		this.meshOptions = meshOptions;
 		this.passwordEncoder = passwordEncoder;
 		this.db = database;
-		this.boot = boot;
 
 		// Use the mesh JWT options in order to setup the JWTAuth provider
 		AuthenticationOptions options = meshOptions.getAuthenticationOptions();
@@ -84,7 +81,6 @@ public class MeshJWTAuthProvider implements AuthProvider, JWTAuth {
 		JWTAuthOptions config = new JWTAuthOptions();
 		config.setKeyStore(new KeyStoreOptions().setPath(keyStorePath).setPassword(keystorePassword).setType(type));
 		jwtProvider = JWTAuth.create(vertx, new JWTAuthOptions(config));
-
 	}
 
 	/**
@@ -160,7 +156,7 @@ public class MeshJWTAuthProvider implements AuthProvider, JWTAuth {
 	 *            Password
 	 */
 	private HibUser authenticate(String username, String password, String newPassword) {
-		HibUser user = db.tx(() -> boot.userDao().findByUsername(username));
+		HibUser user = db.tx(tx -> { return tx.userDao().findByUsername(username); });
 		if (user != null) {
 			String accountPasswordHash = db.tx(user::getPasswordHash);
 			// TODO check if user is enabled
@@ -184,7 +180,7 @@ public class MeshJWTAuthProvider implements AuthProvider, JWTAuth {
 					throw error(BAD_REQUEST, "auth_login_newpassword_failed");
 				} else {
 					if (forcedPasswordChange) {
-						db.tx(() -> boot.userDao().setPassword(user, newPassword));
+						db.tx(tx -> { return tx.userDao().setPassword(user, newPassword); });
 					}
 					return user;
 				}

--- a/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacerImpl.java
+++ b/common/src/main/java/com/gentics/mesh/core/link/WebRootLinkReplacerImpl.java
@@ -16,7 +16,6 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.HibNodeFieldContainer;
 import com.gentics.mesh.core.data.branch.HibBranch;
@@ -25,6 +24,7 @@ import com.gentics.mesh.core.data.dao.NodeDao;
 import com.gentics.mesh.core.data.node.HibNode;
 import com.gentics.mesh.core.data.project.HibProject;
 import com.gentics.mesh.core.data.s3binary.S3HibBinary;
+import com.gentics.mesh.core.data.storage.S3BinaryStorage;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.schema.S3BinaryFieldSchema;
@@ -32,7 +32,6 @@ import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.handler.VersionUtils;
 import com.gentics.mesh.parameter.LinkType;
 import com.gentics.mesh.parameter.VersioningParameters;
-import com.gentics.mesh.core.data.storage.S3BinaryStorage;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -48,15 +47,12 @@ public class WebRootLinkReplacerImpl implements WebRootLinkReplacer {
 
 	private static final Logger log = LoggerFactory.getLogger(WebRootLinkReplacerImpl.class);
 
-	private final BootstrapInitializer boot;
-
 	private final MeshOptions options;
 
 	private S3BinaryStorage s3BinaryStorage;
 
 	@Inject
-	public WebRootLinkReplacerImpl(BootstrapInitializer boot, MeshOptions options, S3BinaryStorage s3BinaryStorage) {
-		this.boot = boot;
+	public WebRootLinkReplacerImpl(MeshOptions options, S3BinaryStorage s3BinaryStorage) {
 		this.options = options;
 		this.s3BinaryStorage = s3BinaryStorage;
 	}
@@ -140,7 +136,7 @@ public class WebRootLinkReplacerImpl implements WebRootLinkReplacer {
 		String... languageTags) {
 		// Get rid of additional whitespaces
 		uuid = uuid.trim();
-		HibNode node = boot.nodeDao().findByUuidGlobal(uuid);
+		HibNode node = Tx.get().nodeDao().findByUuidGlobal(uuid);
 		String language;
 		// check for null
 		if (node == null) {

--- a/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/SetAdminUserFlag.java
+++ b/core/src/main/java/com/gentics/mesh/changelog/highlevel/change/SetAdminUserFlag.java
@@ -8,6 +8,7 @@ import com.gentics.mesh.core.data.dao.GroupDao;
 import com.gentics.mesh.core.data.group.HibGroup;
 import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.etc.config.MeshOptions;
 
 import dagger.Lazy;
@@ -21,11 +22,8 @@ public class SetAdminUserFlag extends AbstractHighLevelChange {
 
 	private static final Logger log = LoggerFactory.getLogger(SetAdminUserFlag.class);
 
-	private final Lazy<BootstrapInitializer> boot;
-
 	@Inject
 	public SetAdminUserFlag(Lazy<BootstrapInitializer> boot) {
-		this.boot = boot;
 	}
 
 	@Override
@@ -46,8 +44,8 @@ public class SetAdminUserFlag extends AbstractHighLevelChange {
 	@Override
 	public void apply() {
 		log.info("Applying change: " + getName());
-		GroupDao groupDao = boot.get().groupDao();
-		for (HibRole role : boot.get().roleDao().findAll()) {
+		GroupDao groupDao = Tx.get().groupDao();
+		for (HibRole role : Tx.get().roleDao().findAll()) {
 			if (!"admin".equals(role.getName())) {
 				continue;
 			}

--- a/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
+++ b/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
@@ -19,13 +19,10 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
-import ch.qos.logback.core.rolling.RollingFileAppender;
-import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
-import ch.qos.logback.core.util.FileSize;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,21 +32,10 @@ import com.gentics.mesh.cache.CacheRegistry;
 import com.gentics.mesh.changelog.highlevel.HighLevelChangelogSystem;
 import com.gentics.mesh.core.data.HibLanguage;
 import com.gentics.mesh.core.data.HibMeshVersion;
-import com.gentics.mesh.core.data.dao.BinaryDao;
-import com.gentics.mesh.core.data.dao.BranchDao;
-import com.gentics.mesh.core.data.dao.ContentDao;
-import com.gentics.mesh.core.data.dao.DaoCollection;
 import com.gentics.mesh.core.data.dao.GroupDao;
-import com.gentics.mesh.core.data.dao.JobDao;
 import com.gentics.mesh.core.data.dao.LanguageDao;
-import com.gentics.mesh.core.data.dao.MicroschemaDao;
-import com.gentics.mesh.core.data.dao.NodeDao;
-import com.gentics.mesh.core.data.dao.ProjectDao;
 import com.gentics.mesh.core.data.dao.RoleDao;
-import com.gentics.mesh.core.data.dao.S3BinaryDao;
 import com.gentics.mesh.core.data.dao.SchemaDao;
-import com.gentics.mesh.core.data.dao.TagDao;
-import com.gentics.mesh.core.data.dao.TagFamilyDao;
 import com.gentics.mesh.core.data.dao.UserDao;
 import com.gentics.mesh.core.data.group.HibGroup;
 import com.gentics.mesh.core.data.project.HibProject;
@@ -88,6 +74,13 @@ import com.gentics.mesh.search.TrackingSearchProvider;
 import com.gentics.mesh.search.verticle.eventhandler.SyncEventHandler;
 import com.gentics.mesh.util.MavenVersionNumber;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
+import ch.qos.logback.core.util.FileSize;
 import dagger.Lazy;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -101,9 +94,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.cluster.ClusterManager;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 /**
  * @see BootstrapInitializer
@@ -166,9 +156,6 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 
 	@Inject
 	public MasterElector coordinatorMasterElector;
-
-	@Inject
-	public DaoCollection daoCollection;
 
 	@Inject
 	public LivenessManager liveness;
@@ -240,10 +227,10 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 	@Override
 	public void initBasicData(MeshOptions config) {
 		db().tx(tx -> {
-			UserDao userDao = userDao();
-			SchemaDao schemaDao = schemaDao();
-			GroupDao groupDao = groupDao();
-			RoleDao roleDao = roleDao();
+			UserDao userDao = tx.userDao();
+			SchemaDao schemaDao = tx.schemaDao();
+			GroupDao groupDao = tx.groupDao();
+			RoleDao roleDao = tx.roleDao();
 
 			// Verify that an admin user exists
 			HibUser adminUser = userDao.findByUsername(ADMIN_USERNAME);
@@ -776,7 +763,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 		if (anonymousRole == null) {
 			synchronized (BootstrapInitializer.class) {
 				// Load the role if it has not been yet loaded
-				anonymousRole = roleDao().findByName("anonymous");
+				anonymousRole = Tx.get().roleDao().findByName("anonymous");
 			}
 		}
 		return anonymousRole;
@@ -798,7 +785,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 			throw new NullPointerException("Languages could not be loaded from classpath file {" + filename + "}");
 		}
 		LanguageSet languageSet = new ObjectMapper().readValue(ins, LanguageSet.class);
-		initLanguageSet(languageSet);
+		db().tx(tx -> { initLanguageSet(tx, languageSet); });
 	}
 
 	@Override
@@ -809,7 +796,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 			db().tx(tx -> {
 				try {
 					LanguageSet languageSet = new ObjectMapper().readValue(languagesFile, LanguageSet.class);
-					initLanguageSet(languageSet);
+					initLanguageSet(tx, languageSet);
 					tx.success();
 				} catch (IOException e) {
 					log.error("Error while initializing optional languages from {" + languagesFilePath + "}", e);
@@ -822,7 +809,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 	@Override
 	public Collection<? extends String> getAllLanguageTags() {
 		if (allLanguageTags.isEmpty()) {
-			for (HibLanguage l : languageDao().findAll()) {
+			for (HibLanguage l : Tx.get().languageDao().findAll()) {
 				String tag = l.getLanguageTag();
 				allLanguageTags.add(tag);
 			}
@@ -906,7 +893,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 			String languageTag = entry.getKey();
 			String languageName = entry.getValue().getName();
 			String languageNativeName = entry.getValue().getNativeName();
-			HibLanguage language = languageDao().findByLanguageTag(languageTag);
+			HibLanguage language = Tx.get().languageDao().findByLanguageTag(languageTag);
 			if (language == null) {
 				language = root.create(languageName, languageTag);
 				language.setNativeName(languageNativeName);
@@ -952,8 +939,8 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 	 *
 	 * @param languageSet
 	 */
-	protected void initLanguageSet(LanguageSet languageSet) {
-		initLanguageSet(languageDao(), languageSet);
+	protected void initLanguageSet(Tx tx, LanguageSet languageSet) {
+		initLanguageSet(tx.languageDao(), languageSet);
 	}
 
 	/**
@@ -1053,79 +1040,4 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 	 * @throws Exception
 	 */
 	protected abstract void initCluster(MeshOptions options, PostProcessFlags flags, boolean isInitMode) throws Exception;
-
-	@Override
-	public SchemaDao schemaDao() {
-		return daoCollection.schemaDao();
-	}
-
-	@Override
-	public MicroschemaDao microschemaDao() {
-		return daoCollection.microschemaDao();
-	}
-
-	@Override
-	public RoleDao roleDao() {
-		return daoCollection.roleDao();
-	}
-
-	@Override
-	public TagDao tagDao() {
-		return daoCollection.tagDao();
-	}
-
-	@Override
-	public TagFamilyDao tagFamilyDao() {
-		return daoCollection.tagFamilyDao();
-	}
-
-	@Override
-	public LanguageDao languageDao() {
-		return daoCollection.languageDao();
-	}
-
-	@Override
-	public UserDao userDao() {
-		return daoCollection.userDao();
-	}
-
-	@Override
-	public GroupDao groupDao() {
-		return daoCollection.groupDao();
-	}
-
-	@Override
-	public JobDao jobDao() {
-		return daoCollection.jobDao();
-	}
-
-	@Override
-	public ProjectDao projectDao() {
-		return daoCollection.projectDao();
-	}
-
-	@Override
-	public NodeDao nodeDao() {
-		return daoCollection.nodeDao();
-	}
-
-	@Override
-	public ContentDao contentDao() {
-		return daoCollection.contentDao();
-	}
-
-	@Override
-	public BranchDao branchDao() {
-		return daoCollection.branchDao();
-	}
-
-	@Override
-	public BinaryDao binaryDao() {
-		return daoCollection.binaryDao();
-	}
-
-	@Override
-	public S3BinaryDao s3binaryDao() {
-		return daoCollection.s3binaryDao();
-	}
 }

--- a/core/src/main/java/com/gentics/mesh/core/actions/impl/TagDAOActionsImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/actions/impl/TagDAOActionsImpl.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.action.DAOActionContext;
@@ -21,19 +20,14 @@ import com.gentics.mesh.core.rest.tag.TagResponse;
 import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.parameter.PagingParameters;
 
-import dagger.Lazy;
-
 /**
  * @see TagDAOActions
  */
 @Singleton
 public class TagDAOActionsImpl implements TagDAOActions {
 
-	private Lazy<BootstrapInitializer> boot;
-
 	@Inject
-	public TagDAOActionsImpl(Lazy<BootstrapInitializer> boot) {
-		this.boot = boot;
+	public TagDAOActionsImpl() {
 	}
 
 	@Override
@@ -65,7 +59,7 @@ public class TagDAOActionsImpl implements TagDAOActions {
 	@Override
 	public Page<? extends HibTag> loadAll(DAOActionContext ctx, PagingParameters pagingInfo) {
 		HibTagFamily hibTagFamily = ctx.parent();
-		TagDao tagDao = boot.get().tagDao();
+		TagDao tagDao = Tx.get().tagDao();
 		if (hibTagFamily != null) {
 			return tagDao.findAll(hibTagFamily, ctx.ac(), pagingInfo);
 		} else {
@@ -76,7 +70,7 @@ public class TagDAOActionsImpl implements TagDAOActions {
 	@Override
 	public Page<? extends HibTag> loadAll(DAOActionContext ctx, PagingParameters pagingInfo, Predicate<HibTag> extraFilter) {
 		HibTagFamily hibTagFamily = ctx.parent();
-		TagDao tagDao = boot.get().tagDao();
+		TagDao tagDao = Tx.get().tagDao();
 		if (hibTagFamily != null) {
 			return ctx.tx().tagDao().findAll(hibTagFamily, ctx.ac(), pagingInfo, extraFilter);
 		} else {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/JobHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/JobHandler.java
@@ -72,7 +72,7 @@ public class JobHandler extends AbstractCrudHandler<HibJob, JobResponse> {
 			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
-			JobDao root = boot.jobDao();
+			JobDao root = tx.jobDao();
 
 			PagingParameters pagingInfo = ac.getPagingParameters();
 			JobParameters jobParameters = ac.getJobParameters();
@@ -169,11 +169,11 @@ public class JobHandler extends AbstractCrudHandler<HibJob, JobResponse> {
 		validateParameter(uuid, "uuid");
 
 		try (WriteLock lock = writeLock.lock(ac)) {
-			utils.syncTx(ac, () -> {
+			utils.syncTx(ac, tx -> {
 				if (!ac.getUser().isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
-				JobDao root = boot.jobDao();
+				JobDao root = tx.jobDao();
 				HibJob job = root.loadObjectByUuidNoPerm(uuid, true);
 				db.tx(() -> {
 					if (job.hasFailed()) {
@@ -223,7 +223,7 @@ public class JobHandler extends AbstractCrudHandler<HibJob, JobResponse> {
 			if (!ac.getUser().isAdmin()) {
 				throw error(FORBIDDEN, "error_admin_permission_required");
 			}
-			JobDao root = boot.jobDao();
+			JobDao root = tx.jobDao();
 			HibJob job = root.loadObjectByUuidNoPerm(uuid, true);
 			db.tx(() -> {
 				job.resetJob();
@@ -245,7 +245,7 @@ public class JobHandler extends AbstractCrudHandler<HibJob, JobResponse> {
 				if (!ac.getUser().isAdmin()) {
 					throw error(FORBIDDEN, "error_admin_permission_required");
 				}
-				JobDao root = boot.jobDao();
+				JobDao root = tx.jobDao();
 				HibJob job = root.loadObjectByUuidNoPerm(uuid, true);
 				db.tx(() -> {
 					JobStatus status = job.getStatus();

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/providers/EntitiesProvider.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/providers/EntitiesProvider.java
@@ -13,6 +13,7 @@ import com.gentics.mesh.core.data.HibCoreElement;
 import com.gentics.mesh.core.data.dao.DaoGlobal;
 import com.gentics.mesh.core.data.dao.DaoTransformable;
 import com.gentics.mesh.core.db.Database;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.endpoint.admin.debuginfo.DebugInfoBufferEntry;
 import com.gentics.mesh.core.endpoint.admin.debuginfo.DebugInfoEntry;
 import com.gentics.mesh.core.endpoint.admin.debuginfo.DebugInfoProvider;
@@ -27,12 +28,10 @@ import io.reactivex.Flowable;
 @Singleton
 public class EntitiesProvider implements DebugInfoProvider {
 
-	private final BootstrapInitializer boot;
 	private final Database db;
 
 	@Inject
 	public EntitiesProvider(BootstrapInitializer boot, Database db) {
-		this.boot = boot;
 		this.db = db;
 	}
 
@@ -43,11 +42,12 @@ public class EntitiesProvider implements DebugInfoProvider {
 
 	@Override
 	public Flowable<DebugInfoEntry> debugInfoEntries(InternalActionContext ac) {
+		Tx tx = Tx.get();
 		return Flowable.mergeArray(
-			rootElements(ac, boot::jobDao, "entities/jobs.json"),
-			rootElements(ac, boot::schemaDao, "entities/schemas.json"),
-			rootElements(ac, boot::microschemaDao, "entities/microschemas.json"),
-			rootElements(ac, boot::projectDao, "entities/projects.json"),
+			rootElements(ac, tx::jobDao, "entities/jobs.json"),
+			rootElements(ac, tx::schemaDao, "entities/schemas.json"),
+			rootElements(ac, tx::microschemaDao, "entities/microschemas.json"),
+			rootElements(ac, tx::projectDao, "entities/projects.json"),
 			branches(ac)
 		);
 	}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/NodeCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/NodeCrudHandler.java
@@ -16,7 +16,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 import javax.inject.Inject;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.action.NodeDAOActions;
 import com.gentics.mesh.core.data.HibLanguage;
@@ -49,8 +48,6 @@ import io.vertx.core.logging.LoggerFactory;
  */
 public class NodeCrudHandler extends AbstractCrudHandler<HibNode, NodeResponse> {
 
-	private final BootstrapInitializer boot;
-
 	private final MeshOptions options;
 
 	private final PageTransformer pageTransformer;
@@ -58,11 +55,10 @@ public class NodeCrudHandler extends AbstractCrudHandler<HibNode, NodeResponse> 
 	private static final Logger log = LoggerFactory.getLogger(NodeCrudHandler.class);
 
 	@Inject
-	public NodeCrudHandler(Database db, HandlerUtilities utils, MeshOptions options, BootstrapInitializer boot, WriteLock writeLock,
+	public NodeCrudHandler(Database db, HandlerUtilities utils, MeshOptions options, WriteLock writeLock,
 		NodeDAOActions nodeActions, PageTransformer pageTransformer) {
 		super(db, utils, writeLock, nodeActions);
 		this.options = options;
-		this.boot = boot;
 		this.pageTransformer = pageTransformer;
 	}
 
@@ -503,7 +499,7 @@ public class NodeCrudHandler extends AbstractCrudHandler<HibNode, NodeResponse> 
 			NodeDao nodeDao = tx.nodeDao();
 			HibProject project = tx.getProject(ac);
 			HibNode node = nodeDao.loadObjectByUuid(project, ac, uuid, READ_PERM);
-			return boot.nodeDao().transformToVersionList(node, ac);
+			return tx.nodeDao().transformToVersionList(node, ac);
 		}, model -> {
 			ac.send(model, OK);
 		});

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/project/ProjectCrudHandler.java
@@ -74,9 +74,9 @@ public class ProjectCrudHandler extends AbstractCrudHandler<HibProject, ProjectR
 				ProjectDao projectDao = tx.projectDao();
 				HibProject project = projectDao.loadObjectByUuid(ac, uuid, DELETE_PERM);
 				if (before.isPresent()) {
-					boot.jobDao().enqueueVersionPurge(user, project, before.get());
+					tx.jobDao().enqueueVersionPurge(user, project, before.get());
 				} else {
-					boot.jobDao().enqueueVersionPurge(user, project);
+					tx.jobDao().enqueueVersionPurge(user, project);
 				}
 				return message(ac, "project_version_purge_enqueued");
 			}, message -> {

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/schema/SchemaCrudHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/schema/SchemaCrudHandler.java
@@ -143,7 +143,7 @@ public class SchemaCrudHandler extends AbstractCrudHandler<HibSchema, SchemaResp
 						for (String microschemaName : allowedSchemas) {
 
 							// schema_error_microschema_reference_no_perm
-							HibMicroschema microschema = boot.get().microschemaDao().findByName(microschemaName);
+							HibMicroschema microschema = tx1.microschemaDao().findByName(microschemaName);
 							if (microschema == null) {
 								throw error(BAD_REQUEST, "schema_error_microschema_reference_not_found", microschemaName, field.getName());
 							}

--- a/core/src/main/java/com/gentics/mesh/dagger/module/MeshModule.java
+++ b/core/src/main/java/com/gentics/mesh/dagger/module/MeshModule.java
@@ -2,10 +2,10 @@ package com.gentics.mesh.dagger.module;
 
 import javax.inject.Singleton;
 
-import com.gentics.mesh.core.data.storage.S3BinaryStorage;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import com.gentics.mesh.cli.BootstrapInitializer;
+import com.gentics.mesh.core.data.storage.S3BinaryStorage;
 import com.gentics.mesh.core.image.ImageManipulator;
 import com.gentics.mesh.etc.config.HttpServerConfig;
 import com.gentics.mesh.etc.config.MeshOptions;
@@ -41,8 +41,8 @@ public class MeshModule {
 	 */
 	@Provides
 	@Singleton
-	public static ImageManipulator imageProvider(io.vertx.reactivex.core.Vertx vertx, MeshOptions options, BootstrapInitializer boot, S3BinaryStorage s3BinaryStorage) {
-		return new ImgscalrImageManipulator(vertx, options, boot, s3BinaryStorage);
+	public static ImageManipulator imageProvider(io.vertx.reactivex.core.Vertx vertx, MeshOptions options, S3BinaryStorage s3BinaryStorage) {
+		return new ImgscalrImageManipulator(vertx, options, s3BinaryStorage);
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/search/SearchEndpointImpl.java
+++ b/core/src/main/java/com/gentics/mesh/search/SearchEndpointImpl.java
@@ -10,11 +10,11 @@ import java.util.function.Function;
 import javax.inject.Inject;
 
 import com.gentics.mesh.auth.MeshAuthChainImpl;
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.HibCoreElement;
 import com.gentics.mesh.core.data.node.HibNode;
 import com.gentics.mesh.core.db.Database;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ListResponse;
 import com.gentics.mesh.core.rest.common.RestModel;
 import com.gentics.mesh.core.rest.group.GroupListResponse;
@@ -42,14 +42,10 @@ import com.gentics.mesh.search.index.tag.TagSearchHandler;
 import com.gentics.mesh.search.index.tagfamily.TagFamilySearchHandler;
 import com.gentics.mesh.search.index.user.UserSearchHandler;
 
-import dagger.Lazy;
-
 /**
  * @see SearchEndpoint
  */
 public class SearchEndpointImpl extends AbstractInternalEndpoint implements SearchEndpoint {
-
-	private Lazy<BootstrapInitializer> boot;
 
 	@Inject
 	AdminIndexHandler adminHandler;
@@ -85,9 +81,8 @@ public class SearchEndpointImpl extends AbstractInternalEndpoint implements Sear
 	Database db;
 
 	@Inject
-	public SearchEndpointImpl(MeshAuthChainImpl chain, NodeSearchHandler searchHandler, Lazy<BootstrapInitializer> boot) {
+	public SearchEndpointImpl(MeshAuthChainImpl chain, NodeSearchHandler searchHandler) {
 		super("search", chain);
-		this.boot = boot;
 	}
 
 	public SearchEndpointImpl() {
@@ -110,32 +105,32 @@ public class SearchEndpointImpl extends AbstractInternalEndpoint implements Sear
 	 * Add various search endpoints using the aggregation nodes.
 	 */
 	private void addSearchEndpoints() {
-		registerHandler("users", (uuid) -> boot.get().userDao().findByUuid(uuid), UserListResponse.class, userSearchHandler,
+		registerHandler("users", (uuid) -> Tx.get().userDao().findByUuid(uuid), UserListResponse.class, userSearchHandler,
 			userExamples.getUserListResponse(), false);
-		registerHandler("groups", (uuid) -> boot.get().groupDao().findByUuid(uuid), GroupListResponse.class, groupSearchHandler,
+		registerHandler("groups", (uuid) -> Tx.get().groupDao().findByUuid(uuid), GroupListResponse.class, groupSearchHandler,
 			groupExamples.getGroupListResponse(), false);
-		registerHandler("roles", (uuid) -> boot.get().roleDao().findByUuid(uuid), RoleListResponse.class, roleSearchHandler,
+		registerHandler("roles", (uuid) -> Tx.get().roleDao().findByUuid(uuid), RoleListResponse.class, roleSearchHandler,
 			roleExamples.getRoleListResponse(), false);
 
 		registerHandler("nodes", (uuid) -> {
-			HibNode node = boot.get().nodeDao().findByUuidGlobal(uuid);
+			HibNode node = Tx.get().nodeDao().findByUuidGlobal(uuid);
 			return node;
 		}, NodeListResponse.class, nodeSearchHandler, nodeExamples.getNodeListResponse(), true);
 
-		registerHandler("tags", (uuid) -> boot.get().tagDao().findByUuid(uuid), TagListResponse.class, tagSearchHandler, tagExamples
+		registerHandler("tags", (uuid) -> Tx.get().tagDao().findByUuid(uuid), TagListResponse.class, tagSearchHandler, tagExamples
 			.createTagListResponse(), false);
-		registerHandler("tagFamilies", (uuid) -> boot.get().tagFamilyDao().findByUuid(uuid), TagFamilyListResponse.class,
+		registerHandler("tagFamilies", (uuid) -> Tx.get().tagFamilyDao().findByUuid(uuid), TagFamilyListResponse.class,
 			tagFamilySearchHandler,
 			tagFamilyExamples.getTagFamilyListResponse(), false);
 
-		registerHandler("projects", (uuid) -> boot.get().projectDao().findByUuid(uuid), ProjectListResponse.class,
+		registerHandler("projects", (uuid) -> Tx.get().projectDao().findByUuid(uuid), ProjectListResponse.class,
 			projectSearchHandler, projectExamples
 				.getProjectListResponse(),
 			false);
-		registerHandler("schemas", (uuid) -> boot.get().schemaDao().findByUuid(uuid), SchemaListResponse.class,
+		registerHandler("schemas", (uuid) -> Tx.get().schemaDao().findByUuid(uuid), SchemaListResponse.class,
 			schemaContainerSearchHandler,
 			schemaExamples.getSchemaListResponse(), false);
-		registerHandler("microschemas", (uuid) -> boot.get().microschemaDao().findByUuid(uuid), MicroschemaListResponse.class,
+		registerHandler("microschemas", (uuid) -> Tx.get().microschemaDao().findByUuid(uuid), MicroschemaListResponse.class,
 			microschemaContainerSearchHandler, microschemaExamples.getMicroschemaListResponse(), false);
 		addAdminHandlers();
 	}

--- a/demo/common/src/main/java/com/gentics/mesh/demo/AbstractDemoDumper.java
+++ b/demo/common/src/main/java/com/gentics/mesh/demo/AbstractDemoDumper.java
@@ -101,7 +101,7 @@ public abstract class AbstractDemoDumper<T extends MeshOptions> extends Abstract
 	public void dump() throws Exception {
 		// Initialise demo data
 		BootstrapInitializer boot = meshInternal.boot();
-		DemoDataProvider provider = new DemoDataProvider(meshInternal.database(), meshInternal.meshLocalClientImpl(), boot);
+		DemoDataProvider provider = new DemoDataProvider(meshInternal.database(), meshInternal.meshLocalClientImpl());
 		invokeDump(boot, provider);
 	}
 

--- a/demo/common/src/main/java/com/gentics/mesh/demo/AbstractDemoRunner.java
+++ b/demo/common/src/main/java/com/gentics/mesh/demo/AbstractDemoRunner.java
@@ -55,7 +55,7 @@ public abstract class AbstractDemoRunner<T extends MeshOptions> extends Abstract
 
 			// Add demo content provider
 			registry.register(DemoAppEndpoint.class);
-			DemoDataProvider data = new DemoDataProvider(meshInternal.database(), meshInternal.meshLocalClientImpl(), meshInternal.boot());
+			DemoDataProvider data = new DemoDataProvider(meshInternal.database(), meshInternal.meshLocalClientImpl());
 			DemoVerticle demoVerticle = new DemoVerticle(meshInternal.boot(), data);
 			DeploymentUtil.deployAndWait(vertx, config, demoVerticle, false);
 

--- a/demo/common/src/main/java/com/gentics/mesh/demo/DemoDataProvider.java
+++ b/demo/common/src/main/java/com/gentics/mesh/demo/DemoDataProvider.java
@@ -87,13 +87,10 @@ public class DemoDataProvider {
 	private Map<String, RoleResponse> roles = new HashMap<>();
 	private Map<String, GroupResponse> groups = new HashMap<>();
 
-	private BootstrapInitializer boot;
-
 	@Inject
-	public DemoDataProvider(Database database, MeshLocalClient client, BootstrapInitializer boot) {
+	public DemoDataProvider(Database database, MeshLocalClient client) {
 		this.db = database;
 		this.client = client;
-		this.boot = boot;
 	}
 
 	/**
@@ -106,8 +103,8 @@ public class DemoDataProvider {
 	 * @throws InterruptedException
 	 */
 	public void setup() throws JsonParseException, JsonMappingException, IOException, MeshSchemaException, InterruptedException {
-		MeshAuthUser user = db.tx(() -> {
-			return boot.userDao().findMeshAuthUserByUsername("admin");
+		MeshAuthUser user = db.tx(tx -> {
+			return tx.userDao().findMeshAuthUserByUsername("admin");
 		});
 		client.setUser(user);
 

--- a/demo/default/src/main/java/com/gentics/mesh/demo/AbstractRunnerNode.java
+++ b/demo/default/src/main/java/com/gentics/mesh/demo/AbstractRunnerNode.java
@@ -59,8 +59,7 @@ public abstract class AbstractRunnerNode extends AbstractMeshOptionsDemoContext<
 			// Add demo content provider
 			registry.register(DemoAppEndpoint.class);
 			DemoVerticle demoVerticle = new DemoVerticle(meshInternal.boot(),
-				new DemoDataProvider(meshInternal.database(), meshInternal.meshLocalClientImpl(),
-					meshInternal.boot()));
+				new DemoDataProvider(meshInternal.database(), meshInternal.meshLocalClientImpl()));
 			DeploymentUtil.deployAndWait(vertx, config, demoVerticle, false);
 
 			// Add admin ui

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/entry/AbstractIndexHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/entry/AbstractIndexHandler.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 import com.gentics.elasticsearch.client.ElasticsearchClient;
 import com.gentics.elasticsearch.client.HttpErrorException;
 import com.gentics.elasticsearch.client.okhttp.RequestBuilder;
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.core.data.Bucket;
 import com.gentics.mesh.core.data.HibBaseElement;
 import com.gentics.mesh.core.data.HibBucketableElement;
@@ -60,8 +59,6 @@ public abstract class AbstractIndexHandler<T extends HibBaseElement> implements 
 
 	protected final Database db;
 
-	protected final BootstrapInitializer boot;
-
 	protected final MeshHelper helper;
 
 	protected final MeshOptions options;
@@ -72,11 +69,10 @@ public abstract class AbstractIndexHandler<T extends HibBaseElement> implements 
 
 	protected final BucketManager bucketManager;
 
-	public AbstractIndexHandler(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public AbstractIndexHandler(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetersFactory, BucketManager bucketManager) {
 		this.searchProvider = searchProvider;
 		this.db = db;
-		this.boot = boot;
 		this.helper = helper;
 		this.options = options;
 		this.complianceMode = options.getSearchOptions().getComplianceMode();

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/group/GroupIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/group/GroupIndexHandlerImpl.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.group.HibGroup;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
@@ -40,9 +39,9 @@ public class GroupIndexHandlerImpl extends AbstractIndexHandler<HibGroup> implem
 	GroupMappingProvider mappingProvider;
 
 	@Inject
-	public GroupIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public GroupIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetersFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetersFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetersFactory, bucketManager);
 	}
 
 	@Override
@@ -86,7 +85,7 @@ public class GroupIndexHandlerImpl extends AbstractIndexHandler<HibGroup> implem
 
 	@Override
 	public Function<String, HibGroup> elementLoader() {
-		return (uuid) -> boot.groupDao().findByUuid(uuid);
+		return (uuid) -> Tx.get().groupDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/microschema/MicroschemaContainerIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/microschema/MicroschemaContainerIndexHandlerImpl.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.HibBucketableElement;
 import com.gentics.mesh.core.data.schema.HibMicroschema;
@@ -44,9 +43,9 @@ public class MicroschemaContainerIndexHandlerImpl extends AbstractIndexHandler<H
 	SyncMetersFactory syncMetersFactory;
 
 	@Inject
-	public MicroschemaContainerIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper,
+	public MicroschemaContainerIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper,
 		MeshOptions options, SyncMetersFactory syncMetricsFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetricsFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetricsFactory, bucketManager);
 	}
 
 	@Override
@@ -93,7 +92,7 @@ public class MicroschemaContainerIndexHandlerImpl extends AbstractIndexHandler<H
 
 	@Override
 	public Function<String, HibMicroschema> elementLoader() {
-		return (uuid) -> boot.microschemaDao().findByUuid(uuid);
+		return (uuid) -> Tx.get().microschemaDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandlerImpl.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.tuple.Triple;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.Bucket;
 import com.gentics.mesh.core.data.HibBucketableElement;
@@ -94,9 +93,9 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	public NodeContainerMappingProviderImpl mappingProvider;
 
 	@Inject
-	public NodeIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public NodeIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetersFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetersFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetersFactory, bucketManager);
 	}
 
 	@Override
@@ -132,8 +131,8 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 			Map<String, IndexInfo> indexInfo = new HashMap<>();
 
 			// Iterate over all projects and construct the index names
-			for (HibProject project : boot.projectDao().findAll()) {
-				for (HibBranch branch : boot.branchDao().findAll(project)) {
+			for (HibProject project : tx.projectDao().findAll()) {
+				for (HibBranch branch : tx.branchDao().findAll(project)) {
 					indexInfo.putAll(getIndices(project, branch).runInExistingTx(tx));
 				}
 			}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/project/ProjectIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/project/ProjectIndexHandlerImpl.java
@@ -12,7 +12,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.project.HibProject;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
@@ -41,9 +40,9 @@ public class ProjectIndexHandlerImpl extends AbstractIndexHandler<HibProject> im
 	ProjectMappingProvider mappingProvider;
 
 	@Inject
-	public ProjectIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public ProjectIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetricsFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetricsFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetricsFactory, bucketManager);
 	}
 
 	@Override
@@ -93,7 +92,7 @@ public class ProjectIndexHandlerImpl extends AbstractIndexHandler<HibProject> im
 
 	@Override
 	public Function<String, HibProject> elementLoader() {
-		return (uuid) -> boot.projectDao().findByUuid(uuid);
+		return (uuid) -> Tx.get().projectDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/role/RoleIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/role/RoleIndexHandlerImpl.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
@@ -41,9 +40,9 @@ public class RoleIndexHandlerImpl extends AbstractIndexHandler<HibRole>  impleme
 	RoleMappingProvider mappingProvider;
 
 	@Inject
-	public RoleIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public RoleIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetricsFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetricsFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetricsFactory, bucketManager);
 	}
 
 	@Override
@@ -97,7 +96,7 @@ public class RoleIndexHandlerImpl extends AbstractIndexHandler<HibRole>  impleme
 
 	@Override
 	public Function<String, HibRole> elementLoader() {
-		return (uuid) -> boot.roleDao().findByUuid(uuid);
+		return (uuid) -> Tx.get().roleDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/schema/SchemaContainerIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/schema/SchemaContainerIndexHandlerImpl.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.schema.HibSchema;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
@@ -41,9 +40,9 @@ public class SchemaContainerIndexHandlerImpl extends AbstractIndexHandler<HibSch
 	SchemaMappingProvider mappingProvider;
 
 	@Inject
-	public SchemaContainerIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public SchemaContainerIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetricsFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetricsFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetricsFactory, bucketManager);
 	}
 
 	@Override
@@ -97,7 +96,7 @@ public class SchemaContainerIndexHandlerImpl extends AbstractIndexHandler<HibSch
 
 	@Override
 	public Function<String, HibSchema> elementLoader() {
-		return (uuid) -> boot.schemaDao().findByUuid(uuid);
+		return (uuid) -> Tx.get().schemaDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/tag/TagIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/tag/TagIndexHandlerImpl.java
@@ -14,7 +14,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.dao.ProjectDao;
 import com.gentics.mesh.core.data.project.HibProject;
@@ -50,9 +49,9 @@ public class TagIndexHandlerImpl extends AbstractIndexHandler<HibTag> implements
 	TagMappingProvider mappingProvider;
 
 	@Inject
-	public TagIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public TagIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetricsFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetricsFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetricsFactory, bucketManager);
 	}
 
 	@Override
@@ -84,9 +83,9 @@ public class TagIndexHandlerImpl extends AbstractIndexHandler<HibTag> implements
 
 	@Override
 	public Map<String, IndexInfo> getIndices() {
-		return db.tx(() -> {
+		return db.tx(tx -> {
 			Map<String, IndexInfo> indexInfo = new HashMap<>();
-			for (HibProject project : boot.projectDao().findAll()) {
+			for (HibProject project : tx.projectDao().findAll()) {
 				IndexInfo info = getIndex(project.getUuid());
 				indexInfo.put(info.getIndexName(), info);
 			}
@@ -106,8 +105,8 @@ public class TagIndexHandlerImpl extends AbstractIndexHandler<HibTag> implements
 
 	@Override
 	public Flowable<SearchRequest> syncIndices(Optional<Pattern> indexPattern) {
-		return Flowable.defer(() -> db.tx(() -> {
-			return boot.projectDao().findAll().stream()
+		return Flowable.defer(() -> db.tx(tx -> {
+			return tx.projectDao().findAll().stream()
 				.map(project -> {
 					String uuid = project.getUuid();
 					return diffAndSync(HibTag.composeIndexName(uuid), uuid, indexPattern);
@@ -144,7 +143,7 @@ public class TagIndexHandlerImpl extends AbstractIndexHandler<HibTag> implements
 
 	@Override
 	public Function<String, HibTag> elementLoader() {
-		return uuid -> boot.tagDao().findByUuid(uuid);
+		return uuid -> Tx.get().tagDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/user/UserIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/user/UserIndexHandlerImpl.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.search.index.IndexInfo;
 import com.gentics.mesh.core.data.search.request.SearchRequest;
@@ -43,9 +42,9 @@ public class UserIndexHandlerImpl extends AbstractIndexHandler<HibUser> implemen
 	UserMappingProvider mappingProvider;
 
 	@Inject
-	public UserIndexHandlerImpl(SearchProvider searchProvider, Database db, BootstrapInitializer boot, MeshHelper helper, MeshOptions options,
+	public UserIndexHandlerImpl(SearchProvider searchProvider, Database db, MeshHelper helper, MeshOptions options,
 		SyncMetersFactory syncMetricsFactory, BucketManager bucketManager) {
-		super(searchProvider, db, boot, helper, options, syncMetricsFactory, bucketManager);
+		super(searchProvider, db, helper, options, syncMetricsFactory, bucketManager);
 	}
 
 	@Override
@@ -92,7 +91,7 @@ public class UserIndexHandlerImpl extends AbstractIndexHandler<HibUser> implemen
 
 	@Override
 	public Function<String, HibUser> elementLoader() {
-		return uuid -> boot.userDao().findByUuid(uuid);
+		return uuid -> Tx.get().userDao().findByUuid(uuid);
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/GroupUserAssignmentHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/GroupUserAssignmentHandler.java
@@ -41,8 +41,8 @@ public class GroupUserAssignmentHandler implements EventHandler {
 	public Flowable<? extends SearchRequest> handle(MessageEvent messageEvent) {
 		return Flowable.defer(() -> {
 			GroupUserAssignModel model = requireType(GroupUserAssignModel.class, messageEvent.message);
-			return Flowable.just(helper.getDb().tx(() -> {
-				HibUser user = helper.getBoot().userDao().findByUuid(model.getUser().getUuid());
+			return Flowable.just(helper.getDb().tx(tx -> {
+				HibUser user = tx.userDao().findByUuid(model.getUser().getUuid());
 				return entities.createRequest(user);
 			}));
 		});

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/TagEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/TagEventHandler.java
@@ -15,11 +15,11 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.core.data.dao.TagDao;
 import com.gentics.mesh.core.data.search.request.CreateDocumentRequest;
 import com.gentics.mesh.core.data.search.request.SearchRequest;
 import com.gentics.mesh.core.data.tag.HibTag;
 import com.gentics.mesh.core.data.tagfamily.HibTagFamily;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.event.MeshProjectElementEventModel;
 import com.gentics.mesh.etc.config.MeshOptions;
@@ -87,10 +87,10 @@ public class TagEventHandler implements EventHandler {
 	}
 
 	private Stream<CreateDocumentRequest> taggedNodes(MeshProjectElementEventModel model, HibTag tag) {
-		TagDao tagDao = helper.getBoot().tagDao();
-		return findElementByUuidStream(helper.getBoot().projectDao(), model.getProject().getUuid())
-			.flatMap(project -> helper.getBoot().branchDao().findAll(project).stream()
-			.flatMap(branch -> tagDao.getNodes(tag, branch).stream()
+		Tx tx = Tx.get();
+		return findElementByUuidStream(tx.projectDao(), model.getProject().getUuid())
+			.flatMap(project -> tx.branchDao().findAll(project).stream()
+			.flatMap(branch -> tx.tagDao().getNodes(tag, branch).stream()
 			.flatMap(node -> entities.generateNodeRequests(node.getUuid(), project, branch))));
 	}
 }

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/TagFamilyEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/TagFamilyEventHandler.java
@@ -17,6 +17,7 @@ import javax.inject.Singleton;
 import com.gentics.mesh.core.data.dao.TagDao;
 import com.gentics.mesh.core.data.search.request.SearchRequest;
 import com.gentics.mesh.core.data.tagfamily.HibTagFamily;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.event.MeshProjectElementEventModel;
 import com.gentics.mesh.core.rest.event.ProjectEvent;
@@ -99,12 +100,12 @@ public class TagFamilyEventHandler implements EventHandler {
 	 * @return
 	 */
 	private Stream<SearchRequest> createNodeUpdates(MeshProjectElementEventModel model, HibTagFamily tagFamily) {
-		TagDao tagDao = helper.getBoot().tagDao();
-		return findElementByUuidStream(helper.getBoot().projectDao(), model.getProject().getUuid())
-			.flatMap(project -> helper.getBoot().branchDao().findAll(project).stream()
+		Tx tx = Tx.get();
+		return findElementByUuidStream(tx.projectDao(), model.getProject().getUuid())
+			.flatMap(project -> tx.branchDao().findAll(project).stream()
 				.flatMap(branch -> {
-					return tagDao.findAll(tagFamily).stream()
-						.flatMap(tag -> tagDao.getNodes(tag, branch).stream())
+					return tx.tagDao().findAll(tagFamily).stream()
+						.flatMap(tag -> tx.tagDao().getNodes(tag, branch).stream())
 						.flatMap(node -> entities.generateNodeRequests(node.getUuid(), project, branch));
 				}));
 	}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/node/NodeMoveEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/node/NodeMoveEventHandler.java
@@ -45,8 +45,8 @@ public class NodeMoveEventHandler implements EventHandler {
 		return Flowable.defer(() -> {
 			NodeMovedEventModel model = requireType(NodeMovedEventModel.class, messageEvent.message);
 			return helper.getDb().transactional(tx -> {
-				return findElementByUuidStream(helper.getBoot().projectDao(), model.getProject().getUuid())
-					.flatMap(project -> findElementByUuidStream(helper.getBoot().branchDao(), project, model.getBranchUuid())
+				return findElementByUuidStream(tx.projectDao(), model.getProject().getUuid())
+					.flatMap(project -> findElementByUuidStream(tx.branchDao(), project, model.getBranchUuid())
 						.flatMap(branch -> entities.generateNodeRequests(model.getUuid(), project, branch)))
 					.collect(toFlowable());
 			}).runInNewTx();

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/node/NodeTagEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/node/NodeTagEventHandler.java
@@ -47,9 +47,8 @@ public class NodeTagEventHandler implements EventHandler {
 		return Flowable.defer(() -> {
 			NodeTaggedEventModel model = requireType(NodeTaggedEventModel.class, messageEvent.message);
 			return helper.getDb().transactional(tx -> {
-				// ProjectDaoWrapper projectDao = tx.projectDao();
-				return findElementByUuidStream(helper.getBoot().projectDao(), model.getProject().getUuid())
-					.flatMap(project -> findElementByUuidStream(helper.getBoot().branchDao(), project, model.getBranch().getUuid())
+				return findElementByUuidStream(tx.projectDao(), model.getProject().getUuid())
+					.flatMap(project -> findElementByUuidStream(tx.branchDao(), project, model.getBranch().getUuid())
 						.flatMap(branch -> entities.generateNodeRequests(model.getNode().getUuid(), project, branch)))
 					.collect(toFlowable());
 			}).runInNewTx();

--- a/mdm/api/src/main/java/com/gentics/mesh/cli/BootstrapInitializer.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/cli/BootstrapInitializer.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.gentics.mesh.Mesh;
 import com.gentics.mesh.annotation.Getter;
 import com.gentics.mesh.core.data.changelog.HighLevelChange;
-import com.gentics.mesh.core.data.dao.*;
 import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.root.RootResolver;
 import com.gentics.mesh.etc.MeshCustomLoader;
@@ -22,51 +21,6 @@ import io.vertx.core.Vertx;
  * GroupDao, UserDao and various element such as the Admin User, Admin Group, Admin Role.
  */
 public interface BootstrapInitializer {
-
-	@Getter
-	ProjectDao projectDao();
-
-	@Getter
-	BranchDao branchDao();
-
-	@Getter
-	LanguageDao languageDao();
-
-	@Getter
-	GroupDao groupDao();
-
-	@Getter
-	UserDao userDao();
-
-	@Getter
-	JobDao jobDao();
-
-	@Getter
-	TagFamilyDao tagFamilyDao();
-
-	@Getter
-	TagDao tagDao();
-
-	@Getter
-	RoleDao roleDao();
-
-	@Getter
-	MicroschemaDao microschemaDao();
-
-	@Getter
-	SchemaDao schemaDao();
-
-	@Getter
-	NodeDao nodeDao();
-
-	@Getter
-	ContentDao contentDao();
-
-	@Getter
-	BinaryDao binaryDao();
-
-	@Getter
-	S3BinaryDao s3binaryDao();
 
 	@Getter
 	RootResolver rootResolver();

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/changelog/highlevel/change/FixNodeVersionOrder.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/changelog/highlevel/change/FixNodeVersionOrder.java
@@ -16,7 +16,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.gentics.mesh.changelog.highlevel.AbstractHighLevelChange;
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.NodeMigrationActionContext;
 import com.gentics.mesh.context.impl.NodeMigrationActionContextImpl;
 import com.gentics.mesh.core.data.GraphFieldContainerEdge;
@@ -34,7 +33,6 @@ import com.gentics.mesh.util.VersionNumber;
 import com.google.common.collect.Iterables;
 import com.syncleus.ferma.EdgeFrame;
 
-import dagger.Lazy;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -52,11 +50,8 @@ import io.vertx.core.logging.LoggerFactory;
 public class FixNodeVersionOrder extends AbstractHighLevelChange {
 	public static final Logger log = LoggerFactory.getLogger(FixNodeVersionOrder.class);
 
-	private final Lazy<BootstrapInitializer> boot;
-
 	@Inject
-	public FixNodeVersionOrder(Lazy<BootstrapInitializer> boot) {
-		this.boot = boot;
+	public FixNodeVersionOrder() {
 	}
 
 	@Override
@@ -86,7 +81,7 @@ public class FixNodeVersionOrder extends AbstractHighLevelChange {
 				if (count != 0 && count % 1000 == 0) {
 					log.info("Checked {} nodes. Found and fixed {} broken nodes", count, fixedNodes.get());
 				}
-				boot.get().contentDao().getFieldContainers(node, ContainerType.INITIAL).stream()
+				Tx.get().contentDao().getFieldContainers(node, ContainerType.INITIAL).stream()
 					.forEach(content -> {
 						boolean mutated = fixNodeVersionOrder(context, toGraph(node), toGraph(content));
 						if (mutated) {
@@ -106,7 +101,7 @@ public class FixNodeVersionOrder extends AbstractHighLevelChange {
 	}
 
 	private boolean fixNodeVersionOrder(NodeMigrationActionContext context, Node node, NodeGraphFieldContainer initialContent) {
-		ContentDao contentDao = boot.get().contentDao();
+		ContentDao contentDao = Tx.get().contentDao();
 		Set<VersionNumber> seenVersions = new HashSet<>();
 		TreeSet<HibNodeFieldContainer> versions = new TreeSet<>(Comparator.comparing(HibNodeFieldContainer::getVersion));
 		HibNodeFieldContainer highestVersion = null;

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/NodeDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/NodeDaoWrapperImpl.java
@@ -145,13 +145,13 @@ public class NodeDaoWrapperImpl extends AbstractRootDaoWrapper<NodeResponse, Hib
 	public Map<HibNode, List<NodeContent>> getChildren(Set<HibNode> nodes, InternalActionContext ac, String branchUuid, List<String> languageTags, ContainerType type) {
 		HibUser user = ac.getUser();
 		return nodes.stream()
-				.map(node -> Pair.of(node, getContentFromNode(user, node, branchUuid, languageTags, type)))
+				.map(node -> Pair.of(node, getContentFromNode(Tx.get(), user, node, branchUuid, languageTags, type)))
 				.collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 	}
 
-	private List<NodeContent> getContentFromNode(HibUser user, HibNode sourceNode, String branchUuid, List<String> languageTags, ContainerType type) {
-		UserDao userDao = Tx.get().userDao();
-		ContentDao contentDao = boot.get().contentDao();
+	private List<NodeContent> getContentFromNode(Tx tx, HibUser user, HibNode sourceNode, String branchUuid, List<String> languageTags, ContainerType type) {
+		UserDao userDao = tx.userDao();
+		ContentDao contentDao = tx.contentDao();
 		return toGraph(sourceNode).getChildren(branchUuid)
 				.stream()
 				.filter(node -> userDao.hasPermissionForId(user, node.getId(), type == PUBLISHED ? READ_PUBLISHED_PERM : READ_PERM))

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/generic/GraphUserPropertiesImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/generic/GraphUserPropertiesImpl.java
@@ -9,9 +9,9 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.core.data.HibBaseElement;
 import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.GraphDBTx;
 import com.gentics.mesh.graphdb.model.MeshElement;
 
 /**
@@ -22,11 +22,8 @@ import com.gentics.mesh.graphdb.model.MeshElement;
 @Singleton
 public class GraphUserPropertiesImpl implements UserProperties {
 
-	private final BootstrapInitializer boot;
-
 	@Inject
-	public GraphUserPropertiesImpl(BootstrapInitializer boot) {
-		this.boot = boot;
+	public GraphUserPropertiesImpl() {
 	}
 
 	@Override
@@ -57,10 +54,11 @@ public class GraphUserPropertiesImpl implements UserProperties {
 		}
 	}
 
+	@SuppressWarnings("resource")
 	private HibUser getUser(MeshElement element, String propertyKey) {
 		return Optional.ofNullable(element)
 			.map(v -> v.<String>getProperty(propertyKey))
-			.map(boot.userDao()::findByUuid)
+			.map(GraphDBTx.getGraphTx().userDao()::findByUuid)
 			.orElse(null);
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/ProjectImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/ProjectImpl.java
@@ -38,6 +38,7 @@ import com.gentics.mesh.core.data.root.impl.ProjectSchemaContainerRootImpl;
 import com.gentics.mesh.core.data.root.impl.TagFamilyRootImpl;
 import com.gentics.mesh.core.data.search.BucketableElementHelper;
 import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.project.ProjectResponse;
 import com.gentics.mesh.core.result.Result;
 import com.gentics.mesh.event.EventQueueBatch;
@@ -153,7 +154,7 @@ public class ProjectImpl extends AbstractMeshCoreVertex<ProjectResponse> impleme
 	@Override
 	@Deprecated
 	public void delete(BulkActionContext bac) {
-		ProjectDao projectDao = mesh().boot().projectDao();
+		ProjectDao projectDao = Tx.get().projectDao();
 		projectDao.delete(this, bac);
 	}
 
@@ -184,7 +185,7 @@ public class ProjectImpl extends AbstractMeshCoreVertex<ProjectResponse> impleme
 
 	@Override
 	public String getSubETag(InternalActionContext ac) {
-		ProjectDao projectRoot = mesh().boot().projectDao();
+		ProjectDao projectRoot = Tx.get().projectDao();
 		return projectRoot.getSubETag(this, ac);
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/RoleImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/RoleImpl.java
@@ -14,6 +14,7 @@ import com.gentics.mesh.core.data.generic.MeshVertexImpl;
 import com.gentics.mesh.core.data.group.HibGroup;
 import com.gentics.mesh.core.data.search.BucketableElementHelper;
 import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.role.RoleReference;
 import com.gentics.mesh.core.rest.role.RoleResponse;
 import com.gentics.mesh.core.result.Result;
@@ -60,13 +61,13 @@ public class RoleImpl extends AbstractMeshCoreVertex<RoleResponse> implements Ro
 
 	@Override
 	public void delete(BulkActionContext bac) {
-		RoleDao roleDao = mesh().boot().roleDao();
+		RoleDao roleDao = Tx.get().roleDao();
 		roleDao.delete(this, bac);
 	}
 
 	@Override
 	public boolean update(InternalActionContext ac, EventQueueBatch batch) {
-		RoleDao roleDao = mesh().boot().roleDao();
+		RoleDao roleDao = Tx.get().roleDao();
 		return roleDao.update(this, ac, batch);
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/TagFamilyImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/TagFamilyImpl.java
@@ -108,13 +108,13 @@ public class TagFamilyImpl extends AbstractMeshCoreVertex<TagFamilyResponse> imp
 
 	@Override
 	public Tag create(InternalActionContext ac, EventQueueBatch batch) {
-		return toGraph(mesh().boot().tagDao().create(this, ac, batch));
+		return toGraph(Tx.get().tagDao().create(this, ac, batch));
 	}
 
 	@Override
 	@Deprecated
 	public Tag create(InternalActionContext ac, EventQueueBatch batch, String uuid) {
-		return toGraph(mesh().boot().tagDao().create(this, ac, batch, uuid));
+		return toGraph(Tx.get().tagDao().create(this, ac, batch, uuid));
 	}
 
 	@Override

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/TagImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/TagImpl.java
@@ -88,7 +88,7 @@ public class TagImpl extends AbstractMeshCoreVertex<TagResponse> implements Tag 
 
 	@Override
 	public String getSubETag(InternalActionContext ac) {
-		TagDao tagRoot = mesh().boot().tagDao();
+		TagDao tagRoot = Tx.get().tagDao();
 		return tagRoot.getSubETag(this, ac);
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -284,7 +284,7 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse> implements Us
 	@Override
 	public User addGroup(Group group) {
 		// Redirect to group implementation
-		mesh().boot().groupDao().addUser(group, this);
+		Tx.get().groupDao().addUser(group, this);
 		return this;
 	}
 
@@ -301,7 +301,7 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse> implements Us
 
 	@Override
 	public void delete(BulkActionContext bac) {
-		UserDao userDao = mesh().boot().userDao();
+		UserDao userDao = Tx.get().userDao();
 		userDao.delete(this, bac);
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/root/impl/AbstractRootVertex.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/root/impl/AbstractRootVertex.java
@@ -18,6 +18,7 @@ import com.gentics.mesh.core.data.generic.MeshVertexImpl;
 import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.root.RootVertex;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.GenericRestResponse;
 import com.gentics.mesh.core.rest.common.PermissionInfo;
 import com.gentics.mesh.core.rest.common.RestModel;
@@ -57,12 +58,12 @@ public abstract class AbstractRootVertex<T extends MeshCoreVertex<? extends Rest
 
 	@Override
 	public PermissionInfo getRolePermissions(HibBaseElement element, InternalActionContext ac, String roleUuid) {
-		return mesh().boot().roleDao().getRolePermissions(element, ac, roleUuid);
+		return Tx.get().roleDao().getRolePermissions(element, ac, roleUuid);
 	}
 
 	@Override
 	public Result<? extends HibRole> getRolesWithPerm(HibBaseElement vertex, InternalPermission perm) {
-		return mesh().boot().roleDao().getRolesWithPerm(vertex, perm);
+		return Tx.get().roleDao().getRolesWithPerm(vertex, perm);
 	}
 
 	/**
@@ -96,8 +97,8 @@ public abstract class AbstractRootVertex<T extends MeshCoreVertex<? extends Rest
 	 * @return
 	 */
 	public final String getETag(T element, InternalActionContext ac) {
-		UserDao userDao = mesh().boot().userDao();
-		RoleDao roleDao = mesh().boot().roleDao();
+		UserDao userDao = Tx.get().userDao();
+		RoleDao roleDao = Tx.get().roleDao();
 
 		StringBuilder keyBuilder = new StringBuilder();
 		keyBuilder.append(getUuid());

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/root/impl/NodeRootImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/root/impl/NodeRootImpl.java
@@ -96,7 +96,7 @@ public class NodeRootImpl extends AbstractRootVertex<Node> implements NodeRoot {
 	public Stream<? extends Node> findAllStream(InternalActionContext ac, InternalPermission perm) {
 		Tx tx = Tx.get();
 		HibUser user = ac.getUser();
-		UserDao userDao = mesh().boot().userDao();
+		UserDao userDao = tx.userDao();
 
 		return findAll(tx.getProject(ac).getUuid())
 			.filter(item -> userDao.hasPermissionForId(user, item.getId(), perm))
@@ -122,7 +122,7 @@ public class NodeRootImpl extends AbstractRootVertex<Node> implements NodeRoot {
 
 		HibBranch branch = Tx.get().getBranch(ac);
 		String branchUuid = branch.getUuid();
-		UserDao userDao = mesh().boot().userDao();
+		UserDao userDao = Tx.get().userDao();
 
 		return findAll(Tx.get().getProject(ac).getUuid()).filter(item -> {
 			// Check whether the node has at least one content of the type in the selected branch - Otherwise the node should be skipped

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/SchemaContainerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/SchemaContainerImpl.java
@@ -11,6 +11,7 @@ import com.gentics.mesh.core.data.schema.Schema;
 import com.gentics.mesh.core.data.schema.SchemaVersion;
 import com.gentics.mesh.core.data.search.BucketableElementHelper;
 import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.schema.SchemaReference;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
@@ -49,7 +50,7 @@ public class SchemaContainerImpl extends
 
 	@Override
 	public void delete(BulkActionContext bac) {
-		mesh().boot().schemaDao().delete(this, bac);
+		Tx.get().schemaDao().delete(this, bac);
 	}
 
 	@Override

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/endpoint/admin/OrientDBAdminHandler.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/endpoint/admin/OrientDBAdminHandler.java
@@ -31,6 +31,7 @@ import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.project.HibProject;
 import com.gentics.mesh.core.db.Database;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.endpoint.admin.consistency.ConsistencyCheckHandler;
 import com.gentics.mesh.core.rest.error.GenericRestException;
 import com.gentics.mesh.core.verticle.handler.HandlerUtilities;
@@ -129,7 +130,7 @@ public class OrientDBAdminHandler extends AdminHandler {
 			routerStorage.root().apiRouter().projectsRouter().getProjectRouters().clear();
 		}).andThen(db.asyncTx(() -> {
 			// Update the routes by loading the projects
-			initProjects();
+			initProjects(Tx.get());
 			return Single.just(message(ac, "restore_finished"));
 		})).doFinally(() -> {
 			mesh.setStatus(oldStatus);
@@ -184,8 +185,8 @@ public class OrientDBAdminHandler extends AdminHandler {
 	 *
 	 * @throws InvalidNameException
 	 */
-	private void initProjects() throws InvalidNameException {
-		for (HibProject project : boot.projectDao().findAll()) {
+	private void initProjects(Tx tx) throws InvalidNameException {
+		for (HibProject project : tx.projectDao().findAll()) {
 			routerStorageRegistry.addProject(project.getName());
 			if (log.isDebugEnabled()) {
 				log.debug("Initalized project {" + project.getName() + "}");

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/check/GraphFieldContainerCheck.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/endpoint/admin/consistency/check/GraphFieldContainerCheck.java
@@ -176,10 +176,9 @@ public class GraphFieldContainerCheck extends AbstractConsistencyCheck {
 	public boolean repair(HibNodeFieldContainer hibContainer) {
 		NodeGraphFieldContainer container = toGraph(hibContainer);
 		MeshComponent mesh = container.getGraphAttribute(GraphAttribute.MESH_COMPONENT);
-		BootstrapInitializer boot = mesh.boot();
 		// Pick the first project we find to fetch the initial branchUuid
-		HibProject project = boot.projectDao().findAll().iterator().next();
-		String branchUuid = boot.branchDao().getInitialBranch(project).getUuid();
+		HibProject project = Tx.get().projectDao().findAll().iterator().next();
+		String branchUuid = Tx.get().branchDao().getInitialBranch(project).getUuid();
 
 		HibSchemaVersion version = container.getSchemaContainerVersion();
 		if (version == null) {

--- a/tests/context-orientdb/src/main/java/com/gentics/mesh/core/node/OrientDBNodeEndpointTest.java
+++ b/tests/context-orientdb/src/main/java/com/gentics/mesh/core/node/OrientDBNodeEndpointTest.java
@@ -68,7 +68,7 @@ public class OrientDBNodeEndpointTest extends AbstractMeshTest {
 		// assert that the containers have both webrootpath properties set
 		try (Tx tx1 = tx()) {
 			for (String language : Arrays.asList("en", "de")) {
-				NodeGraphFieldContainer container = (NodeGraphFieldContainer) boot().contentDao().getFieldContainer(folder("products"), language);
+				NodeGraphFieldContainer container = (NodeGraphFieldContainer) tx1.contentDao().getFieldContainer(folder("products"), language);
 				GraphFieldContainerEdge draftEdge = container.getContainerEdge(DRAFT, initialBranchUuid()).next();
 				assertThat(draftEdge.getSegmentInfo()).isNotNull();
 				GraphFieldContainerEdge publishEdge = container.getContainerEdge(PUBLISHED, initialBranchUuid()).next();
@@ -82,7 +82,7 @@ public class OrientDBNodeEndpointTest extends AbstractMeshTest {
 		// assert that the containers have only the draft webrootpath properties set
 		try (Tx tx2 = tx()) {
 			for (String language : Arrays.asList("en", "de")) {
-				NodeGraphFieldContainer container = (NodeGraphFieldContainer) boot().contentDao().getFieldContainer(folder("products"), language);
+				NodeGraphFieldContainer container = (NodeGraphFieldContainer) tx2.contentDao().getFieldContainer(folder("products"), language);
 				GraphFieldContainerEdge draftEdge = container.getContainerEdge(DRAFT, initialBranchUuid()).next();
 				assertThat(draftEdge.getSegmentInfo()).isNotNull();
 				assertFalse(container.getContainerEdge(PUBLISHED, initialBranchUuid()).hasNext());

--- a/tests/tests-core/src/main/java/com/gentics/mesh/auth/AbstractOAuthTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/auth/AbstractOAuthTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractOAuthTest extends AbstractMeshTest {
 	}
 
 	protected void assertGroupRoles(String groupName, String... expectedRoles) {
-		String groupUuid = tx(() -> boot().groupDao().findByName(groupName).getUuid());
+		String groupUuid = tx(tx -> { return tx.groupDao().findByName(groupName).getUuid(); });
 		RoleListResponse rolesForGroup = call(() -> client().findRolesForGroup(groupUuid));
 		List<String> roleNamesOfGroup = rolesForGroup.getData().stream().map(r -> r.getName()).collect(Collectors.toList());
 		assertThat(roleNamesOfGroup).as("Roles of group {" + groupName + "}").containsExactlyInAnyOrder(expectedRoles);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/auth/OAuth2KeycloakPluginTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/auth/OAuth2KeycloakPluginTest.java
@@ -81,10 +81,10 @@ public class OAuth2KeycloakPluginTest extends AbstractOAuthTest {
 		assertNotNull(tx(tx -> {
 			return tx.groupDao().findByName("group1");
 		}));
-		assertNotNull(tx(() -> boot().groupDao().findByName("group2")));
+		assertNotNull(tx(tx -> { return tx.groupDao().findByName("group2"); }));
 
-		assertNotNull(tx(() -> boot().roleDao().findByName("role1")));
-		assertNotNull(tx(() -> boot().roleDao().findByName("role2")));
+		assertNotNull(tx(tx -> { return tx.roleDao().findByName("role1"); }));
+		assertNotNull(tx(tx -> { return tx.roleDao().findByName("role2"); }));
 
 		// Invoke request without token
 		JsonObject meJson = new JsonObject(get(MeshVersion.CURRENT_API_BASE_PATH + "/auth/me"));
@@ -241,12 +241,12 @@ public class OAuth2KeycloakPluginTest extends AbstractOAuthTest {
 		setAdminToken();
 
 		// Apply permissions
-		String role1Uuid = tx(() -> boot().roleDao().findByName("role1").getUuid());
+		String role1Uuid = tx(tx -> { return tx.roleDao().findByName("role1").getUuid(); });
 		RolePermissionRequest updateRequest = new RolePermissionRequest().setRecursive(true);
 		updateRequest.getPermissions().setRead(true);
 		call(() -> client().updateRolePermissions(role1Uuid, "projects/" + projectUuid(), updateRequest));
 		// Assign the role to the group
-		String groupUuid = tx(() -> boot().groupDao().findByName("group1").getUuid());
+		String groupUuid = tx(tx -> { return tx.groupDao().findByName("group1").getUuid(); });
 		call(() -> client().addRoleToGroup(groupUuid, role1Uuid));
 
 		// Reset the keycloak token

--- a/tests/tests-core/src/main/java/com/gentics/mesh/cli/MeshMeshIntegrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/cli/MeshMeshIntegrationTest.java
@@ -45,11 +45,11 @@ public abstract class MeshMeshIntegrationTest<T extends MeshOptions> implements 
 		MeshComponent meshInternalB = meshB.internal();
 		assertNotEquals(meshInternalA, meshInternalB);
 		assertNotEquals(meshInternalA.boot(), meshInternalB.boot());
-		meshInternalA.database().tx(() -> {
-			System.out.println("Admin in A: " + meshInternalA.boot().userDao().findByName("admin").getUuid());
+		meshInternalA.database().tx(tx -> {
+			System.out.println("Admin in A: " + tx.userDao().findByName("admin").getUuid());
 		});
-		meshInternalB.database().tx(() -> {
-			System.out.println("Admin in B: " + meshInternalB.boot().userDao().findByName("admin").getUuid());
+		meshInternalB.database().tx(tx -> {
+			System.out.println("Admin in B: " + tx.userDao().findByName("admin").getUuid());
 		});
 
 		meshA.shutdown();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/MultithreadGraphTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/MultithreadGraphTest.java
@@ -32,10 +32,10 @@ public class MultithreadGraphTest extends AbstractMeshTest {
 			try (Tx tx = tx()) {
 				// fg.getEdges();
 				runAndWait(() -> {
-					HibUser user = boot().userDao().findByUsername("test");
+					HibUser user = tx.userDao().findByUsername("test");
 					assertNotNull(user);
 				});
-				HibUser user = boot().userDao().findByUsername("test");
+				HibUser user = tx.userDao().findByUsername("test");
 				assertNotNull(user);
 				System.out.println("Read user");
 
@@ -43,7 +43,7 @@ public class MultithreadGraphTest extends AbstractMeshTest {
 		});
 
 		try (Tx tx = tx()) {
-			HibUser user = boot().userDao().findByUsername("test");
+			HibUser user = tx.userDao().findByUsername("test");
 			assertNotNull(user);
 		}
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/branch/BranchMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/branch/BranchMigrationEndpointTest.java
@@ -87,7 +87,7 @@ public class BranchMigrationEndpointTest extends AbstractMeshTest {
 		}
 		nodes.forEach(node -> {
 			Arrays.asList(ContainerType.INITIAL, ContainerType.DRAFT, ContainerType.PUBLISHED).forEach(type -> {
-				assertThat(tx(() -> boot().contentDao().getFieldContainers(node, newBranch, type).list()))
+				assertThat(tx(() -> Tx.get().contentDao().getFieldContainers(node, newBranch, type).list()))
 					.as(type + " Field Containers before Migration").isNotNull()
 					.isEmpty();
 			});
@@ -101,17 +101,17 @@ public class BranchMigrationEndpointTest extends AbstractMeshTest {
 			assertThat(newBranchReloaded.isMigrated()).as("Branch migration status").isEqualTo(true);
 			nodes.forEach(node -> {
 				Arrays.asList(ContainerType.INITIAL, ContainerType.DRAFT).forEach(type -> {
-					assertThat(boot().contentDao().getFieldContainers(node, newBranchReloaded, type)).as(type + " Field Containers after Migration")
+					assertThat(tx.contentDao().getFieldContainers(node, newBranchReloaded, type)).as(type + " Field Containers after Migration")
 						.isNotNull()
 						.isNotEmpty();
 				});
 
 				if (published.contains(node)) {
-					assertThat(boot().contentDao().getFieldContainers(node, newBranchReloaded, ContainerType.PUBLISHED))
+					assertThat(tx.contentDao().getFieldContainers(node, newBranchReloaded, ContainerType.PUBLISHED))
 						.as("Published field containers after migration")
 						.isNotNull().isNotEmpty();
 				} else {
-					assertThat(boot().contentDao().getFieldContainers(node, newBranchReloaded, ContainerType.PUBLISHED))
+					assertThat(tx.contentDao().getFieldContainers(node, newBranchReloaded, ContainerType.PUBLISHED))
 						.as("Published field containers after migration")
 						.isNotNull().isEmpty();
 				}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/AbstractFieldTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/AbstractFieldTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractFieldTest<FS extends FieldSchema> extends Abstract
 		nodeDao.setParentNode(node, branch.getUuid(), nodeDao.findByUuidGlobal(project().getBaseNode().getUuid()));
 		EventQueueBatch batch = Mockito.mock(EventQueueBatch.class);
 		Tx.get().branchDao().assignSchemaVersion(branch, user(), version, batch);
-		HibNodeFieldContainer nodeContainer = boot().contentDao().createFieldContainer(node, english(), branch, user());
+		HibNodeFieldContainer nodeContainer = Tx.get().contentDao().createFieldContainer(node, english(), branch, user());
 
 		return Tuple.tuple(node, nodeContainer);
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
@@ -99,7 +99,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 		// 1. Upload a binary field
 		String uuid = tx(() -> folder("2015").getUuid());
 		Buffer buffer = TestUtils.randomBuffer(1000);
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion(); });
 		NodeResponse responseA = call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, "en", version.toString(), FIELD_NAME,
 			new ByteArrayInputStream(buffer.getBytes()), buffer.length(),
 			"filename.txt", "application/binary"));
@@ -125,7 +125,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 			// 1. Upload a binary field
 			String uuid = tx(() -> folder("2015").getUuid());
 			Buffer buffer = TestUtils.randomBuffer(1000);
-			VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+			VersionNumber version = tx(() -> tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion());
 			call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, "en", version.toString(), FIELD_NAME,
 				new ByteArrayInputStream(buffer.getBytes()), buffer.length(), "filename.txt",
 				"application/binary"));
@@ -151,7 +151,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 
 		// 1. Upload a binary field
 		String uuid = tx(() -> folder("2015").getUuid());
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion(); });
 
 		call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, "en", version.toString(), FIELD_NAME,
 			new ByteArrayInputStream(buffer.getBytes()), buffer.length(), filename, "application/binary"));
@@ -220,7 +220,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 			// 1. Upload a binary field
 			String uuid = tx(() -> folder("2015").getUuid());
 			Buffer buffer = TestUtils.randomBuffer(1000);
-			VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+			VersionNumber version = tx(() -> tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion());
 			call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, "en", version.toString(), FIELD_NAME,
 				new ByteArrayInputStream(buffer.getBytes()), buffer.length(), "filename.txt",
 				"application/binary"));
@@ -241,7 +241,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 		String uuid = tx(() -> folder("2015").getUuid());
 		// 1. Upload a binary field
 		Buffer buffer = TestUtils.randomBuffer(1000);
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion(); });
 		call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, "en", version.toString(), FIELD_NAME,
 			new ByteArrayInputStream(buffer.getBytes()), buffer.length(), "filename.txt",
 			"application/binary"));
@@ -369,7 +369,7 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 	public NodeResponse createNodeWithField() {
 		String uuid = tx(() -> folder("2015").getUuid());
 		Buffer buffer = TestUtils.randomBuffer(1000);
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion(); });
 		return call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, "en", version.toString(), FIELD_NAME,
 			new ByteArrayInputStream(buffer.getBytes()), buffer.length(), "filename.txt",
 			"application/binary"));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldUploadEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldUploadEndpointTest.java
@@ -134,7 +134,7 @@ public class BinaryFieldUploadEndpointTest extends AbstractMeshTest {
 		for (int i = 0; i < 20; i++) {
 			String newFileName = "somefile" + i + ".dat";
 			String oldFilename = null;
-			HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+			HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 			try (Tx tx = tx()) {
 				HibBinaryField oldValue = container.getBinary("binary");
 				if (oldValue != null) {
@@ -199,7 +199,7 @@ public class BinaryFieldUploadEndpointTest extends AbstractMeshTest {
 		}
 
 		String uuid = tx(() -> folder("news").getUuid());
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(folder("news"), "en").getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(folder("news"), "en").getVersion(); });
 
 		Map<String, Buffer> data = new HashMap<>();
 		for (String field : fields) {
@@ -581,11 +581,11 @@ public class BinaryFieldUploadEndpointTest extends AbstractMeshTest {
 		// The test nodes
 		HibNode nodeA = folder("news");
 		String uuidA = tx(() -> nodeA.getUuid());
-		String versionA = tx(() -> boot().contentDao().getFieldContainer(nodeA, "en").getVersion()).toString();
+		String versionA = tx(tx -> { return tx.contentDao().getFieldContainer(nodeA, "en").getVersion(); }).toString();
 
 		HibNode nodeB = folder("products");
 		String uuidB = tx(() -> nodeB.getUuid());
-		String versionB = tx(() -> boot().contentDao().getFieldContainer(nodeA, "en").getVersion()).toString();
+		String versionB = tx(tx -> { return tx.contentDao().getFieldContainer(nodeA, "en").getVersion(); }).toString();
 
 		// Setup the schemas
 		try (Tx tx = tx()) {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/bool/BooleanFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/bool/BooleanFieldEndpointTest.java
@@ -72,7 +72,7 @@ public class BooleanFieldEndpointTest extends AbstractFieldEndpointTest {
 		HibNode node = folder("2015");
 		for (int i = 0; i < 20; i++) {
 			boolean flag = false;
-			VersionNumber oldVersion = tx(() -> boot().contentDao().getFieldContainer(node, "en").getVersion());
+			VersionNumber oldVersion = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getVersion(); });
 
 			NodeResponse response = updateNode(FIELD_NAME, new BooleanFieldImpl().setValue(flag));
 			BooleanFieldImpl field = response.getFields().getBooleanField(FIELD_NAME);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/bool/BooleanListFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/bool/BooleanListFieldEndpointTest.java
@@ -115,7 +115,7 @@ public class BooleanListFieldEndpointTest extends AbstractListFieldEndpointTest 
 			List<Boolean> newValue;
 
 			try (Tx tx = tx()) {
-				container = boot().contentDao().getFieldContainer(node, "en");
+				container = tx.contentDao().getFieldContainer(node, "en");
 				oldValue = getListValues(container::getBooleanList, FIELD_NAME);
 				newValue = valueCombinations.get(i % valueCombinations.size());
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/date/DateFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/date/DateFieldEndpointTest.java
@@ -27,7 +27,6 @@ import com.gentics.mesh.core.rest.node.field.DateField;
 import com.gentics.mesh.core.rest.node.field.Field;
 import com.gentics.mesh.core.rest.node.field.impl.DateFieldImpl;
 import com.gentics.mesh.core.rest.schema.DateFieldSchema;
-import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 import com.gentics.mesh.core.rest.schema.impl.DateFieldSchemaImpl;
 import com.gentics.mesh.test.MeshTestSetting;
 
@@ -66,7 +65,7 @@ public class DateFieldEndpointTest extends AbstractFieldEndpointTest {
 			Long oldValue;
 
 			try (Tx tx = tx()) {
-				container = boot().contentDao().getFieldContainer(node, "en");
+				container = tx.contentDao().getFieldContainer(node, "en");
 				oldValue = getDateValue(container, FIELD_NAME);
 			}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/date/DateFieldListEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/date/DateFieldListEndpointTest.java
@@ -123,7 +123,7 @@ public class DateFieldListEndpointTest extends AbstractListFieldEndpointTest {
 			HibNodeFieldContainer container;
 			List<Long> oldValue;
 			try (Tx tx = tx()) {
-				container = boot().contentDao().getFieldContainer(node, "en");
+				container = tx.contentDao().getFieldContainer(node, "en");
 				oldValue = getListValues(container::getDateList, FIELD_NAME);
 				List<String> newValue = valueCombinations.get(i % valueCombinations.size());
 				for (String value : newValue) {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/html/HtmlFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/html/HtmlFieldEndpointTest.java
@@ -56,7 +56,7 @@ public class HtmlFieldEndpointTest extends AbstractFieldEndpointTest {
 	public void testUpdateNodeFieldWithField() {
 		HibNode node = folder("2015");
 		for (int i = 0; i < 20; i++) {
-			VersionNumber oldVersion = tx(() -> boot().contentDao().getFieldContainer(node, "en").getVersion());
+			VersionNumber oldVersion = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getVersion(); });
 			String newValue = "some<b>html <i>" + i + "</i>";
 
 			NodeResponse response = updateNode(FIELD_NAME, new HtmlFieldImpl().setHTML(newValue));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/html/HtmlFieldListEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/html/HtmlFieldListEndpointTest.java
@@ -122,7 +122,7 @@ public class HtmlFieldListEndpointTest extends AbstractListFieldEndpointTest {
 		List<List<String>> valueCombinations = Arrays.asList(Arrays.asList("A", "B", "C"), Arrays.asList("C", "B", "A"), Collections.emptyList(),
 			Arrays.asList("X", "Y"), Arrays.asList("C"));
 
-		HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+		HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 		for (int i = 0; i < 20; i++) {
 			List<String> oldValue;
 			List<String> newValue;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicronodeFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicronodeFieldEndpointTest.java
@@ -108,7 +108,7 @@ public class MicronodeFieldEndpointTest extends AbstractFieldEndpointTest {
 			HibMicronode oldValue = null;
 			HibNodeFieldContainer container = null;
 			try (Tx tx = tx()) {
-				container = boot().contentDao().getFieldContainer(node, "en");
+				container = tx.contentDao().getFieldContainer(node, "en");
 				oldValue = getMicronodeValue(container, FIELD_NAME);
 				field = new MicronodeResponse();
 				field.setMicroschema(new MicroschemaReferenceImpl().setName("vcard"));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicronodeListFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicronodeListFieldEndpointTest.java
@@ -118,7 +118,7 @@ public class MicronodeListFieldEndpointTest extends AbstractListFieldEndpointTes
 		disableAutoPurge();
 		HibNode node = folder("2015");
 
-		HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+		HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 		for (int i = 0; i < 20; i++) {
 
 			final HibNodeFieldContainer currentContainer = container;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicroschemaModelTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/micronode/MicroschemaModelTest.java
@@ -108,14 +108,14 @@ public class MicroschemaModelTest extends AbstractMeshTest implements BasicObjec
 			String invalidName = "thereIsNoMicroschemaWithThisName";
 
 			for (String name : microschemaContainers().keySet()) {
-				HibMicroschema container = boot().microschemaDao().findByName(name);
+				HibMicroschema container = tx.microschemaDao().findByName(name);
 				assertNotNull("Could not find microschema container for name " + name, container);
 				MicroschemaModel microschemaModel = container.getLatestVersion().getSchema();
 				assertNotNull("Container for microschema " + name + " did not contain a microschema", microschemaModel);
 				assertEquals("Check microschema name", name, microschemaModel.getName());
 			}
 
-			assertNull("Must not find microschema with name " + invalidName, boot().microschemaDao().findByName(invalidName));
+			assertNull("Must not find microschema with name " + invalidName, tx.microschemaDao().findByName(invalidName));
 		}
 	}
 
@@ -125,7 +125,7 @@ public class MicroschemaModelTest extends AbstractMeshTest implements BasicObjec
 		try (Tx tx = tx()) {
 			String invalidUUID = UUIDUtil.randomUUID();
 
-			MicroschemaDao root = boot().microschemaDao();
+			MicroschemaDao root = tx.microschemaDao();
 			for (HibMicroschema container : microschemaContainers().values()) {
 				String uuid = container.getUuid();
 				assertNotNull("Could not find microschema with uuid " + uuid, root.findByUuid(uuid));
@@ -309,20 +309,20 @@ public class MicroschemaModelTest extends AbstractMeshTest implements BasicObjec
 		try (Tx tx = tx()) {
 			HibMicroschemaVersion newVCard = microschemaContainer("vcard").getLatestVersion();
 
-			HibNodeFieldContainer containerWithBoth = boot().contentDao().getFieldContainer(folder("2015"), "en");
+			HibNodeFieldContainer containerWithBoth = tx.contentDao().getFieldContainer(folder("2015"), "en");
 			containerWithBoth.createMicronode("single", vcard);
 			containerWithBoth.createMicronodeList("list").createMicronode(vcard);
 			containerUuids.add(containerWithBoth.getUuid());
 
-			HibNodeFieldContainer containerWithField = boot().contentDao().getFieldContainer(folder("news"), "en");
+			HibNodeFieldContainer containerWithField = tx.contentDao().getFieldContainer(folder("news"), "en");
 			containerWithField.createMicronode("single", vcard);
 			containerUuids.add(containerWithField.getUuid());
 
-			HibNodeFieldContainer containerWithList = boot().contentDao().getFieldContainer(folder("products"), "en");
+			HibNodeFieldContainer containerWithList = tx.contentDao().getFieldContainer(folder("products"), "en");
 			containerWithList.createMicronodeList("list").createMicronode(vcard);
 			containerUuids.add(containerWithList.getUuid());
 
-			HibNodeFieldContainer containerWithOtherVersion = boot().contentDao().getFieldContainer(folder("deals"), "en");
+			HibNodeFieldContainer containerWithOtherVersion = tx.contentDao().getFieldContainer(folder("deals"), "en");
 			containerWithOtherVersion.createMicronode("single", newVCard);
 			tx.success();
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/node/NodeFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/node/NodeFieldEndpointTest.java
@@ -82,7 +82,7 @@ public class NodeFieldEndpointTest extends AbstractFieldEndpointTest {
 			HibNodeFieldContainer container = null;
 
 			try (Tx tx = tx()) {					
-				container = boot().contentDao().getFieldContainer(node, "en");
+				container = tx.contentDao().getFieldContainer(node, "en");
 				oldValue = getNodeValue(container, FIELD_NAME);
 			}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/node/NodeListFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/node/NodeListFieldEndpointTest.java
@@ -112,7 +112,7 @@ public class NodeListFieldEndpointTest extends AbstractListFieldEndpointTest {
 		List<List<HibNode>> valueCombinations = Arrays.asList(Arrays.asList(targetNode), Arrays.asList(targetNode2, targetNode), Collections.emptyList(),
 			Arrays.asList(targetNode, targetNode2), Arrays.asList(targetNode2));
 
-		HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+		HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 		for (int i = 0; i < 20; i++) {
 			List<HibNode> oldValue;
 			List<HibNode> newValue;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/number/NumberFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/number/NumberFieldEndpointTest.java
@@ -62,7 +62,7 @@ public class NumberFieldEndpointTest extends AbstractNumberFieldEndpointTest {
 
 		HibNode node = folder("2015");
 		for (int i = 0; i < 20; i++) {
-			HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+			HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 			Number oldValue;
 			Number newValue;
 			try (Tx tx = tx()) {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/number/NumberFieldListEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/number/NumberFieldListEndpointTest.java
@@ -115,7 +115,7 @@ public class NumberFieldListEndpointTest extends AbstractListFieldEndpointTest {
 		List<List<Number>> valueCombinations = Arrays.asList(Arrays.asList(1.1, 2, 3), Arrays.asList(3, 2, 1.1), Collections.emptyList(),
 			Arrays.asList(47.11, 8.15), Arrays.asList(3));
 
-		HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+		HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 		for (int i = 0; i < 20; i++) {
 			final HibNodeFieldContainer currentContainer = container;
 			List<Number> oldValue = tx(() -> getListValues(currentContainer::getNumberList, FIELD_NAME));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/string/StringFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/string/StringFieldEndpointTest.java
@@ -73,7 +73,7 @@ public class StringFieldEndpointTest extends AbstractFieldEndpointTest {
 	@Override
 	public void testUpdateNodeFieldWithField() {
 		for (int i = 0; i < 20; i++) {
-			VersionNumber oldVersion = tx(() -> boot().contentDao().getFieldContainer(folder("2015"), "en").getVersion());
+			VersionNumber oldVersion = tx(tx -> { return tx.contentDao().getFieldContainer(folder("2015"), "en").getVersion(); });
 
 			String newValue = "content " + i;
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/string/StringFieldListEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/string/StringFieldListEndpointTest.java
@@ -145,7 +145,7 @@ public class StringFieldListEndpointTest extends AbstractListFieldEndpointTest {
 		List<List<String>> valueCombinations = Arrays.asList(Arrays.asList("A", "B", "C"), Arrays.asList("C", "B", "A"), Collections.emptyList(),
 			Arrays.asList("X", "Y"), Arrays.asList("C"));
 
-		HibNodeFieldContainer container = tx(() -> boot().contentDao().getFieldContainer(node, "en"));
+		HibNodeFieldContainer container = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en"); });
 		for (int i = 0; i < 20; i++) {
 			StringFieldListImpl list = new StringFieldListImpl();
 			List<String> oldValue;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
@@ -237,12 +237,12 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 
 			HibNode node = folder("2015");
 			HibNode folder = folder("news");
-			boot().contentDao().updateWebrootPathInfo(boot().contentDao().getFieldContainer(folder, "de"), initialBranchUuid(), null);
-			boot().contentDao().updateWebrootPathInfo(boot().contentDao().getFieldContainer(folder, "de"), initialBranchUuid(), null);
+			tx.contentDao().updateWebrootPathInfo(tx.contentDao().getFieldContainer(folder, "de"), initialBranchUuid(), null);
+			tx.contentDao().updateWebrootPathInfo(tx.contentDao().getFieldContainer(folder, "de"), initialBranchUuid(), null);
 
 			HibNode node2 = content();
-			boot().contentDao().updateWebrootPathInfo(boot().contentDao().getFieldContainer(node2, "en"), initialBranchUuid(), null);
-			boot().contentDao().updateWebrootPathInfo(boot().contentDao().getFieldContainer(node2, "de"), initialBranchUuid(), null);
+			tx.contentDao().updateWebrootPathInfo(tx.contentDao().getFieldContainer(node2, "en"), initialBranchUuid(), null);
+			tx.contentDao().updateWebrootPathInfo(tx.contentDao().getFieldContainer(node2, "de"), initialBranchUuid(), null);
 			HibNode node3 = folder("2014");
 
 			// Update the folder schema to contain all fields
@@ -337,7 +337,7 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 			actions().updateSchemaVersion(schemaContainer("folder").getLatestVersion());
 
 			// Setup some test data
-			HibNodeFieldContainer container = boot().contentDao().createFieldContainer(node, "en", initialBranch(), user());
+			HibNodeFieldContainer container = tx.contentDao().createFieldContainer(node, "en", initialBranch(), user());
 
 			// node
 			container.createNode("nodeRef", node2);
@@ -433,7 +433,7 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 				micronodeField.getMicronode().createString("address").setString("Somewhere");
 				micronodeField.getMicronode().createString("postcode").setString("1010");
 			}
-			boot().contentDao().updateWebrootPathInfo(container, initialBranchUuid(), null);
+			tx.contentDao().updateWebrootPathInfo(container, initialBranchUuid(), null);
 			tx.success();
 		}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/group/GroupEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/group/GroupEndpointTest.java
@@ -82,7 +82,7 @@ public class GroupEndpointTest extends AbstractMeshTest implements BasicRestTest
 		trackingSearchProvider().clear().blockingAwait();
 
 		try (Tx tx = tx()) {
-			assertNotNull(boot().groupDao().findByUuid(restGroup.getUuid()));
+			assertNotNull(tx.groupDao().findByUuid(restGroup.getUuid()));
 		}
 	}
 
@@ -174,7 +174,7 @@ public class GroupEndpointTest extends AbstractMeshTest implements BasicRestTest
 			GroupResponse restGroup = call(() -> client().createGroup(request));
 			assertThat(restGroup).matches(request);
 
-			assertNotNull(boot().groupDao().findByUuid(restGroup.getUuid()));
+			assertNotNull(tx.groupDao().findByUuid(restGroup.getUuid()));
 			call(() -> client().createGroup(request), CONFLICT, "group_conflicting_name", name);
 		}
 	}
@@ -501,7 +501,7 @@ public class GroupEndpointTest extends AbstractMeshTest implements BasicRestTest
 		assertThat(trackingSearchProvider()).hasEvents(1, 0, 1, 0, 0);
 
 		try (Tx tx = tx()) {
-			assertNull(boot().groupDao().findByUuid(uuid));
+			assertNull(tx.groupDao().findByUuid(uuid));
 		}
 	}
 
@@ -533,7 +533,7 @@ public class GroupEndpointTest extends AbstractMeshTest implements BasicRestTest
 
 		try (Tx tx = tx()) {
 			call(() -> client().deleteGroup(groupUuid()), FORBIDDEN, "error_missing_perm", groupUuid(), DELETE_PERM.getRestPerm().getName());
-			assertNotNull(boot().groupDao().findByUuid(groupUuid()));
+			assertNotNull(tx.groupDao().findByUuid(groupUuid()));
 		}
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/group/GroupTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/group/GroupTest.java
@@ -206,8 +206,8 @@ public class GroupTest extends AbstractMeshTest implements BasicObjectTestcases 
 			// TODO add users to group?
 			BulkActionContext bac = createBulkContext();
 			groupDao.delete(group, bac);
-			assertElement(boot().groupDao(), uuid, false);
-			assertElement(boot().userDao(), userUuid, true);
+			assertElement(tx.groupDao(), uuid, false);
+			assertElement(tx.userDao(), userUuid, true);
 			assertEquals(1, bac.batch().getEntries().size());
 		}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/job/JobTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/job/JobTest.java
@@ -33,7 +33,7 @@ public class JobTest extends AbstractMeshTest {
 	@Test
 	public void testJob() {
 		try (Tx tx = tx()) {
-			JobDao root = boot().jobDao();
+			JobDao root = tx.jobDao();
 			HibJob job = root.enqueueBranchMigration(user(), initialBranch());
 			// Disabled in order to apply to contention fix
 			assertNull("The creator should not be set.",job.getCreator());
@@ -53,7 +53,7 @@ public class JobTest extends AbstractMeshTest {
 		}
 
 		try (Tx tx = tx()) {
-			JobDao root = boot().jobDao();
+			JobDao root = tx.jobDao();
 			List<? extends HibJob> list = TestUtils.toList(root.findAll());
 			assertThat(list).hasSize(1);
 			HibJob job = list.get(0);
@@ -81,7 +81,7 @@ public class JobTest extends AbstractMeshTest {
 	@Test
 	public void testJobErrorDetailTruncate() {
 		try (Tx tx = tx()) {
-			JobDao root = boot().jobDao();
+			JobDao root = tx.jobDao();
 			HibJob job = root.enqueueBranchMigration(user(), initialBranch());
 			assertNull("The job error detail should be null since it has not yet been marked as failed.", job.getErrorDetail());
 			Exception ex = buildExceptionStackTraceLongerThan(HibJob.ERROR_DETAIL_MAX_LENGTH * 2);
@@ -94,7 +94,7 @@ public class JobTest extends AbstractMeshTest {
 		}
 
 		try (Tx tx = tx()) {
-			JobDao root = boot().jobDao();
+			JobDao root = tx.jobDao();
 			List<? extends HibJob> list = TestUtils.toList(root.findAll());
 			assertThat(list).hasSize(1);
 			HibJob job = list.get(0);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeConflictEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeConflictEndpointTest.java
@@ -160,7 +160,7 @@ public class NodeConflictEndpointTest extends AbstractMeshTest {
 		HibNode node = getTestNode();
 		String nodeUuid = tx(() -> node.getUuid());
 
-		HibNodeFieldContainer oldContainer = tx(() -> boot().contentDao().findVersion(node, "en", project().getLatestBranch().getUuid(), "1.0"));
+		HibNodeFieldContainer oldContainer = tx(tx -> { return tx.contentDao().findVersion(node, "en", project().getLatestBranch().getUuid(), "1.0"); });
 		NodeUpdateRequest request = prepareNameFieldUpdateRequest("1234", "1.0");
 		// Add micronode / string list
 		request.getFields().put("stringList", FieldUtil.createStringListField("a", "b", "c"));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeDeleteEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeDeleteEndpointTest.java
@@ -268,8 +268,8 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 		// Assert that the node was only deleted in the new branch
 		try (Tx tx = tx()) {
 			assertElement(tx.nodeDao(), project(), uuid, true);
-			assertThat(boot().contentDao().getFieldContainers(node, initialBranch(), DRAFT)).as("draft containers for initial branch").isNotEmpty();
-			assertThat(boot().contentDao().getFieldContainers(node, newBranch, DRAFT)).as("draft containers for new branch").isEmpty();
+			assertThat(tx.contentDao().getFieldContainers(node, initialBranch(), DRAFT)).as("draft containers for initial branch").isNotEmpty();
+			assertThat(tx.contentDao().getFieldContainers(node, newBranch, DRAFT)).as("draft containers for new branch").isEmpty();
 		}
 
 	}
@@ -307,11 +307,11 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 		// Assert deletion - nodes should only be deleted for new branch
 		try (Tx tx = tx()) {
 			assertElement(tx.nodeDao(), project(), uuid, true);
-			assertThat(boot().contentDao().getFieldContainers(node, initialBranch(), ContainerType.DRAFT)).as("draft containers for initial branch").isNotEmpty();
-			assertThat(boot().contentDao().getFieldContainers(node, initialBranch(), ContainerType.PUBLISHED)).as("published containers for initial branch")
+			assertThat(tx.contentDao().getFieldContainers(node, initialBranch(), ContainerType.DRAFT)).as("draft containers for initial branch").isNotEmpty();
+			assertThat(tx.contentDao().getFieldContainers(node, initialBranch(), ContainerType.PUBLISHED)).as("published containers for initial branch")
 				.isNotEmpty();
-			assertThat(boot().contentDao().getFieldContainers(node, newBranch, ContainerType.DRAFT)).as("draft containers for new branch").isEmpty();
-			assertThat(boot().contentDao().getFieldContainers(node, newBranch, ContainerType.PUBLISHED)).as("published containers for new branch").isEmpty();
+			assertThat(tx.contentDao().getFieldContainers(node, newBranch, ContainerType.DRAFT)).as("draft containers for new branch").isEmpty();
+			assertThat(tx.contentDao().getFieldContainers(node, newBranch, ContainerType.PUBLISHED)).as("published containers for new branch").isEmpty();
 		}
 	}
 
@@ -323,7 +323,7 @@ public class NodeDeleteEndpointTest extends AbstractMeshTest {
 
 			call(() -> client().deleteNode(PROJECT_NAME, uuid), METHOD_NOT_ALLOWED, "node_basenode_not_deletable");
 
-			HibNode foundNode = boot().nodeDao().findByUuid(project(), uuid);
+			HibNode foundNode = tx.nodeDao().findByUuid(project(), uuid);
 			assertNotNull("The node should still exist.", foundNode);
 		}
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointBinaryFieldTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointBinaryFieldTest.java
@@ -279,7 +279,7 @@ public class NodeEndpointBinaryFieldTest extends AbstractMeshTest {
 		int binaryLen = 8000;
 		String fileName = "somefile.dat";
 		HibNode node = prepareSchema();
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(node, "en").getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getVersion(); });
 		String uuid = tx(() -> node.getUuid());
 
 		// 1. Upload some binary data

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeEndpointTest.java
@@ -696,7 +696,7 @@ public class NodeEndpointTest extends AbstractMeshTest implements BasicRestTestc
 		HibNode parentNode = folder("2015");
 		// Don't grant permissions to the no perm node. We want to make sure that this one will not be listed.
 		HibNode noPermNode = tx(tx -> { return tx.nodeDao().create(parentNode, user(), schemaContainer("content").getLatestVersion(), project()); });
-		String noPermNodeUUID = noPermNode.getUuid();
+		String noPermNodeUUID = tx(() -> noPermNode.getUuid());
 
 		// Create 20 drafts
 		int nNodes = 20;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/node/NodeTest.java
@@ -196,7 +196,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 	public void testFindByUUID() throws Exception {
 		try (Tx tx = tx()) {
 			HibNode newsNode = content("news overview");
-			HibNode node = boot().nodeDao().findByUuid(project(), newsNode.getUuid());
+			HibNode node = tx.nodeDao().findByUuid(project(), newsNode.getUuid());
 			assertNotNull(node);
 			assertEquals(newsNode.getUuid(), node.getUuid());
 		}
@@ -239,7 +239,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			assertNotNull(subNode.getUuid());
 			BulkActionContext context = createBulkContext();
 			InternalActionContext ac = mockActionContext("");
-			boot().nodeDao().deleteFromBranch(subNode, ac, project().getLatestBranch(), context, false);
+			tx.nodeDao().deleteFromBranch(subNode, ac, project().getLatestBranch(), context, false);
 		}
 	}
 
@@ -265,7 +265,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			HibNode node = folder("2015");
 			assertEquals("folder", node.getSchemaContainer().getLatestVersion().getSchema().getName());
 			assertTrue(node.getSchemaContainer().getLatestVersion().getSchema().getContainer());
-			HibNodeFieldContainer englishVersion = boot().contentDao().getFieldContainer(node, "en");
+			HibNodeFieldContainer englishVersion = tx.contentDao().getFieldContainer(node, "en");
 			assertNotNull(englishVersion);
 		}
 	}
@@ -289,7 +289,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			String english = english();
 			String german = german();
 
-			HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english,
+			HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english,
 				node.getProject().getLatestBranch(), user);
 			schemaVersion.getSchema().addField(new StringFieldSchemaImpl().setName("name"));
 			actions().updateSchemaVersion(schemaVersion);
@@ -303,7 +303,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			assertNotNull(allProperties);
 			assertEquals(1, allProperties.size());
 
-			HibNodeFieldContainer germanContainer = boot().contentDao().createFieldContainer(node, german, node.getProject().getLatestBranch(),
+			HibNodeFieldContainer germanContainer = tx.contentDao().createFieldContainer(node, german, node.getProject().getLatestBranch(),
 				user);
 			germanContainer.createHTML("content").setHtml("german content");
 			assertEquals(2, TestUtils.size(contentDao.getDraftFieldContainers(node)));
@@ -326,7 +326,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			InternalActionContext ac = mockActionContext("");
 			ac.getDeleteParameters().setRecursive(true);
 			try (Tx tx2 = tx()) {
-				boot().nodeDao().deleteFromBranch(node, ac, project().getLatestBranch(), createBulkContext(), false);
+				tx.nodeDao().deleteFromBranch(node, ac, project().getLatestBranch(), createBulkContext(), false);
 				tx2.success();
 			}
 
@@ -397,20 +397,20 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 
 			// 1. create folder with subfolder and subsubfolder
 			HibNode folder = nodeDao.create(project.getBaseNode(), user(), folderSchema, project);
-			boot().contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
+			tx.contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
 			String folderUuid = folder.getUuid();
 			HibNode subFolder = nodeDao.create(folder, user(), folderSchema, project);
-			boot().contentDao().createFieldContainer(subFolder, english(), initialBranch, user()).createString("name").setString("SubFolder");
+			tx.contentDao().createFieldContainer(subFolder, english(), initialBranch, user()).createString("name").setString("SubFolder");
 			String subFolderUuid = subFolder.getUuid();
 			HibNode subSubFolder = nodeDao.create(subFolder, user(), folderSchema, project);
-			boot().contentDao().createFieldContainer(subSubFolder, english(), initialBranch, user()).createString("name")
+			tx.contentDao().createFieldContainer(subSubFolder, english(), initialBranch, user()).createString("name")
 				.setString("SubSubFolder");
 			String subSubFolderUuid = subSubFolder.getUuid();
 
 			// 2. delete folder for initial release
 			InternalActionContext ac = mockActionContext("");
 			ac.getDeleteParameters().setRecursive(true);
-			boot().nodeDao().deleteFromBranch(subFolder, ac, initialBranch, bac, false);
+			tx.nodeDao().deleteFromBranch(subFolder, ac, initialBranch, bac, false);
 
 			// 3. assert for new branch
 			assertThat(folder).as("folder").hasNoChildren(initialBranch);
@@ -433,12 +433,12 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 
 			// 1. create folder with subfolder and subsubfolder
 			HibNode folder = nodeDao.create(project.getBaseNode(), user(), folderSchema, project);
-			boot().contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
+			tx.contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
 			HibNode subFolder = nodeDao.create(folder, user(), folderSchema, project);
-			boot().contentDao().createFieldContainer(subFolder, english(), initialBranch, user()).createString("name").setString("SubFolder");
+			tx.contentDao().createFieldContainer(subFolder, english(), initialBranch, user()).createString("name").setString("SubFolder");
 			String subFolderUuid = subFolder.getUuid();
 			HibNode subSubFolder = nodeDao.create(subFolder, user(), folderSchema, project);
-			boot().contentDao().createFieldContainer(subSubFolder, english(), initialBranch, user()).createString("name")
+			tx.contentDao().createFieldContainer(subSubFolder, english(), initialBranch, user()).createString("name")
 				.setString("SubSubFolder");
 			String subSubFolderUuid = subSubFolder.getUuid();
 
@@ -474,7 +474,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			// 8. delete folder for initial release
 			InternalActionContext ac = mockActionContext("");
 			ac.getDeleteParameters().setRecursive(true);
-			boot().nodeDao().deleteFromBranch(subFolder, ac, initialBranch, bac, false);
+			tx.nodeDao().deleteFromBranch(subFolder, ac, initialBranch, bac, false);
 
 			// 9. assert for new branch
 			assertThat(folder).as("folder").hasChildren(newBranch, subSubFolder);
@@ -508,7 +508,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 				BulkActionContext bac2 = createBulkContext();
 				roleDao.applyPermissions(folder, bac.batch(), role(), false, new HashSet<>(Arrays.asList(InternalPermission.READ_PERM,
 					InternalPermission.READ_PUBLISHED_PERM)), Collections.emptySet());
-				boot().contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
+				tx.contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
 				nodeDao.publish(folder, mockActionContext(), bac2);
 				assertEquals(1, bac2.batch().size());
 				return folder.getUuid();
@@ -531,7 +531,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			// 3. delete
 			InternalActionContext ac = mockActionContext("");
 			tx(tx2 -> {
-				tx2.nodeDao().deleteFromBranch(boot().nodeDao().findByUuid(project(), folderUuid), ac, initialBranch, bac, false);
+				tx2.nodeDao().deleteFromBranch(tx.nodeDao().findByUuid(project(), folderUuid), ac, initialBranch, bac, false);
 			});
 
 			// 4. assert published and draft gone
@@ -565,7 +565,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 				RoleDao roleDao = tx.roleDao();
 				roleDao.applyPermissions(folder, bac.batch(), role(), false, new HashSet<>(Arrays.asList(InternalPermission.READ_PERM,
 					InternalPermission.READ_PUBLISHED_PERM)), Collections.emptySet());
-				boot().contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
+				tx.contentDao().createFieldContainer(folder, english(), initialBranch, user()).createString("name").setString("Folder");
 				nodeDao.publish(folder, mockActionContext(), bac);
 				return folder.getUuid();
 			});
@@ -581,7 +581,7 @@ public class NodeTest extends AbstractMeshTest implements BasicObjectTestcases {
 			// 3. delete from initial branch
 			InternalActionContext ac = mockActionContext("");
 			tx(() -> {
-				boot().nodeDao().deleteFromBranch(boot().nodeDao().findByUuid(project(), folderUuid), ac, initialBranch, createBulkContext(),
+				tx.nodeDao().deleteFromBranch(tx.nodeDao().findByUuid(project(), folderUuid), ac, initialBranch, createBulkContext(),
 					false);
 			});
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/project/ProjectEndpointTest.java
@@ -169,8 +169,8 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 		assertThat(restProject).matches(request);
 		try (Tx tx = tx()) {
 			UserDao userDao = tx.userDao();
-			assertNotNull("The project should have been created.", boot().projectDao().findByName(name));
-			HibProject project = boot().projectDao().findByUuid(restProject.getUuid());
+			assertNotNull("The project should have been created.", tx.projectDao().findByName(name));
+			HibProject project = tx.projectDao().findByUuid(restProject.getUuid());
 			assertNotNull(project);
 			assertTrue(userDao.hasPermission(user(), project, CREATE_PERM));
 			assertTrue(userDao.hasPermission(user(), project.getBaseNode(), CREATE_PERM));
@@ -749,7 +749,7 @@ public class ProjectEndpointTest extends AbstractMeshTest implements BasicRestTe
 	@Override
 	public void testCreateMultithreaded() throws Exception {
 		int nJobs = 100;
-		long nProjectsBefore = boot().projectDao().count();
+		long nProjectsBefore = tx(tx -> { return tx.projectDao().count(); });
 
 		validateCreation(nJobs, i -> {
 			ProjectCreateRequest request = new ProjectCreateRequest();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/rest/MeshLocalClientTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/rest/MeshLocalClientTest.java
@@ -19,7 +19,7 @@ public class MeshLocalClientTest extends AbstractMeshTest {
 	@Test
 	public void testClientParameterHandling() {
 		String newsNodeUuid = db().tx(() -> folder("news").getUuid());
-		MeshAuthUser user = db().tx(() -> boot().userDao().findMeshAuthUserByUsername(user().getUsername()));
+		MeshAuthUser user = db().tx(tx -> { return tx.userDao().findMeshAuthUserByUsername(user().getUsername()); });
 		meshDagger().meshLocalClientImpl().setUser(user);
 		NodeResponse response = call(
 				() -> meshDagger().meshLocalClientImpl().findNodeByUuid(PROJECT_NAME, newsNodeUuid, new NodeParametersImpl().setLanguages("de")));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/role/RoleTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/role/RoleTest.java
@@ -13,15 +13,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
-import com.gentics.mesh.core.data.dao.PersistingGroupDao;
-import com.gentics.mesh.core.db.CommonTx;
 import org.junit.Test;
 
 import com.gentics.mesh.context.BulkActionContext;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.context.impl.InternalRoutingActionContextImpl;
-import com.gentics.mesh.core.data.dao.GroupDao;
 import com.gentics.mesh.core.data.dao.NodeDao;
+import com.gentics.mesh.core.data.dao.PersistingGroupDao;
 import com.gentics.mesh.core.data.dao.RoleDao;
 import com.gentics.mesh.core.data.dao.UserDao;
 import com.gentics.mesh.core.data.node.HibNode;
@@ -30,6 +28,7 @@ import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.service.BasicObjectTestcases;
 import com.gentics.mesh.core.data.user.HibUser;
+import com.gentics.mesh.core.db.CommonTx;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.role.RoleReference;
 import com.gentics.mesh.core.rest.role.RoleResponse;
@@ -64,7 +63,7 @@ public class RoleTest extends AbstractMeshTest implements BasicObjectTestcases {
 			HibRole createdRole = roleDao.create(roleName, user());
 			assertNotNull(createdRole);
 			String uuid = createdRole.getUuid();
-			HibRole role = boot().roleDao().findByUuid(uuid);
+			HibRole role = tx.roleDao().findByUuid(uuid);
 			assertNotNull(role);
 			assertEquals(roleName, role.getName());
 		}
@@ -270,8 +269,8 @@ public class RoleTest extends AbstractMeshTest implements BasicObjectTestcases {
 	@Override
 	public void testFindByName() {
 		try (Tx tx = tx()) {
-			assertNotNull(boot().roleDao().findByName(role().getName()));
-			assertNull(boot().roleDao().findByName("bogus"));
+			assertNotNull(tx.roleDao().findByName(role().getName()));
+			assertNull(tx.roleDao().findByName("bogus"));
 		}
 	}
 
@@ -281,7 +280,7 @@ public class RoleTest extends AbstractMeshTest implements BasicObjectTestcases {
 		try (Tx tx = tx()) {
 			HibRole role = tx.roleDao().findByUuid(role().getUuid());
 			assertNotNull(role);
-			role = boot().roleDao().findByUuid("bogus");
+			role = tx.roleDao().findByUuid("bogus");
 			assertNull(role);
 		}
 	}
@@ -342,7 +341,7 @@ public class RoleTest extends AbstractMeshTest implements BasicObjectTestcases {
 	@Override
 	public void testFindAll() throws InvalidArgumentException {
 		try (Tx tx = tx()) {
-			long size = Iterators.size(boot().roleDao().findAll().iterator());
+			long size = Iterators.size(tx.roleDao().findAll().iterator());
 			assertEquals(roles().size(), size);
 		}
 	}
@@ -376,7 +375,7 @@ public class RoleTest extends AbstractMeshTest implements BasicObjectTestcases {
 				roleDao.delete(role, context);
 				tx2.success();
 			}
-			assertNull(boot().roleDao().findByUuid(uuid));
+			assertNull(tx.roleDao().findByUuid(uuid));
 			assertEquals("The role event was not included in the batch", 1, context.batch().getEntries().size());
 		}
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/MicroschemaChangesEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/MicroschemaChangesEndpointTest.java
@@ -76,7 +76,7 @@ public class MicroschemaChangesEndpointTest extends AbstractMeshTest {
 		try (Tx tx = tx()) {
 			HibMicroschemaVersion reloaded = CommonTx.get().load(beforeVersion.getId(), tx().<CommonTx>unwrap().microschemaDao().getVersionPersistenceClass());
 			assertNotNull("The change should have been added to the schema.", reloaded.getNextChange());
-			HibNodeFieldContainer fieldContainer = boot().contentDao().getFieldContainer(node, "en");
+			HibNodeFieldContainer fieldContainer = tx.contentDao().getFieldContainer(node, "en");
 			assertNotNull("The node should have a micronode graph field", fieldContainer.getMicronode("micronodeField"));
 		}
 	}
@@ -179,10 +179,10 @@ public class MicroschemaChangesEndpointTest extends AbstractMeshTest {
 		micronode.getFields().put("lastName", new StringFieldImpl().setString("Mustermann"));
 		NodeResponse response = createNode("micronodeField", micronode);
 
-		return tx(() -> {
-			HibNode node = boot().nodeDao().findByUuid(project(), response.getUuid());
+		return tx(tx -> {
+			HibNode node = tx.nodeDao().findByUuid(project(), response.getUuid());
 			assertNotNull("The node should have been created.", node);
-			assertNotNull("The node should have a micronode graph field", boot().contentDao().getFieldContainer(node, "en").getMicronode("micronodeField"));
+			assertNotNull("The node should have a micronode graph field", tx.contentDao().getFieldContainer(node, "en").getMicronode("micronodeField"));
 			return node;
 		});
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/MicroschemaEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/MicroschemaEndpointTest.java
@@ -317,7 +317,7 @@ public class MicroschemaEndpointTest extends AbstractMeshTest implements BasicRe
 
 			call(() -> client().updateMicroschema("bogus", request), NOT_FOUND, "object_not_found_for_uuid", "bogus");
 
-			HibMicroschema reloaded = boot().microschemaDao().findByUuid(microschema.getUuid());
+			HibMicroschema reloaded = tx.microschemaDao().findByUuid(microschema.getUuid());
 			assertEquals("The name should not have been changed.", oldName, reloaded.getName());
 		}
 	}
@@ -337,7 +337,7 @@ public class MicroschemaEndpointTest extends AbstractMeshTest implements BasicRe
 		// schema_delete_still_in_use
 
 		try (Tx tx = tx()) {
-			HibMicroschema reloaded = boot().microschemaDao().findByUuid(uuid);
+			HibMicroschema reloaded = tx.microschemaDao().findByUuid(uuid);
 			assertNull("The microschema should have been deleted.", reloaded);
 		}
 	}
@@ -445,7 +445,7 @@ public class MicroschemaEndpointTest extends AbstractMeshTest implements BasicRe
 			microschemaContainerUuid);
 
 		try (Tx tx = tx()) {
-			HibMicroschema reloaded = boot().microschemaDao().findByUuid(microschemaContainerUuid);
+			HibMicroschema reloaded = tx.microschemaDao().findByUuid(microschemaContainerUuid);
 			assertNotNull("The microschema should not have been deleted.", reloaded);
 		}
 
@@ -483,7 +483,7 @@ public class MicroschemaEndpointTest extends AbstractMeshTest implements BasicRe
 			call(() -> client().deleteMicroschema(microschema.getUuid()), FORBIDDEN, "error_missing_perm", microschema.getUuid(),
 				DELETE_PERM.getRestPerm().getName());
 
-			assertElement(boot().microschemaDao(), microschema.getUuid(), true);
+			assertElement(tx.microschemaDao(), microschema.getUuid(), true);
 		}
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -18,12 +18,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -435,12 +431,12 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			String english = english();
 			HibNode parentNode = folder("2015");
 			firstNode = nodeDao.create(parentNode, user, versionA, project());
-			HibNodeFieldContainer firstEnglishContainer = boot().contentDao().createFieldContainer(firstNode, english,
+			HibNodeFieldContainer firstEnglishContainer = tx.contentDao().createFieldContainer(firstNode, english,
 				firstNode.getProject().getLatestBranch(), user);
 			firstEnglishContainer.createString(oldFieldName).setString("first content");
 
 			secondNode = nodeDao.create(parentNode, user, versionA, project());
-			HibNodeFieldContainer secondEnglishContainer = boot().contentDao().createFieldContainer(secondNode, english,
+			HibNodeFieldContainer secondEnglishContainer = tx.contentDao().createFieldContainer(secondNode, english,
 				secondNode.getProject().getLatestBranch(), user);
 			secondEnglishContainer.createString(oldFieldName).setString("second content");
 
@@ -454,13 +450,13 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		try (Tx tx = tx()) {
 			// assert that migration worked
 			assertThat(firstNode).as("Migrated Node").isOf(container).hasTranslation("en");
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").isOf(versionB).hasVersion("0.2");
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getString(newFieldName).getString()).as("Migrated field value")
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").isOf(versionB).hasVersion("0.2");
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getString(newFieldName).getString()).as("Migrated field value")
 				.isEqualTo(
 					"first content");
 			assertThat(secondNode).as("Migrated Node").isOf(container).hasTranslation("en");
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en")).as("Migrated field container").isOf(versionB).hasVersion("0.2");
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en").getString(newFieldName).getString()).as("Migrated field value")
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en")).as("Migrated field container").isOf(versionB).hasVersion("0.2");
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en").getString(newFieldName).getString()).as("Migrated field value")
 				.isEqualTo(
 					"second content");
 
@@ -575,7 +571,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			HibNode parentNode = folder("2015");
 			firstNode = nodeDao.create(parentNode, user, versionA, project());
 			Tx.get().commit();
-			HibNodeFieldContainer firstEnglishContainer = boot().contentDao().createFieldContainer(firstNode, english,
+			HibNodeFieldContainer firstEnglishContainer = tx.contentDao().createFieldContainer(firstNode, english,
 				firstNode.getProject().getLatestBranch(), user);
 			firstEnglishContainer.createString(oldFieldName).setString("first content");
 
@@ -591,8 +587,8 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		try (Tx tx = tx()) {
 			// assert that migration worked, but was only performed once
 			assertThat(firstNode).as("Migrated Node").isOf(container).hasTranslation("en");
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").isOf(versionB).hasVersion("0.2");
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getString(newFieldName).getString()).as("Migrated field value")
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").isOf(versionB).hasVersion("0.2");
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getString(newFieldName).getString()).as("Migrated field value")
 				.isEqualTo(
 					"first content");
 		}
@@ -624,7 +620,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 
 			// create a node and publish
 			node = nodeDao.create(folder("2015"), user(), versionA, project());
-			HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english(), project().getLatestBranch(),
+			HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english(), project().getLatestBranch(),
 				user());
 			englishContainer.createString(oldFieldName).setString("content");
 			englishContainer.createString("name").setString("someName");
@@ -639,7 +635,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 
 		try (Tx tx = tx()) {
 			ContentDao contentDao = tx.contentDao();
-			assertThat(boot().contentDao().getFieldContainer(node, "en")).as("Migrated draft").isOf(versionB).hasVersion("2.0");
+			assertThat(tx.contentDao().getFieldContainer(node, "en")).as("Migrated draft").isOf(versionB).hasVersion("2.0");
 			assertThat(contentDao.getFieldContainer(node, "en", project().getLatestBranch().getUuid(), ContainerType.PUBLISHED))
 				.as("Migrated published")
 				.isOf(versionB).hasVersion("2.0");
@@ -848,7 +844,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 //		try (Tx tx = tx()) {
 //			ContentDao contentDao = tx.contentDao();
 //			System.out.println();
-//			HibNode node = boot().nodeDao().findByUuid(project(), uuid);
+//			HibNode node = tx.nodeDao().findByUuid(project(), uuid);
 //			for (GraphFieldContainerEdgeImpl e : toGraph(node).outE("HAS_FIELD_CONTAINER").frameExplicit(GraphFieldContainerEdgeImpl.class)) {
 //				NodeGraphFieldContainer container = e.getNodeContainer();
 //				System.out.println("Type: " + e.getType() + " " + container.getUuid() + " version: " + container.getVersion());
@@ -988,7 +984,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 
 			// create micronode based on the old schema
 			String english = english();
-			firstNode = boot().nodeDao().findByUuidGlobal(folder("2015").getUuid());
+			firstNode = tx.nodeDao().findByUuidGlobal(folder("2015").getUuid());
 			SchemaVersionModel schema = firstNode.getSchemaContainer().getLatestVersion().getSchema();
 			schema.addField(new MicronodeFieldSchemaImpl().setName(micronodeFieldName).setLabel("Micronode Field"));
 			schema.getField(micronodeFieldName, MicronodeFieldSchema.class).setAllowedMicroSchemas(versionA.getName());
@@ -996,20 +992,20 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 
 			actions().updateSchemaVersion(firstNode.getSchemaContainer().getLatestVersion());
 			Tx.get().commit();
-			firstMicronodeField = boot().contentDao().createFieldContainer(firstNode, english, firstNode.getProject().getLatestBranch(), user())
+			firstMicronodeField = tx.contentDao().createFieldContainer(firstNode, english, firstNode.getProject().getLatestBranch(), user())
 				.createMicronode(
 					micronodeFieldName, versionA);
 			firstMicronodeField.getMicronode().createString(oldFieldName).setString("first content");
 
 			secondNode = folder("news");
-			secondMicronodeField = boot().contentDao()
+			secondMicronodeField = tx.contentDao()
 				.createFieldContainer(secondNode, english, secondNode.getProject().getLatestBranch(), user()).createMicronode(
 					micronodeFieldName, versionA);
 			secondMicronodeField.getMicronode().createString(oldFieldName).setString("second content");
 			tx.success();
 		}
 
-		String jobUuid = tx(() -> boot().jobDao().enqueueMicroschemaMigration(user(), initialBranch(), versionA, versionB).getUuid());
+		String jobUuid = tx(tx -> { return tx.jobDao().enqueueMicroschemaMigration(user(), initialBranch(), versionA, versionB).getUuid(); });
 
 		triggerAndWaitForJob(jobUuid);
 		try (Tx tx = tx()) {
@@ -1018,22 +1014,22 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			assertThat(firstMicronodeField.getMicronode()).as("Old Micronode").isOf(versionA);
 			assertThat(firstMicronodeField.getMicronode().getString(oldFieldName).getString()).as("Old field value").isEqualTo("first content");
 
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").hasVersion("1.2");
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getMicronode(micronodeFieldName).getMicronode())
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").hasVersion("1.2");
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getMicronode(micronodeFieldName).getMicronode())
 				.as("Migrated Micronode").isOf(
 					versionB);
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getMicronode(micronodeFieldName).getMicronode()
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getMicronode(micronodeFieldName).getMicronode()
 				.getString(newFieldName).getString()).as(
 					"Migrated field value").isEqualTo("first content");
 
 			assertThat(secondMicronodeField.getMicronode()).as("Old Micronode").isOf(versionA);
 			assertThat(secondMicronodeField.getMicronode().getString(oldFieldName).getString()).as("Old field value").isEqualTo("second content");
 
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en")).as("Migrated field container").hasVersion("1.2");
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en").getMicronode(micronodeFieldName).getMicronode())
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en")).as("Migrated field container").hasVersion("1.2");
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en").getMicronode(micronodeFieldName).getMicronode())
 				.as("Migrated Micronode").isOf(
 					versionB);
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en").getMicronode(micronodeFieldName).getMicronode()
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en").getMicronode(micronodeFieldName).getMicronode()
 				.getString(newFieldName).getString())
 					.as(
 						"Migrated field value")
@@ -1144,11 +1140,11 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			assertThat(firstMicronodeListField.getList().get(0).getMicronode().getString(oldFieldName).getString()).as("Old field value").isEqualTo(
 				"first content");
 
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").hasVersion("2.1");
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").hasVersion("2.1");
 			assertThat(
-				boot().contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0).getMicronode()).as(
+				tx.contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0).getMicronode()).as(
 					"Migrated Micronode").isOf(versionB);
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0)
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0)
 				.getMicronode().getString(
 					newFieldName)
 				.getString()).as("Migrated field value").isEqualTo("first content");
@@ -1160,18 +1156,18 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			assertThat(secondMicronodeListField.getList().get(1).getMicronode().getString(oldFieldName).getString()).as("Old field value").isEqualTo(
 				"third content");
 
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en")).as("Migrated field container").hasVersion("2.1");
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en")).as("Migrated field container").hasVersion("2.1");
 			assertThat(
-				boot().contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(0).getMicronode()).as(
+				tx.contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(0).getMicronode()).as(
 					"Migrated Micronode").isOf(versionB);
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(0)
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(0)
 				.getMicronode().getString(
 					newFieldName)
 				.getString()).as("Migrated field value").isEqualTo("second content");
 			assertThat(
-				boot().contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(1).getMicronode()).as(
+				tx.contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(1).getMicronode()).as(
 					"Migrated Micronode").isOf(versionB);
-			assertThat(boot().contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(1)
+			assertThat(tx.contentDao().getFieldContainer(secondNode, "en").getMicronodeList(micronodeFieldName).getList().get(1)
 				.getMicronode().getString(
 					newFieldName)
 				.getString()).as("Migrated field value").isEqualTo("third content");
@@ -1263,7 +1259,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			tx.success();
 		}
 
-		String jobUuid = tx(() -> boot().jobDao().enqueueMicroschemaMigration(user(), project().getLatestBranch(), versionA, versionB).getUuid());
+		String jobUuid = tx(tx -> { return tx.jobDao().enqueueMicroschemaMigration(user(), project().getLatestBranch(), versionA, versionB).getUuid(); });
 
 		triggerAndWaitForJob(jobUuid);
 
@@ -1278,19 +1274,19 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			assertThat(firstMicronodeListField.getList().get(1).getMicronode().getString("firstName").getString()).as("Old field value").isEqualTo(
 				"Max");
 
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").hasVersion("2.1");
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en")).as("Migrated field container").hasVersion("2.1");
 			assertThat(
-				boot().contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0).getMicronode()).as(
+				tx.contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0).getMicronode()).as(
 					"Migrated Micronode").isOf(versionB);
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0)
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(0)
 				.getMicronode().getString(
 					newFieldName)
 				.getString()).as("Migrated field value").isEqualTo("first content");
 
 			assertThat(
-				boot().contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(1).getMicronode()).as(
+				tx.contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(1).getMicronode()).as(
 					"Not migrated Micronode").isOf(microschemaContainer("vcard").getLatestVersion());
-			assertThat(boot().contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(1)
+			assertThat(tx.contentDao().getFieldContainer(firstNode, "en").getMicronodeList(micronodeFieldName).getList().get(1)
 				.getMicronode().getString(
 					"firstName")
 				.getString()).as("Not migrated field value").isEqualTo("Max");

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaChangesEndpointTest.java
@@ -209,9 +209,9 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			HibNode node = content();
 			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
 				!Objects.equals(reloaded.getVersion(),
-					boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
+					tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
 			assertNull("There should no longer be a content field of type html",
-				boot().contentDao().getFieldContainer(node, "en").getHtml("content"));
+				tx.contentDao().getFieldContainer(node, "en").getHtml("content"));
 		}
 	}
 
@@ -320,7 +320,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 
 		try (Tx tx = tx()) {
 			assertNotNull("The node should have a filename string graph field",
-				boot().contentDao().getFieldContainer(node, "en").getString("slug"));
+				tx.contentDao().getFieldContainer(node, "en").getString("slug"));
 
 			// 1. Create changes
 			SchemaChangeModel change = SchemaChangeModel.createRemoveFieldChange("slug");
@@ -334,7 +334,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			call(() -> client().applyChangesToSchema(container.getUuid(), listOfChanges), BAD_REQUEST, "schema_error_segmentfield_invalid", "slug");
 
 			// 3. Assert migrated node
-			HibNodeFieldContainer fieldContainer = boot().contentDao().getFieldContainer(node, "en");
+			HibNodeFieldContainer fieldContainer = tx.contentDao().getFieldContainer(node, "en");
 			assertNull("The node should still have a filename string graph field", fieldContainer.getHtml("slug"));
 		}
 	}
@@ -346,7 +346,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 		HibSchema schemaContainer = schemaContainer("content");
 		String schemaUuid = tx(() -> schemaContainer.getUuid());
 		HibSchemaVersion currentVersion = tx(() -> schemaContainer.getLatestVersion());
-		assertNotNull("The node should have a html graph field", tx(() -> boot().contentDao().getFieldContainer(node, "en").getHtml("content")));
+		assertNotNull("The node should have a html graph field", tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getHtml("content"); }));
 
 		// 2. Create changes
 		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
@@ -370,7 +370,7 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			assertNotNull("The change should have been added to the schema.", currentVersion.getNextChange());
 
 			// 6. Assert migrated node
-			HibNodeFieldContainer fieldContainer = boot().contentDao().getFieldContainer(node, "en");
+			HibNodeFieldContainer fieldContainer = tx.contentDao().getFieldContainer(node, "en");
 			assertNull("The node should no longer have a content html graph field", fieldContainer.getHtml("content"));
 		}
 	}
@@ -406,14 +406,14 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			// Assert that migration worked
 			HibNode node = content();
 			assertNotNull("The schema of the node should contain the new field schema",
-				boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
+				tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
 			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
 				!Objects.equals(reloaded.getVersion(),
-					boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
+					tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
 			assertEquals("label1234",
-				boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField").getLabel());
+				tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField").getLabel());
 			assertEquals(elasticSearch,
-					boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField").getElasticsearch());
+					tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField").getElasticsearch());
 		}
 	}
 
@@ -449,10 +449,10 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			// Assert that migration worked
 			HibNode node = content();
 			assertNotNull("The schema of the node should contain the new field schema",
-					boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
+					tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
 			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
-				!Objects.equals(reloaded.getVersion(), boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
-			assertArrayEquals(new String[] {"5678"}, boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
+				!Objects.equals(reloaded.getVersion(), tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
+			assertArrayEquals(new String[] {"5678"}, tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
 		}
 	}
 
@@ -488,10 +488,10 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			// Assert that migration worked
 			HibNode node = content();
 			assertNotNull("The schema of the node should contain the new field schema",
-				boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
+				tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
 			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
-				!Objects.equals(reloaded.getVersion(), boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
-			assertArrayEquals(new String[] {"5678"}, boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
+				!Objects.equals(reloaded.getVersion(), tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
+			assertArrayEquals(new String[] {"5678"}, tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
 		}
 
 		// 3. Unrestrict field
@@ -518,10 +518,10 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 			// Assert that migration worked
 			HibNode node = content();
 			assertNotNull("The schema of the node should contain the new field schema",
-					boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
+					tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField"));
 			assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
-				!Objects.equals(currentVersion.getVersion(), boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
-			assertArrayEquals(new String[] {}, boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
+				!Objects.equals(currentVersion.getVersion(), tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
+			assertArrayEquals(new String[] {}, tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField", StringFieldSchema.class).getAllowedValues());
 		}
 	}
 
@@ -564,10 +564,10 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 				// Assert that migration worked
 				HibNode node = content();
 				assertNotNull("The schema of the node should contain the new field schema",
-					boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField_" + i));
+					tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getSchema().getField("newField_" + i));
 				assertTrue("The version of the original schema and the schema that is now linked to the node should be different.",
 					!Objects.equals(reloaded.getVersion(),
-						boot().contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
+						tx.contentDao().getFieldContainer(node, "en").getSchemaContainerVersion().getVersion()));
 			}
 
 		}
@@ -753,10 +753,10 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 		String schemaUuid = tx(() -> schemaContainer.getUuid());
 		String contentFieldValue;
 		try (Tx tx = tx()) {
-			assertNotNull("The node should have a html graph field", boot().contentDao().getFieldContainer(node, "en").getHtml("content"));
-			contentFieldValue = boot().contentDao().getFieldContainer(node, "en").getHtml("content").getHTML();
+			assertNotNull("The node should have a html graph field", tx.contentDao().getFieldContainer(node, "en").getHtml("content"));
+			contentFieldValue = tx.contentDao().getFieldContainer(node, "en").getHtml("content").getHTML();
 		}
-		assertEquals("1.0", tx(() -> boot().contentDao().getFieldContainer(node, "en").getVersion().toString()));
+		assertEquals("1.0", tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getVersion().toString(); }));
 
 		// 2. Create changes
 		SchemaChangesListModel listOfChanges = new SchemaChangesListModel();
@@ -777,9 +777,9 @@ public class SchemaChangesEndpointTest extends AbstractNodeSearchEndpointTest {
 		});
 
 		// Note : testing against content() directly (orientdb model) doesnt work since old field is not deleted
-		assertEquals("2.0", tx(() -> boot().contentDao().getFieldContainer(node, "en").getVersion().toString()));
+		assertEquals("2.0", tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getVersion().toString(); }));
 		assertNull("We would expect the new version to not include the old field value.",
-			tx(() -> boot().contentDao().getFieldContainer(node, "en").getHtml("content")));
+			tx(tx -> { return tx.contentDao().getFieldContainer(node, "en").getHtml("content"); }));
 
 		// Read node and check that content field has been migrated to newcontent
 		NodeResponse response = call(() -> client().findNodeByUuid(PROJECT_NAME, contentUuid(), new VersioningParametersImpl().draft()));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaEndpointTest.java
@@ -201,7 +201,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 		try (Tx tx = tx()) {
 			assertThat(trackingSearchProvider()).hasEvents(1, 0, 0, 0, 0);
 			assertThat(schema).matches(restSchema);
-			assertElement(boot().schemaDao(), restSchema.getUuid(), true);
+			assertElement(tx.schemaDao(), restSchema.getUuid(), true);
 		}		
 		call(() -> client().findSchemaByUuid(restSchema.getUuid()));
 		trackingSearchProvider().reset();
@@ -630,7 +630,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 			call(() -> client().updateSchema(uuid, request));
 		}, COMPLETED, 1);
 
-		String jobUuid = tx(() -> boot().schemaDao().findByUuid(uuid).getLatestVersion().referencedJobsViaTo().iterator().next().getUuid());
+		String jobUuid = tx(tx -> { return tx.schemaDao().findByUuid(uuid).getLatestVersion().referencedJobsViaTo().iterator().next().getUuid(); });
 
 		try (Tx tx = tx()) {
 			SchemaDao schemaDao = tx.schemaDao();
@@ -688,7 +688,7 @@ public class SchemaEndpointTest extends AbstractMeshTest implements BasicRestTes
 		try (Tx tx = tx()) {
 			call(() -> client().deleteSchema(schema.getUuid()), FORBIDDEN, "error_missing_perm", schema.getUuid(),
 				DELETE_PERM.getRestPerm().getName());
-			assertElement(boot().schemaDao(), schema.getUuid(), true);
+			assertElement(tx.schemaDao(), schema.getUuid(), true);
 		}
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaProjectEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaProjectEndpointTest.java
@@ -106,7 +106,7 @@ public class SchemaProjectEndpointTest extends AbstractMeshTest {
 
 		try (Tx tx = tx()) {
 			SchemaDao schemaDao = tx.schemaDao();
-			ProjectDao projectRoot = boot().projectDao();
+			ProjectDao projectRoot = tx.projectDao();
 			HibProject extraProject = projectRoot.findByUuid(created.getUuid());
 			assertNotNull("The schema should be added to the extra project", schemaDao.findByUuid(extraProject, schemaUuid));
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/AbstractFieldMigrationTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/field/AbstractFieldMigrationTest.java
@@ -100,9 +100,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		ExecutionException, TimeoutException {
 		try (Tx tx = tx()) {
 			if (getClass().isAnnotationPresent(MicroschemaTest.class)) {
-				removeMicroschemaField(creator, dataProvider, fetcher);
+				removeMicroschemaField(tx, creator, dataProvider, fetcher);
 			} else {
-				removeSchemaField(creator, dataProvider, fetcher);
+				removeSchemaField(tx, creator, dataProvider, fetcher);
 			}
 		}
 	}
@@ -120,11 +120,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	private void removeSchemaField(FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher) throws InterruptedException,
+	private void removeSchemaField(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher) throws InterruptedException,
 		ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingSchemaDao schemaDao = (PersistingSchemaDao) boot().schemaDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingSchemaDao schemaDao = (PersistingSchemaDao) tx.schemaDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
 
 		String removedFieldName = "toremove";
 		String persistentFieldName = "persistent";
@@ -161,7 +161,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		HibNode parentNode = folder("2015");
 		HibNode node = nodeDao.create(parentNode, user, versionA, project());
 		Tx.get().commit();
-		HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
+		HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
 			user);
 		dataProvider.set(englishContainer, persistentFieldName);
 		dataProvider.set(englishContainer, removedFieldName);
@@ -181,10 +181,10 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 
 		// assert that migration worked
 		assertThat(node).as("Migrated Node").isOf(container).hasTranslation("en");
-		assertThat(boot().contentDao().getFieldContainer(node, "en")).as("Migrated field container").isOf(versionB);
-		assertThat(fetcher.fetch(boot().contentDao().getFieldContainer(node, "en"), persistentFieldName))
+		assertThat(tx.contentDao().getFieldContainer(node, "en")).as("Migrated field container").isOf(versionB);
+		assertThat(fetcher.fetch(tx.contentDao().getFieldContainer(node, "en"), persistentFieldName))
 			.as("Field '" + persistentFieldName + "'").isNotNull();
-		assertThat(fetcher.fetch(boot().contentDao().getFieldContainer(node, "en"), removedFieldName)).as("Field '" + removedFieldName + "'")
+		assertThat(fetcher.fetch(tx.contentDao().getFieldContainer(node, "en"), removedFieldName)).as("Field '" + removedFieldName + "'")
 			.isNull();
 	}
 
@@ -201,11 +201,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	private void removeMicroschemaField(FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher) throws InterruptedException,
+	private void removeMicroschemaField(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher) throws InterruptedException,
 		ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) boot().microschemaDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) tx.microschemaDao();
 
 		String removedFieldName = "toremove";
 		String persistentFieldName = "persistent";
@@ -234,9 +234,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		// create a micronode based on the old microschema
 		HibNode node = nodeDao.create(folder("2015"), user(), schemaContainer("content").getLatestVersion(), project());
 		Tx.get().commit();
-		HibMicronodeField micronodeField = createMicronodefield(node, micronodeFieldName, versionA, dataProvider, persistentFieldName,
+		HibMicronodeField micronodeField = createMicronodefield(tx, node, micronodeFieldName, versionA, dataProvider, persistentFieldName,
 			removedFieldName);
-		HibNodeFieldContainer oldContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibNodeFieldContainer oldContainer = tx.contentDao().getFieldContainer(node, "en");
 		VersionNumber oldVersion = oldContainer.getVersion();
 
 		// migrate the node
@@ -254,7 +254,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		assertThat(micronodeField.getMicronode()).as("Old Micronode").isOf(versionA);
 
 		// assert that migration worked
-		HibNodeFieldContainer newContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibNodeFieldContainer newContainer = tx.contentDao().getFieldContainer(node, "en");
 		assertThat(newContainer).as("New container").hasVersion(oldVersion.nextDraft().toString());
 		HibMicronodeField newMicronodeField = newContainer.getMicronode(micronodeFieldName);
 		assertThat(newMicronodeField.getMicronode()).as("Migrated Micronode").isOf(versionB);
@@ -283,9 +283,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		throws InterruptedException, ExecutionException, TimeoutException {
 		try (Tx tx = tx()) {
 			if (getClass().isAnnotationPresent(MicroschemaTest.class)) {
-				renameMicroschemaField(creator, dataProvider, fetcher, asserter);
+				renameMicroschemaField(tx, creator, dataProvider, fetcher, asserter);
 			} else {
-				renameSchemaField(creator, dataProvider, fetcher, asserter);
+				renameSchemaField(tx, creator, dataProvider, fetcher, asserter);
 			}
 		}
 	}
@@ -307,11 +307,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws InterruptedException
 	 * @throws IOException
 	 */
-	private void renameSchemaField(FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, DataAsserter asserter)
+	private void renameSchemaField(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, DataAsserter asserter)
 		throws InterruptedException, ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingSchemaDao schemaDao = ((PersistingSchemaDao) boot().schemaDao());
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingSchemaDao schemaDao = ((PersistingSchemaDao) tx.schemaDao());
 
 		String oldFieldName = "oldname";
 		String newFieldName = "newname";
@@ -353,7 +353,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		String english = english();
 		HibNode parentNode = folder("2015");
 		HibNode node = nodeDao.create(parentNode, user, versionA, project());
-		HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
+		HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
 			user);
 		dataProvider.set(englishContainer, oldFieldName);
 
@@ -371,9 +371,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 
 		// assert that migration worked
 		assertThat(node).as("Migrated Node").isOf(container).hasTranslation("en");
-		assertThat(boot().contentDao().getFieldContainer(node, "en")).as("Migrated field container").isOf(versionB);
-		assertThat(fetcher.fetch(boot().contentDao().getFieldContainer(node, "en"), oldFieldName)).as("Field '" + oldFieldName + "'").isNull();
-		asserter.assertThat(boot().contentDao().getFieldContainer(node, "en"), newFieldName);
+		assertThat(tx.contentDao().getFieldContainer(node, "en")).as("Migrated field container").isOf(versionB);
+		assertThat(fetcher.fetch(tx.contentDao().getFieldContainer(node, "en"), oldFieldName)).as("Field '" + oldFieldName + "'").isNull();
+		asserter.assertThat(tx.contentDao().getFieldContainer(node, "en"), newFieldName);
 	}
 
 	/**
@@ -393,11 +393,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws InterruptedException
 	 * @throws IOException
 	 */
-	private void renameMicroschemaField(FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, DataAsserter asserter)
+	private void renameMicroschemaField(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, DataAsserter asserter)
 		throws InterruptedException, ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) boot().microschemaDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) tx.microschemaDao();
 		String oldFieldName = "oldname";
 		String newFieldName = "newname";
 		String microschemaName = UUIDUtil.randomUUID();
@@ -429,8 +429,8 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 
 		// create a node based on the old schema
 		HibNode node = nodeDao.create(folder("2015"), user(), schemaContainer("content").getLatestVersion(), project());
-		HibMicronodeField micronodeField = createMicronodefield(node, micronodeFieldName, versionA, dataProvider, oldFieldName);
-		HibNodeFieldContainer oldContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibMicronodeField micronodeField = createMicronodefield(tx, node, micronodeFieldName, versionA, dataProvider, oldFieldName);
+		HibNodeFieldContainer oldContainer = tx.contentDao().getFieldContainer(node, "en");
 		VersionNumber oldVersion = oldContainer.getVersion();
 
 		// migrate the micronode
@@ -453,7 +453,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		assertThat(micronodeField.getMicronode()).as("Old Micronode").isOf(versionA);
 
 		// assert that migration worked
-		HibNodeFieldContainer newContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibNodeFieldContainer newContainer = tx.contentDao().getFieldContainer(node, "en");
 		assertThat(newContainer).as("New container").hasVersion(oldVersion.nextDraft().toString());
 		HibMicronodeField newMicronodeField = newContainer.getMicronode(micronodeFieldName);
 		assertThat(newMicronodeField.getMicronode()).as("Migrated Micronode").isOf(versionB);
@@ -506,9 +506,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 */
 	private void changeSchemaType(Tx tx, FieldSchemaCreator oldField, DataProvider dataProvider, FieldFetcher oldFieldFetcher, FieldSchemaCreator newField,
 			DataAsserter asserter) throws InterruptedException, ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingSchemaDao schemaDao = (PersistingSchemaDao) boot().schemaDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingSchemaDao schemaDao = (PersistingSchemaDao) tx.schemaDao();
 
 		String fieldName = "changedfield";
 		String schemaName = "schema_" + System.currentTimeMillis();
@@ -549,7 +549,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		HibNode parentNode = folder("2015");
 		HibNode node = nodeDao.create(parentNode, user, versionA, project());
 		tx.commit();
-		HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
+		HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
 			user);
 		dataProvider.set(englishContainer, fieldName);
 		assertThat(englishContainer).isOf(versionA).hasVersion("0.1");
@@ -575,7 +575,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		// old container must not be changed
 		assertThat(englishContainer).isOf(versionA).hasVersion("0.1");
 		// assert that migration worked
-		HibNodeFieldContainer migratedContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibNodeFieldContainer migratedContainer = tx.contentDao().getFieldContainer(node, "en");
 		assertThat(migratedContainer).isOf(versionB).hasVersion("0.2");
 		assertThat(node).as("Migrated Node").isOf(container).hasTranslation("en");
 
@@ -608,8 +608,8 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 */
 	private void changeMicroschemaType(Tx tx, FieldSchemaCreator oldField, DataProvider dataProvider, FieldFetcher oldFieldFetcher,
 			FieldSchemaCreator newField, DataAsserter asserter) throws InterruptedException, ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) boot().microschemaDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) tx.microschemaDao();
 		
 		String fieldName = "changedfield";
 		String microschemaName = UUIDUtil.randomUUID();
@@ -643,8 +643,8 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		tx.commit();
 
 		// create a node based on the old schema
-		HibMicronodeField micronodeField = createMicronodefield(node, micronodeFieldName, versionA, dataProvider, fieldName);
-		HibNodeFieldContainer oldContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibMicronodeField micronodeField = createMicronodefield(tx, node, micronodeFieldName, versionA, dataProvider, fieldName);
+		HibNodeFieldContainer oldContainer = tx.contentDao().getFieldContainer(node, "en");
 		VersionNumber oldVersion = oldContainer.getVersion();
 
 		if (dataProvider == FieldTestHelper.NOOP) {
@@ -667,7 +667,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		assertThat(micronodeField.getMicronode()).as("Old micronode").isOf(versionA);
 
 		// assert that migration worked
-		HibNodeFieldContainer newContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibNodeFieldContainer newContainer = tx.contentDao().getFieldContainer(node, "en");
 		assertThat(newContainer).as("New container").hasVersion(oldVersion.nextDraft().toString());
 		HibMicronodeField newMicronodeField = newContainer.getMicronode(micronodeFieldName);
 		assertThat(newMicronodeField.getMicronode()).as("Migrated Micronode").isOf(versionB);
@@ -704,9 +704,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		DataAsserter asserter) throws InterruptedException, ExecutionException, TimeoutException {
 		try (Tx tx = tx()) {
 			if (getClass().isAnnotationPresent(MicroschemaTest.class)) {
-				customMicroschemaMigrationScript(creator, dataProvider, fetcher, migrationScript, asserter);
+				customMicroschemaMigrationScript(tx, creator, dataProvider, fetcher, migrationScript, asserter);
 			} else {
-				customSchemaMigrationScript(creator, dataProvider, fetcher, migrationScript, asserter);
+				customSchemaMigrationScript(tx, creator, dataProvider, fetcher, migrationScript, asserter);
 			}
 		}
 	}
@@ -728,11 +728,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	private void customSchemaMigrationScript(FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, String migrationScript,
+	private void customSchemaMigrationScript(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, String migrationScript,
 		DataAsserter asserter) throws InterruptedException, ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingSchemaDao schemaDao = (PersistingSchemaDao) boot().schemaDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingSchemaDao schemaDao = (PersistingSchemaDao) tx.schemaDao();
 
 		String fieldName = "migratedField";
 		String schemaName = "migratedSchema";
@@ -768,7 +768,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		String english = english();
 		HibNode parentNode = folder("2015");
 		HibNode node = nodeDao.create(parentNode, user, versionA, project());
-		HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
+		HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
 			user);
 		dataProvider.set(englishContainer, fieldName);
 
@@ -786,8 +786,8 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 
 		// assert that migration worked
 		assertThat(node).as("Migrated Node").isOf(container).hasTranslation("en");
-		assertThat(boot().contentDao().getFieldContainer(node, "en")).as("Migrated field container").isOf(versionB);
-		asserter.assertThat(boot().contentDao().getFieldContainer(node, "en"), fieldName);
+		assertThat(tx.contentDao().getFieldContainer(node, "en")).as("Migrated field container").isOf(versionB);
+		asserter.assertThat(tx.contentDao().getFieldContainer(node, "en"), fieldName);
 	}
 
 	/**
@@ -807,11 +807,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	private void customMicroschemaMigrationScript(FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, String migrationScript,
+	private void customMicroschemaMigrationScript(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, FieldFetcher fetcher, String migrationScript,
 		DataAsserter asserter) throws InterruptedException, ExecutionException, TimeoutException {
-		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) boot().microschemaDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		NodeDao nodeDao = boot().nodeDao();
+		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) tx.microschemaDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		NodeDao nodeDao = tx.nodeDao();
 
 		String fieldName = "migratedField";
 		String microschemaName = UUIDUtil.randomUUID();
@@ -840,8 +840,8 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		// create a micronode based on the old schema
 		microschemaDao.assign(container, project(), user(), createBatch());
 		HibNode node = nodeDao.create(folder("2015"), user(), schemaContainer("content").getLatestVersion(), project());
-		HibMicronodeField micronodeField = createMicronodefield(node, micronodeFieldName, versionA, dataProvider, fieldName);
-		HibNodeFieldContainer oldContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibMicronodeField micronodeField = createMicronodefield(tx, node, micronodeFieldName, versionA, dataProvider, fieldName);
+		HibNodeFieldContainer oldContainer = tx.contentDao().getFieldContainer(node, "en");
 		VersionNumber oldVersion = oldContainer.getVersion();
 
 		// migrate the micronode
@@ -860,7 +860,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		assertThat(micronodeField.getMicronode()).as("Old Micronode").isOf(versionA);
 
 		// assert that migration worked
-		HibNodeFieldContainer newContainer = boot().contentDao().getFieldContainer(node, "en");
+		HibNodeFieldContainer newContainer = tx.contentDao().getFieldContainer(node, "en");
 		assertThat(newContainer).as("New container").hasVersion(oldVersion.nextDraft().toString());
 		HibMicronodeField newMicronodeField = newContainer.getMicronode(micronodeFieldName);
 		asserter.assertThat(newMicronodeField.getMicronode(), fieldName);
@@ -881,9 +881,9 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		try (Tx tx = tx()) {
 			try {
 				if (getClass().isAnnotationPresent(MicroschemaTest.class)) {
-					invalidMicroschemaMigrationScript(creator, dataProvider, script);
+					invalidMicroschemaMigrationScript(tx, creator, dataProvider, script);
 				} else {
-					invalidSchemaMigrationScript(creator, dataProvider, script);
+					invalidSchemaMigrationScript(tx, creator, dataProvider, script);
 				}
 			} catch (CompositeException e) {
 				Throwable firstError = e.getExceptions().get(0);
@@ -911,11 +911,11 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	private void invalidSchemaMigrationScript(FieldSchemaCreator creator, DataProvider dataProvider, String script) throws InterruptedException,
+	private void invalidSchemaMigrationScript(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, String script) throws InterruptedException,
 		ExecutionException, TimeoutException {
-		NodeDao nodeDao = boot().nodeDao();
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingSchemaDao schemaDao = (PersistingSchemaDao) boot().schemaDao();
+		NodeDao nodeDao = tx.nodeDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingSchemaDao schemaDao = (PersistingSchemaDao) tx.schemaDao();
 
 		String fieldName = "migratedField";
 		String schemaName = "migratedSchema";
@@ -951,7 +951,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		String english = english();
 		HibNode parentNode = folder("2015");
 		HibNode node = nodeDao.create(parentNode, user, versionA, project());
-		HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
+		HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
 			user);
 		dataProvider.set(englishContainer, fieldName);
 
@@ -980,13 +980,13 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	private void invalidMicroschemaMigrationScript(FieldSchemaCreator creator, DataProvider dataProvider, String script) throws InterruptedException,
+	private void invalidMicroschemaMigrationScript(Tx tx, FieldSchemaCreator creator, DataProvider dataProvider, String script) throws InterruptedException,
 		ExecutionException, TimeoutException {
 		String fieldName = "migratedField";
 		String microschemaName = UUIDUtil.randomUUID();
 		String micronodeFieldName = "micronodefield";
-		PersistingBranchDao branchDao = (PersistingBranchDao) boot().branchDao();
-		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) boot().microschemaDao();
+		PersistingBranchDao branchDao = (PersistingBranchDao) tx.branchDao();
+		PersistingMicroschemaDao microschemaDao = (PersistingMicroschemaDao) tx.microschemaDao();
 
 		// create version 1 of the microschema
 		FieldSchema oldField = creator.create(fieldName);
@@ -1008,7 +1008,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		versionA.setNextVersion(versionB);
 
 		// create a micronode based on the old schema
-		createMicronodefield(folder("2015"), micronodeFieldName, versionA, dataProvider, fieldName);
+		createMicronodefield(tx, folder("2015"), micronodeFieldName, versionA, dataProvider, fieldName);
 
 		// migrate the node
 		branchDao.assignMicroschemaVersion(project().getLatestBranch(), user(), versionB, createBatch());
@@ -1064,7 +1064,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 	 *            field names to fill
 	 * @return micronode field
 	 */
-	protected HibMicronodeField createMicronodefield(HibNode node, String micronodeFieldName, HibMicroschemaVersion schemaVersion,
+	protected HibMicronodeField createMicronodefield(Tx tx, HibNode node, String micronodeFieldName, HibMicroschemaVersion schemaVersion,
 		DataProvider dataProvider, String... fieldNames) {
 		String english = english();
 
@@ -1078,7 +1078,7 @@ public abstract class AbstractFieldMigrationTest extends AbstractMeshTest implem
 		schema.getField(micronodeFieldName, MicronodeFieldSchema.class).setAllowedMicroSchemas(schemaVersion.getName());
 		latestVersion.setSchema(schema);
 
-		HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
+		HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english, node.getProject().getLatestBranch(),
 			user());
 		actions().updateSchemaVersion(englishContainer.getSchemaContainerVersion());
 		HibMicronodeField micronodeField = englishContainer.createMicronode(micronodeFieldName, schemaVersion);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/tag/AtomicTagTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/tag/AtomicTagTest.java
@@ -28,7 +28,7 @@ public class AtomicTagTest extends AbstractMeshTest {
 			TagDao tagDao = tx.tagDao();
 
 			HibUser user = userDao.create("test", null);
-			LanguageDao languageRoot = boot().languageDao();
+			LanguageDao languageRoot = tx.languageDao();
 			assertNotNull(languageRoot);
 
 			HibProject project = project();
@@ -41,7 +41,7 @@ public class AtomicTagTest extends AbstractMeshTest {
 			tag.setName("renamed tag");
 			assertEquals("renamed tag", tag.getName());
 
-			HibTag reloadedTag = boot().tagDao().findByUuid(uuid);
+			HibTag reloadedTag = tx.tagDao().findByUuid(uuid);
 			assertNotNull(reloadedTag);
 			assertEquals("renamed tag", reloadedTag.getName());
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/tag/TagEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/tag/TagEndpointTest.java
@@ -383,7 +383,7 @@ public class TagEndpointTest extends AbstractMeshTest implements BasicRestTestca
 			}
 			assertThat(trackingSearchProvider()).hasEvents(4, 0, 1, 0, 0);
 
-			HibTag reloadedTag = boot().tagDao().findByUuid(tagUuid);
+			HibTag reloadedTag = tx.tagDao().findByUuid(tagUuid);
 			assertNull("The tag should have been deleted", reloadedTag);
 
 			HibProject project = tx.projectDao().findByName(PROJECT_NAME);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/tag/TagTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/tag/TagTest.java
@@ -144,7 +144,7 @@ public class TagTest extends AbstractMeshTest implements BasicObjectTestcases {
 			HibNode parentNode = folder("2015");
 			HibNode node = nodeDao.create(parentNode, user(), getSchemaContainer().getLatestVersion(), project);
 			String german = "de";
-			HibNodeFieldContainer germanContainer = boot().contentDao().createFieldContainer(node, german, branch, user());
+			HibNodeFieldContainer germanContainer = tx.contentDao().createFieldContainer(node, german, branch, user());
 
 			germanContainer.getSchemaContainerVersion().getSchema().addField(new StringFieldSchemaImpl().setName("displayName"));
 			germanContainer.getSchemaContainerVersion().getSchema().addField(new StringFieldSchemaImpl().setName("name"));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/tagfamily/TagFamilyEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/tagfamily/TagFamilyEndpointTest.java
@@ -349,10 +349,10 @@ public class TagFamilyEndpointTest extends AbstractMeshTest implements BasicRest
 			TagDao tagDao = tx.tagDao();
 			tags.forEach(t -> {
 				tagDao.getNodes(t, initialBranch()).forEach(n -> {
-					boot().contentDao().getFieldContainers(n, initialBranch(), ContainerType.DRAFT).forEach(c -> {
+					tx.contentDao().getFieldContainers(n, initialBranch(), ContainerType.DRAFT).forEach(c -> {
 						taggedDraftContentUuids.add(c.getUuid());
 					});
-					boot().contentDao().getFieldContainers(n, initialBranch(), ContainerType.PUBLISHED).forEach(c -> {
+					tx.contentDao().getFieldContainers(n, initialBranch(), ContainerType.PUBLISHED).forEach(c -> {
 						taggedPublishedContentUuids.add(c.getUuid());
 					});
 				});
@@ -484,7 +484,7 @@ public class TagFamilyEndpointTest extends AbstractMeshTest implements BasicRest
 						taggedNodes.add(node.getUuid());
 						for (ContainerType containerType : Arrays.asList(ContainerType.DRAFT,
 								ContainerType.PUBLISHED)) {
-							for (HibNodeFieldContainer fieldContainer : boot().contentDao()
+							for (HibNodeFieldContainer fieldContainer : tx.contentDao()
 									.getFieldContainers(node, branch, containerType)) {
 								HibSchemaVersion schema = node.getSchemaContainer().getLatestVersion();
 								storeCount++;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootEndpointTest.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 
 import javax.imageio.ImageIO;
 
-import com.gentics.mesh.core.rest.node.field.impl.NodeFieldImpl;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -249,7 +248,7 @@ public class WebRootEndpointTest extends AbstractMeshTest {
 
 			// Grant permissions to the node otherwise it will not be able to be loaded
 			roleDao.grantPermissions(role(), node, InternalPermission.values());
-			HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(node, german(), project().getLatestBranch(), user());
+			HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, german(), project().getLatestBranch(), user());
 			englishContainer.createString("teaser").setString("german teaser");
 			englishContainer.createString("title").setString("german title");
 			//englishContainer.createString("displayName").setString("german displayName");

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webrootfield/WebRootFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webrootfield/WebRootFieldEndpointTest.java
@@ -116,7 +116,6 @@ public class WebRootFieldEndpointTest extends AbstractMeshTest {
 	public void testReadContentWithNodeRefByPath() throws Exception {
 		HibNode nodeRef = null;
 		try (Tx tx = tx()) {
-			ContentDao contentDao = tx.contentDao();
 			NodeDao nodeDao = tx.nodeDao();
 			RoleDao roleDao = tx.roleDao();
 
@@ -137,7 +136,7 @@ public class WebRootFieldEndpointTest extends AbstractMeshTest {
 
 			// Grant permissions to the node otherwise it will not be able to be loaded
 			roleDao.grantPermissions(role(), nodeRef, InternalPermission.values());
-			HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(nodeRef, german(),
+			HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(nodeRef, german(),
 					project().getLatestBranch(), user());
 			englishContainer.createString("teaser").setString("german teaser");
 			englishContainer.createString("title").setString("german title");

--- a/tests/tests-core/src/main/java/com/gentics/mesh/database/TxTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/database/TxTest.java
@@ -44,11 +44,11 @@ public class TxTest extends AbstractMeshTest {
 		try (Tx tx = tx()) {
 			UserDao userDao= tx.userDao();
 			assertNotNull(userDao.create("testuser" + e, user()));
-			assertNotNull(boot().userDao().findByUsername("testuser" + e));
+			assertNotNull(tx.userDao().findByUsername("testuser" + e));
 			tx.success();
 		}
 		try (Tx tx = tx()) {
-			assertNotNull(boot().userDao().findByUsername("testuser" + e));
+			assertNotNull(tx.userDao().findByUsername("testuser" + e));
 		}
 		int u = i.incrementAndGet();
 		Runnable task = () -> {
@@ -58,14 +58,14 @@ public class TxTest extends AbstractMeshTest {
 				assertNotNull(userDao.findByUsername("testuser" + u));
 				tx.failure();
 			}
-			assertNull(boot().userDao().findByUsername("testuser" + u));
+			assertNull(tx(tx -> { return tx.userDao().findByUsername("testuser" + u); }));
 
 		};
 		Thread t = new Thread(task);
 		t.start();
 		t.join();
 		try (Tx tx = tx()) {
-			assertNull(boot().userDao().findByUsername("testuser" + u));
+			assertNull(tx.userDao().findByUsername("testuser" + u));
 			System.out.println("RUN: " + i.get());
 		}
 
@@ -77,7 +77,7 @@ public class TxTest extends AbstractMeshTest {
 			try (Tx tx = tx()) {
 				HibUser user = tx.userDao().findByUuid(userUuid());
 				user.setUsername("test2");
-				assertNotNull(boot().userDao().findByUsername("test2"));
+				assertNotNull(tx.userDao().findByUsername("test2"));
 				tx.success();
 			}
 
@@ -85,7 +85,7 @@ public class TxTest extends AbstractMeshTest {
 				try (Tx tx = tx()) {
 					HibUser user = tx.userDao().findByUuid(userUuid());
 					user.setUsername("test3");
-					assertNotNull(boot().userDao().findByUsername("test3"));
+					assertNotNull(tx.userDao().findByUsername("test3"));
 					tx.failure();
 				}
 
@@ -102,8 +102,8 @@ public class TxTest extends AbstractMeshTest {
 		t2.start();
 		t2.join();
 		try (Tx tx = tx()) {
-			assertNull(boot().userDao().findByUsername("test3"));
-			assertNotNull("The user with username test2 could not be found.", boot().userDao().findByUsername("test2"));
+			assertNull(tx.userDao().findByUsername("test3"));
+			assertNotNull("The user with username test2 could not be found.", tx.userDao().findByUsername("test2"));
 		}
 
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/linkrenderer/LinkRendererTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/linkrenderer/LinkRendererTest.java
@@ -291,12 +291,12 @@ public class LinkRendererTest extends AbstractMeshTest {
 			actions().updateSchemaVersion(schemaVersion);
 			// Create some dummy content
 			HibNode content = nodeDao.create(parentNode, user(), schemaVersion, project());
-			HibNodeFieldContainer germanContainer = boot().contentDao().createFieldContainer(content, german, content.getProject().getLatestBranch(), user());
+			HibNodeFieldContainer germanContainer = tx.contentDao().createFieldContainer(content, german, content.getProject().getLatestBranch(), user());
 			germanContainer.createString("displayName").setString("german name");
 			germanContainer.createString("name").setString("german.html");
 
 			HibNode content2 = nodeDao.create(parentNode, user(), schemaContainer("content").getLatestVersion(), project());
-			HibNodeFieldContainer englishContainer = boot().contentDao().createFieldContainer(content2, english, content2.getProject().getLatestBranch(), user());
+			HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(content2, english, content2.getProject().getLatestBranch(), user());
 			englishContainer.createString("displayName").setString("content 2 english");
 			englishContainer.createString("name").setString("english.html");
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/NodeSearchEndpointDTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/NodeSearchEndpointDTest.java
@@ -164,7 +164,7 @@ public class NodeSearchEndpointDTest extends AbstractNodeSearchEndpointTest {
 		NodeResponse request = call(() -> client().findNodeByUuid(projectName(), content("concorde").getUuid()));
 		for (int i = 0; i < numAdditionalNodes; i++) {
 			NodeCreateRequest createRequest = new NodeCreateRequest();
-			createRequest.setSchema(schemaVersion.transformToReference());
+			createRequest.setSchema(tx(() -> schemaVersion.transformToReference()));
 			MicronodeResponse micronodeField = new MicronodeResponse();
 			micronodeField.getFields().putAll(
 					Map.of("firstName", new StringFieldImpl().setString("Mickey"),
@@ -209,7 +209,7 @@ public class NodeSearchEndpointDTest extends AbstractNodeSearchEndpointTest {
 		// Create tags:
 		int tagCount = 20;
 		for (int i = 0; i < tagCount; i++) {
-			TagResponse tagResponse = createTag(PROJECT_NAME, tagFamily("colors").getUuid(), "tag" + i);
+			TagResponse tagResponse = createTag(PROJECT_NAME, tx(() -> tagFamily("colors").getUuid()), "tag" + i);
 			// Add tags to node:
 			call(() -> client().addTagToNode(PROJECT_NAME, node.getUuid(), tagResponse.getUuid(), new VersioningParametersImpl().draft()));
 		}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/ProjectSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/ProjectSearchEndpointTest.java
@@ -55,7 +55,7 @@ public class ProjectSearchEndpointTest extends AbstractMultiESTest implements Ba
 		final String newName = "newproject";
 		ProjectResponse project = createProject(newName);
 		try (Tx tx = tx()) {
-			assertNotNull(boot().projectDao().findByUuid(project.getUuid()));
+			assertNotNull(tx.projectDao().findByUuid(project.getUuid()));
 		}
 		waitForSearchIdleEvent();
 		ProjectListResponse response = call(() -> client().searchProjects(getSimpleTermQuery("name.raw", newName), new PagingParametersImpl().setPage(

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/SchemaSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/SchemaSearchEndpointTest.java
@@ -121,7 +121,7 @@ public class SchemaSearchEndpointTest extends AbstractMultiESTest implements Bas
 		final String newName = "newschema";
 		SchemaResponse schema = createSchema(newName);
 		try (Tx tx = tx()) {
-			assertNotNull(boot().schemaDao().findByUuid(schema.getUuid()));
+			assertNotNull(tx.schemaDao().findByUuid(schema.getUuid()));
 		}
 		waitForSearchIdleEvent();
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/index/BasicIndexSyncTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/index/BasicIndexSyncTest.java
@@ -114,9 +114,9 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 	@Ignore("Currently fails due to https://github.com/gentics/mesh/issues/606")
 	public void testUserSync() throws Exception {
 		// Assert insert
-		tx(() -> {
+		tx(tx -> {
 			for (int i = 0; i < 400; i++) {
-				boot().userDao().create("user_" + i, user(), null);
+				tx.userDao().create("user_" + i, user(), null);
 			}
 		});
 		syncIndex();
@@ -157,8 +157,8 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 		assertMetrics("group", 0, 1, 0);
 
 		// Assert deletion
-		tx(() -> {
-			HibGroup group3 = boot().groupDao().findByName("group_3");
+		tx(tx -> {
+			HibGroup group3 = tx.groupDao().findByName("group_3");
 			CommonTx.get().groupDao().deletePersisted(group3);
 		});
 		syncIndex();
@@ -168,24 +168,24 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 	@Test
 	public void testRoleSync() throws Exception {
 		// Assert insert
-		tx(() -> {
+		tx(tx -> {
 			for (int i = 0; i < 400; i++) {
-				boot().roleDao().create("role_" + i, user(), null);
+				tx.roleDao().create("role_" + i, user(), null);
 			}
 		});
 		syncIndex();
 		assertMetrics("role", 400, 0, 0);
 
 		// Assert update
-		tx(() -> {
-			Tx.get().roleDao().findByUuid(role().getUuid()).setName("updated");
+		tx(tx -> {
+			tx.roleDao().findByUuid(role().getUuid()).setName("updated");
 		});
 		syncIndex();
 		assertMetrics("role", 0, 1, 0);
 
 		// Assert deletion
-		tx(() -> {
-			boot().roleDao().findByName("role_3").removeElement();
+		tx(tx -> {
+			tx.roleDao().findByName("role_3").removeElement();
 		});
 		syncIndex();
 		assertMetrics("role", 0, 0, 1);
@@ -298,9 +298,9 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 	@Test
 	public void testNodeSync() throws Exception {
 		// Assert insert
-		tx(() -> {
+		tx(tx -> {
 			HibNode node = folder("2015");
-			boot().contentDao().createFieldContainer(node, german(), initialBranch(), user());
+			tx.contentDao().createFieldContainer(node, german(), initialBranch(), user());
 		});
 		syncIndex();
 		assertInsertedMetrics(call(() -> client().searchStatus()).getMetrics().get("node"), 1);
@@ -348,8 +348,8 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 		// Assert update
 		SchemaResponse response = call(() -> client().createSchema(new SchemaCreateRequest().setName("dummy")));
 		waitForSearchIdleEvent();
-		tx(() -> {
-			boot().schemaDao().findByUuid(response.getUuid()).setName("updated");
+		tx(tx -> {
+			tx.schemaDao().findByUuid(response.getUuid()).setName("updated");
 		});
 		syncIndex();
 		assertMetrics("schema", 0, 1, 0);
@@ -379,8 +379,8 @@ public class BasicIndexSyncTest extends AbstractMeshTest {
 		assertMetrics("microschema", 400, 0, 0);
 
 		// Assert update
-		tx(() -> {
-			boot().microschemaDao().findByName("microschema_100").setName("updated");
+		tx(tx -> {
+			tx.microschemaDao().findByName("microschema_100").setName("updated");
 		});
 		syncIndex();
 		assertMetrics("microschema", 0, 1, 0);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/permission/GroupPermissionSearchTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/permission/GroupPermissionSearchTest.java
@@ -48,7 +48,7 @@ public class GroupPermissionSearchTest extends AbstractMeshTest {
 		// Now add the perm
 		try (Tx tx = tx()) {
 			RoleDao roleDao = tx.roleDao();
-			HibGroup group = boot().groupDao().findByUuid(response.getUuid());
+			HibGroup group = tx.groupDao().findByUuid(response.getUuid());
 			System.out.println("Group Uuid:" + response.getUuid());
 			roleDao.grantPermissions(role(), group, InternalPermission.READ_PERM);
 			tx.success();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/permission/UserPermissionSearchTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/permission/UserPermissionSearchTest.java
@@ -30,7 +30,7 @@ public class UserPermissionSearchTest extends AbstractMeshTest {
 		try (Tx tx = tx()) {
 			RoleDao roleDao = tx.roleDao();
 			UserDao userDao = tx.userDao();
-			HibUser user = boot().userDao().findByUuid(response.getUuid());
+			HibUser user = tx.userDao().findByUuid(response.getUuid());
 			System.out.println("User Uuid:" + response.getUuid());
 			for (HibRole role : userDao.getRoles(user())) {
 				roleDao.revokePermissions(role, user, InternalPermission.READ_PERM);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/TestDataProvider.java
@@ -146,7 +146,7 @@ public class TestDataProvider {
 			boot.initMandatoryData(meshOptions);
 			boot.initBasicData(meshOptions);
 			if (setAdminPassword) {
-				setAdminPassword();
+				setAdminPassword(tx);
 			}
 			boot.initOptionalData(true);
 			schemaContainers.clear();
@@ -161,15 +161,15 @@ public class TestDataProvider {
 
 			addBootstrappedData(tx);
 			addSchemaContainers();
-			addUserGroupRoleProject();
+			addUserGroupRoleProject(tx);
 			if (getSize() == FULL) {
 				addMicroschemaContainers();
 				addTagFamilies();
 				addTags();
 			}
-			addFolderStructure();
+			addFolderStructure(tx);
 			if (getSize() == FULL) {
-				addContents();
+				addContents(tx);
 			}
 
 			long startPerm = System.currentTimeMillis();
@@ -205,9 +205,9 @@ public class TestDataProvider {
 		log.debug("Setup took: {" + duration + "}");
 	}
 
-	private void setAdminPassword() {
+	private void setAdminPassword(Tx tx) {
 		String hash = "$2a$10$X7NA0kiqrFlyX0NUhPdW1e7jevHyoaoB4OyoxV1pdA7B3SLVSkx22";
-		UserDao userDao = boot.userDao();
+		UserDao userDao = tx.userDao();
 		userDao.updatePasswordHash(userDao.findByUsername("admin"), hash);
 	}
 
@@ -249,32 +249,32 @@ public class TestDataProvider {
 		}
 	}
 
-	private void addContents() {
-		TagDao tagDao = Tx.get().tagDao();
+	private void addContents(Tx tx) {
+		TagDao tagDao = tx.tagDao();
 
-		addContent(folders.get("2014"), "News_2014", "News!", "Neuigkeiten!");
-		addContent(folders.get("march"), "New_in_March_2014", "This is new in march 2014.", "Das ist neu im März 2014");
+		addContent(tx, folders.get("2014"), "News_2014", "News!", "Neuigkeiten!");
+		addContent(tx, folders.get("march"), "New_in_March_2014", "This is new in march 2014.", "Das ist neu im März 2014");
 
-		HibNode content = addContent(folders.get("news"), "News Overview", "News Overview", "News Übersicht",
+		HibNode content = addContent(tx, folders.get("news"), "News Overview", "News Overview", "News Übersicht",
 			CONTENT_UUID);
 		contentUuid = content.getUuid();
 
-		addContent(folders.get("deals"), "Super Special Deal 2015", "Buy two get nine!",
+		addContent(tx, folders.get("deals"), "Super Special Deal 2015", "Buy two get nine!",
 			"Kauf zwei und nimm neun mit!");
-		addContent(folders.get("deals"), "Special Deal June 2015", "Buy two get three!",
+		addContent(tx, folders.get("deals"), "Special Deal June 2015", "Buy two get three!",
 			"Kauf zwei und nimm drei mit!");
 
-		addContent(folders.get("2015"), "Special News_2014", "News!", "Neuigkeiten!");
-		addContent(folders.get("2015"), "News_2015", "News!", "Neuigkeiten!");
+		addContent(tx, folders.get("2015"), "Special News_2014", "News!", "Neuigkeiten!");
+		addContent(tx, folders.get("2015"), "News_2015", "News!", "Neuigkeiten!");
 
-		HibNode concorde = addContent(folders.get("products"), "Concorde",
+		HibNode concorde = addContent(tx, folders.get("products"), "Concorde",
 			"Aérospatiale-BAC Concorde is a turbojet-powered supersonic passenger jet airliner that was in service from 1976 to 2003.",
 			"Die Aérospatiale-BAC Concorde 101/102, kurz Concorde (französisch und englisch für Eintracht, Einigkeit), ist ein Überschall-Passagierflugzeug, das von 1976 bis 2003 betrieben wurde.");
 		tagDao.addTag(concorde, tags.get("plane"), project.getLatestBranch());
 		tagDao.addTag(concorde, tags.get("twinjet"), project.getLatestBranch());
 		tagDao.addTag(concorde, tags.get("red"), project.getLatestBranch());
 
-		HibNode hondaNR = addContent(folders.get("products"), "Honda NR",
+		HibNode hondaNR = addContent(tx, folders.get("products"), "Honda NR",
 			"The Honda NR (New Racing) was a V-four motorcycle engine series started by Honda in 1979 with the 500cc NR500 Grand Prix racer that used oval pistons.",
 			"Die NR750 ist ein Motorrad mit Ovalkolben-Motor des japanischen Motorradherstellers Honda, von dem in den Jahren 1991 und 1992 300 Exemplare gebaut wurden.");
 		tagDao.addTag(hondaNR, tags.get("vehicle"), project.getLatestBranch());
@@ -283,25 +283,25 @@ public class TestDataProvider {
 
 	}
 
-	private void addFolderStructure() {
-		TagDao tagDao = Tx.get().tagDao();
+	private void addFolderStructure(Tx tx) {
+		TagDao tagDao = tx.tagDao();
 
 		HibNode baseNode = project.getBaseNode();
 		// rootNode.addProject(project);
 
-		HibNode news = addFolder(baseNode, "News", "Neuigkeiten", NEWS_UUID);
-		HibNode news2015 = addFolder(news, "2015", null);
+		HibNode news = addFolder(tx, baseNode, "News", "Neuigkeiten", NEWS_UUID);
+		HibNode news2015 = addFolder(tx, news, "2015", null);
 		if (getSize() == FULL) {
 			tagDao.addTag(news2015, tags.get("car"), project.getLatestBranch());
 			tagDao.addTag(news2015, tags.get("bike"), project.getLatestBranch());
 			tagDao.addTag(news2015, tags.get("plane"), project.getLatestBranch());
 			tagDao.addTag(news2015, tags.get("jeep"), project.getLatestBranch());
 
-			HibNode news2014 = addFolder(news, "2014", null);
-			addFolder(news2014, "March", "März");
+			HibNode news2014 = addFolder(tx, news, "2014", null);
+			addFolder(tx, news2014, "March", "März");
 
-			addFolder(baseNode, "Products", "Produkte");
-			addFolder(baseNode, "Deals", "Angebote");
+			addFolder(tx, baseNode, "Products", "Produkte");
+			addFolder(tx, baseNode, "Deals", "Angebote");
 		}
 
 	}
@@ -372,12 +372,12 @@ public class TestDataProvider {
 		return new UserInfo(user, group, role, password);
 	}
 
-	private void addUserGroupRoleProject() {
-		UserDao userDao = Tx.get().userDao();
-		RoleDao roleDao = Tx.get().roleDao();
-		GroupDao groupDao = Tx.get().groupDao();
-		SchemaDao schemaDao = Tx.get().schemaDao();
-		ProjectDao projectDao = Tx.get().projectDao();
+	private void addUserGroupRoleProject(Tx tx) {
+		UserDao userDao = tx.userDao();
+		RoleDao roleDao = tx.roleDao();
+		GroupDao groupDao = tx.groupDao();
+		SchemaDao schemaDao = tx.schemaDao();
+		ProjectDao projectDao = tx.projectDao();
 
 		// User, Groups, Roles
 		userInfo = createUserInfo("joe1", "Joe", "Doe");
@@ -417,7 +417,7 @@ public class TestDataProvider {
 		}
 		// Publish the project basenode
 		InternalActionContext ac = new NodeMigrationActionContextImpl();
-		boot.contentDao().publish(project.getBaseNode(), ac, getEnglish(), getProject().getLatestBranch(),
+		tx.contentDao().publish(project.getBaseNode(), ac, getEnglish(), getProject().getLatestBranch(),
 			getUserInfo().getUser());
 		contentCount++;
 
@@ -540,13 +540,13 @@ public class TestDataProvider {
 		microschemaDao.assign(microschema, project, user(), createBatch());
 	}
 
-	public HibNode addFolder(HibNode rootNode, String englishName, String germanName) {
-		return addFolder(rootNode, englishName, germanName, null);
+	public HibNode addFolder(Tx tx, HibNode rootNode, String englishName, String germanName) {
+		return addFolder(tx, rootNode, englishName, germanName, null);
 	}
 
-	public HibNode addFolder(HibNode rootNode, String englishName, String germanName, String uuid) {
-		NodeDao nodeDao = boot.nodeDao();
-		ContentDao contentDao = boot.contentDao();
+	public HibNode addFolder(Tx tx, HibNode rootNode, String englishName, String germanName, String uuid) {
+		NodeDao nodeDao = tx.nodeDao();
+		ContentDao contentDao = tx.contentDao();
 		InternalActionContext ac = new NodeMigrationActionContextImpl();
 		HibSchemaVersion schemaVersion = schemaContainers.get("folder").getLatestVersion();
 		HibBranch branch = project.getLatestBranch();
@@ -599,14 +599,14 @@ public class TestDataProvider {
 		return tag;
 	}
 
-	private HibNode addContent(HibNode parentNode, String name, String englishContent, String germanContent) {
-		return addContent(parentNode, name, englishContent, germanContent, null);
+	private HibNode addContent(Tx tx, HibNode parentNode, String name, String englishContent, String germanContent) {
+		return addContent(tx, parentNode, name, englishContent, germanContent, null);
 	}
 
-	private HibNode addContent(HibNode parentNode, String name, String englishContent, String germanContent,
+	private HibNode addContent(Tx tx, HibNode parentNode, String name, String englishContent, String germanContent,
 		String uuid) {
-		NodeDao nodeDao = boot.nodeDao();
-		ContentDao contentDao = boot.contentDao();
+		NodeDao nodeDao = tx.nodeDao();
+		ContentDao contentDao = tx.contentDao();
 		InternalActionContext ac = new NodeMigrationActionContextImpl();
 		HibBranch branch = project.getLatestBranch();
 		HibNode node;
@@ -652,8 +652,8 @@ public class TestDataProvider {
 	/**
 	 * Returns the path to the tag for the given language.
 	 */
-	public String getPathForNews2015Tag(String languageTag) {
-		ContentDao contentDao = boot.contentDao();
+	private String getPathForNews2015Tag(Tx tx, String languageTag) {
+		ContentDao contentDao = tx.contentDao();
 
 		String name = contentDao.getLatestDraftFieldContainer(folders.get("news"), languageTag).getString("name")
 			.getString();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/TestGraphHelper.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/TestGraphHelper.java
@@ -65,6 +65,6 @@ public interface TestGraphHelper extends TestHelper {
 	default Stream<HibNodeFieldContainer> getAllContents() {
 		return Tx.get().nodeDao().findAll(project()).stream()
 			.flatMap(node -> Stream.of(DRAFT, PUBLISHED)
-			.flatMap(type -> boot().contentDao().getFieldContainers(node, type).stream()));
+			.flatMap(type -> Tx.get().contentDao().getFieldContainers(node, type).stream()));
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/TestHelper.java
@@ -430,7 +430,7 @@ public interface TestHelper extends EventHelper, ClientHelper {
 
 	default int upload(HibNode node, Buffer buffer, String languageTag, String fieldname, String filename, String contentType) throws IOException {
 		String uuid = tx(() -> node.getUuid());
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(node, languageTag).getVersion());
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(node, languageTag).getVersion(); });
 		NodeResponse response = call(() -> client().updateNodeBinaryField(PROJECT_NAME, uuid, languageTag, version.toString(), fieldname,
 			new ByteArrayInputStream(buffer.getBytes()), buffer.length(),
 			filename, contentType));
@@ -658,7 +658,7 @@ public interface TestHelper extends EventHelper, ClientHelper {
 		String fileName) {
 
 		String uuid = tx(() -> node.getUuid());
-		VersionNumber version = tx(() -> boot().contentDao().getFieldContainer(boot().nodeDao().findByUuidGlobal(uuid), "en").getVersion());		
+		VersionNumber version = tx(tx -> { return tx.contentDao().getFieldContainer(tx.nodeDao().findByUuidGlobal(uuid), "en").getVersion(); });		
 
 		Buffer buffer = TestUtils.randomBuffer(binaryLen);
 		return client().updateNodeBinaryField(PROJECT_NAME, uuid, languageTag, version.toString(), fieldKey,

--- a/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulatorTest.java
+++ b/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulatorTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.awt.image.BufferedImage;
@@ -33,7 +32,6 @@ import org.codehaus.jettison.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.core.data.binary.HibBinary;
 import com.gentics.mesh.core.data.dao.BinaryDao;
 import com.gentics.mesh.core.image.ImageInfo;
@@ -60,7 +58,6 @@ public class ImgscalrImageManipulatorTest extends AbstractImageTest {
 	private static final Logger log = LoggerFactory.getLogger(ImgscalrImageManipulatorTest.class);
 
 	private ImgscalrImageManipulator manipulator;
-	private BootstrapInitializer boot;
 
 	@Before
 	public void setup() {
@@ -68,10 +65,8 @@ public class ImgscalrImageManipulatorTest extends AbstractImageTest {
 
 		ImageManipulatorOptions options = new ImageManipulatorOptions();
 
-		boot = mock(BootstrapInitializer.class);
-		when(boot.binaryDao()).thenReturn(mockBinaryDao());
 		options.setImageCacheDirectory(cacheDir.getAbsolutePath());
-		manipulator = new ImgscalrImageManipulator(Vertx.vertx(), options, boot,null);
+		manipulator = new ImgscalrImageManipulator(Vertx.vertx(), options, null);
 	}
 
 	@Test
@@ -80,7 +75,7 @@ public class ImgscalrImageManipulatorTest extends AbstractImageTest {
 			log.debug("Handling " + imageName);
 
 			HibBinary hb = createMockedBinary(path);
-			BinaryDao dao = boot.binaryDao();
+			BinaryDao dao = mockBinaryDao();
 			when(dao.openBlockingStream(any(HibBinary.class))).thenReturn(() -> ImageTestUtil.class.getResourceAsStream(path));
 			Single<byte[]> obs = manipulator
 				.handleResize(hb, new ImageManipulationParametersImpl().setWidth(150).setHeight(180))

--- a/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrResizeFilterTest.java
+++ b/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrResizeFilterTest.java
@@ -1,8 +1,6 @@
 package com.gentics.mesh.image;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
@@ -13,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.etc.config.ImageManipulatorOptions;
 import com.gentics.mesh.etc.config.ResampleFilter;
 import com.gentics.mesh.parameter.impl.ImageManipulationParametersImpl;
@@ -38,9 +35,7 @@ public class ImgscalrResizeFilterTest extends AbstractImageTest {
 		options.setResampleFilter(filter);
 
 		options.setImageCacheDirectory(cacheDir.getAbsolutePath());
-		BootstrapInitializer boot = mock(BootstrapInitializer.class);
-		when(boot.binaryDao()).thenReturn(mockBinaryDao());
-		manipulator = new ImgscalrImageManipulator(Vertx.vertx(), options, boot, null);
+		manipulator = new ImgscalrImageManipulator(Vertx.vertx(), options, null);
 	}
 
 	@Parameterized.Parameters(name = "filter={0}")

--- a/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ReferenceImageCreator.java
+++ b/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ReferenceImageCreator.java
@@ -2,8 +2,6 @@ package com.gentics.mesh.image;
 
 import static com.gentics.mesh.image.ImgscalrImageManipulatorTest.getReferenceFilename;
 import static com.gentics.mesh.test.util.ImageTestUtil.createMockedBinary;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -12,7 +10,6 @@ import org.apache.commons.io.IOUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 
-import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.etc.config.ImageManipulatorOptions;
 import com.gentics.mesh.parameter.impl.ImageManipulationParametersImpl;
 
@@ -44,9 +41,7 @@ public class ReferenceImageCreator {
 		String tmpDir = new File("target", "tmp_" + System.currentTimeMillis()).getAbsolutePath();
 		options.setImageCacheDirectory(tmpDir);
 
-		BootstrapInitializer boot = mock(BootstrapInitializer.class);
-		when(boot.binaryDao()).thenReturn(AbstractImageTest.mockBinaryDao());
-		ImgscalrImageManipulator manipulator = new ImgscalrImageManipulator(vertx, options, boot, null);
+		ImgscalrImageManipulator manipulator = new ImgscalrImageManipulator(vertx, options, null);
 
 		readImageConfig().blockingForEach(image -> {
 			String imageName = image.getString("name");


### PR DESCRIPTION
…omponents. No access to DAOs outside the transaction.

## Abstract

DAOs have to be accessed from within an existing transaction. Having them accessible from BootstrapInitializer violates the TX existence requirement. Since DAOs are removed from BootstrapInitializer, the BootstrapInitializer itself is no longer required in the fair most of components.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
