### PR TITLE
Hotfix 1.6.x sup 11414

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.31]]
+== 1.6.31 (TBD)
+
+icon:check[] Core: Mesh will now trigger job executions on startup.
+
 [[v1.6.30]]
 == 1.6.30 (06.07.2022)
 

--- a/common/src/main/java/com/gentics/mesh/verticle/AbstractJobVerticle.java
+++ b/common/src/main/java/com/gentics/mesh/verticle/AbstractJobVerticle.java
@@ -90,7 +90,7 @@ public abstract class AbstractJobVerticle extends AbstractVerticle {
 	}
 
 	/**
-	 * Acquire a cluster wide exclusive lock. By default the method will try to acquire the lock within 10s. The errorAction is invoked if the lock could not be
+	 * Acquire a cluster wide exclusive lock. By default the method will try to acquire the lock within 1s. The errorAction is invoked if the lock could not be
 	 * acquired by then.
 	 * 
 	 * @param action

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -405,7 +405,11 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 		}
 
 		eventbusLiveness.startRegularChecks();
-		db.clusterManager().waitUntilWriteQuorumReached().andThen(Completable.fromAction(() -> MeshEvent.triggerJobWorker(mesh))).subscribe();
+		db.clusterManager().waitUntilWriteQuorumReached().andThen(Completable.fromAction(() -> {
+			if (!isClustered || coordinatorMasterElector.isMaster()) {
+				MeshEvent.triggerJobWorker(mesh);
+			}
+		})).subscribe();
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.gentics.mesh.core.rest.MeshEvent;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -404,6 +405,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 		}
 
 		eventbusLiveness.startRegularChecks();
+		MeshEvent.triggerJobWorker(mesh);
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/BootstrapInitializerImpl.java
@@ -405,7 +405,7 @@ public class BootstrapInitializerImpl implements BootstrapInitializer {
 		}
 
 		eventbusLiveness.startRegularChecks();
-		MeshEvent.triggerJobWorker(mesh);
+		db.clusterManager().waitUntilWriteQuorumReached().andThen(Completable.fromAction(() -> MeshEvent.triggerJobWorker(mesh))).subscribe();
 	}
 
 	/**


### PR DESCRIPTION
## Abstract
Trigger jobs on startup.
Since the job worker is deployed on each mesh instance, I've restricted the triggering to the master instance, in order to avoid replicas to write to the graph store.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
