### PR TITLE
add tests for case sensitity

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,9 @@ include::content/docs/variables.adoc-include[]
 
 icon:check[] Core: Possible errors during node migrations in branches have been fixed.
 
+icon:check[] Core: Schema field names are now checked for uniqueness regardless of case sensitivity. This behavior was already
+enforced in the UI, and is now enforced in the REST API. The check is not performed for existing schemas.
+
 [[v1.8.6]]
 == 1.8.6 (06.07.2022)
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchemaContainer.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchemaContainer.java
@@ -208,7 +208,7 @@ public interface FieldSchemaContainer extends RestModel {
 		Set<String> fieldNames = new HashSet<>();
 		for (FieldSchema field : getFields()) {
 			if (field.getName() != null) {
-				if (!fieldNames.add(field.getName())) {
+				if (!fieldNames.add(field.getName().toLowerCase())) {
 					throw error(BAD_REQUEST, "schema_error_duplicate_field_name", field.getName());
 				}
 			}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaModelTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaModelTest.java
@@ -272,7 +272,7 @@ public class SchemaModelTest {
 		schema.setDisplayField("name");
 		schema.addField(FieldUtil.createStringFieldSchema("name"));
 		schema.addField(FieldUtil.createStringFieldSchema("Name"));
-		schema.validate();
+		expectErrorOnValidate(schema, "schema_error_duplicate_field_name", "Name");
 	}
 
 	/**

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaModelTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/SchemaModelTest.java
@@ -264,6 +264,17 @@ public class SchemaModelTest {
 		expectErrorOnValidate(schema, "schema_error_duplicate_field_name", "name");
 	}
 
+	@Test
+	public void testCaseSensitivityDuplicateSchemaName() {
+		SchemaModel schema = new SchemaModelImpl();
+		schema.setName("test");
+		schema.setSegmentField("name");
+		schema.setDisplayField("name");
+		schema.addField(FieldUtil.createStringFieldSchema("name"));
+		schema.addField(FieldUtil.createStringFieldSchema("Name"));
+		schema.validate();
+	}
+
 	/**
 	 * The display field must always point to a string field.
 	 */


### PR DESCRIPTION
## Abstract
Add a few tests for case sensitivity.
Test one check that the segment field content is unique considering casing.
Test two check that it's possible to create two fields with the same name, but different casing. Interestingly, this is allowed in the rest api, but the mesh ui will complain about that

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
