### PR TITLE
Plugin initialization depends on database online status

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,8 @@ icon:plus[] Java Rest Client: The new options `maxRetries` and `retryDelayMs` ca
 
 icon:check[] Plugins: Fixes plugin initialization such that plugins that failed to load will cause the livenes probe to return an unhealthy status.
 
+icon:check[] Cluster: The plugin initialization now waits not only for the write quorum being reached, but for the node availability as well, during the startup.
+
 [[v1.8.6]]
 == 1.8.6 (06.07.2022)
 

--- a/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
+++ b/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
@@ -604,8 +604,8 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 		// Handle admin password reset
 		String password = configuration.getAdminPassword();
 		if (password != null) {
-			// wait for writeQuorum, then update/create the admin user
-			db().clusterManager().waitUntilWriteQuorumReached().andThen(doWithLock(GLOBAL_CHANGELOG_LOCK_KEY,
+			// wait for DB being ready, then update/create the admin user
+			db().clusterManager().waitUntilDistributedDatabaseReady().andThen(doWithLock(GLOBAL_CHANGELOG_LOCK_KEY,
 					"setting admin password", ensureAdminUser(password), 60 * 1000)).subscribe();
 		}
 

--- a/core/src/main/java/com/gentics/mesh/plugin/registry/DelegatingPluginRegistryImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/registry/DelegatingPluginRegistryImpl.java
@@ -122,7 +122,7 @@ public class DelegatingPluginRegistryImpl implements DelegatingPluginRegistry {
 
 		String id = plugin.id();
 		JsonObject payload = toEventPayload(plugin);
-		optionalQuorumCheck().andThen(optionalLock(registerAndInitializePlugin(plugin), id)).subscribe(() -> {
+		optionalDatabaseReadyCheck().andThen(optionalLock(registerAndInitializePlugin(plugin), id)).subscribe(() -> {
 			log.info("Completed handling of pre-registered plugin {" + id + "}");
 			manager.get().setStatus(id, REGISTERED);
 
@@ -179,9 +179,9 @@ public class DelegatingPluginRegistryImpl implements DelegatingPluginRegistry {
 		}
 	}
 
-	private Completable optionalQuorumCheck() {
+	private Completable optionalDatabaseReadyCheck() {
 		if (options.getClusterOptions().isEnabled()) {
-			return db.clusterManager().waitUntilWriteQuorumReached();
+			return db.clusterManager().waitUntilWriteQuorumReached().andThen(db.clusterManager().waitUntilLocalNodeOnline());
 		} else {
 			return Completable.complete();
 		}

--- a/core/src/main/java/com/gentics/mesh/plugin/registry/DelegatingPluginRegistryImpl.java
+++ b/core/src/main/java/com/gentics/mesh/plugin/registry/DelegatingPluginRegistryImpl.java
@@ -181,7 +181,7 @@ public class DelegatingPluginRegistryImpl implements DelegatingPluginRegistry {
 
 	private Completable optionalDatabaseReadyCheck() {
 		if (options.getClusterOptions().isEnabled()) {
-			return db.clusterManager().waitUntilWriteQuorumReached().andThen(db.clusterManager().waitUntilLocalNodeOnline());
+			return db.clusterManager().waitUntilDistributedDatabaseReady();
 		} else {
 			return Completable.complete();
 		}

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/cluster/ClusterManager.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/cluster/ClusterManager.java
@@ -47,6 +47,13 @@ public interface ClusterManager {
 	Completable waitUntilWriteQuorumReached();
 
 	/**
+	 * Returns a completable which will complete once the local node is online and fully usable.
+	 * 
+	 * @return
+	 */
+	Completable waitUntilLocalNodeOnline();
+
+	/**
 	 * Checks if the cluster storage is locked cluster-wide.
 	 * 
 	 * @return

--- a/mdm/api/src/main/java/com/gentics/mesh/core/db/cluster/ClusterManager.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/db/cluster/ClusterManager.java
@@ -72,4 +72,13 @@ public interface ClusterManager {
 	 * @return
 	 */
 	boolean isWriteQuorumReached();
+
+	/**
+	 * Returns a completable which will complete once the database is ready for serving requests.
+	 * 
+	 * @return
+	 */
+	default Completable waitUntilDistributedDatabaseReady() {
+		return waitUntilWriteQuorumReached().andThen(waitUntilLocalNodeOnline());
+	}
 }

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/cli/OrientDBBootstrapInitializerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/cli/OrientDBBootstrapInitializerImpl.java
@@ -298,7 +298,7 @@ public class OrientDBBootstrapInitializerImpl extends AbstractBootstrapInitializ
 		}
 
 		// wait for writeQuorum, then raise a global lock and execute changelog
-		db.clusterManager().waitUntilWriteQuorumReached()
+		db.clusterManager().waitUntilDistributedDatabaseReady()
 				.andThen(doWithLock(GLOBAL_CHANGELOG_LOCK_KEY, "executing changelog", executeChangelog(flags, configuration), 60 * 1000)).subscribe();
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/plugin/AbstractPluginTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/plugin/AbstractPluginTest.java
@@ -87,10 +87,7 @@ public class AbstractPluginTest extends AbstractMeshTest {
 	}
 
 	public void copy(String sourcePath, String name) throws IOException {
-		new File(pluginDir()).mkdirs();
-		try (InputStream sourceRes = getClass().getResourceAsStream(sourcePath)) {
-			Files.copy(sourceRes, new File(pluginDir(), name).toPath(), StandardCopyOption.REPLACE_EXISTING);
-		}
+		copyFromResources(getClass(), sourcePath, pluginDir(), name);
 	}
 
 	public PluginResponse copyAndDeploy(String sourcePath, String name) throws IOException {
@@ -103,5 +100,12 @@ public class AbstractPluginTest extends AbstractMeshTest {
 		copy(sourcePath, name);	
 		PluginDeploymentRequest request = new PluginDeploymentRequest().setPath(name);
 		call(() -> client().deployPlugin(request), status, key, params);
+	}
+
+	public static void copyFromResources(Class<?> cls, String sourcePath, String targetPath, String name) throws IOException {
+		new File(targetPath).mkdirs();
+		try (InputStream sourceRes = cls.getResourceAsStream(sourcePath)) {
+			Files.copy(sourceRes, new File(targetPath, name).toPath(), StandardCopyOption.REPLACE_EXISTING);
+		}
 	}
 }

--- a/tests/tests-distributed/pom.xml
+++ b/tests/tests-distributed/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -42,6 +43,10 @@
 		<dependency>
 			<groupId>com.gentics.mesh</groupId>
 			<artifactId>mesh-test-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.gentics.mesh</groupId>
+			<artifactId>tests-mesh-core</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/PluginClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/PluginClusterTest.java
@@ -39,7 +39,7 @@ public class PluginClusterTest extends AbstractClusterTest {
 
 	private static final String BASIC_PLUGIN_NAME = "basic.jar";
 
-	private static final String BASIC_PLUGIN = "../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar";
+	private static final String BASIC_PLUGIN = "target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar";
 
 	private static String clusterPostFix = randomUUID();
 

--- a/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/PluginClusterTest.java
+++ b/tests/tests-distributed/src/main/java/com/gentics/mesh/distributed/PluginClusterTest.java
@@ -8,6 +8,7 @@ import static com.gentics.mesh.util.UUIDUtil.randomUUID;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -21,6 +22,7 @@ import com.gentics.mesh.context.impl.LoggingConfigurator;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.core.rest.plugin.PluginListResponse;
 import com.gentics.mesh.core.rest.plugin.PluginResponse;
+import com.gentics.mesh.plugin.AbstractPluginTest;
 import com.gentics.mesh.rest.client.MeshWebsocket;
 import com.gentics.mesh.test.category.ClusterTests;
 import com.gentics.mesh.test.category.PluginTests;
@@ -35,11 +37,23 @@ import io.vertx.core.logging.LoggerFactory;
 @Category({ClusterTests.class, PluginTests.class})
 public class PluginClusterTest extends AbstractClusterTest {
 
+	private static final String BASIC_PLUGIN_NAME = "basic.jar";
+
+	private static final String BASIC_PLUGIN = "../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar";
+
 	private static String clusterPostFix = randomUUID();
 
 	private static final int STARTUP_TIMEOUT = 500;
 
 	private static final Logger log = LoggerFactory.getLogger(PluginClusterTest.class);
+
+	static {
+		try {
+			AbstractPluginTest.copyFromResources(PluginClusterTest.class, AbstractPluginTest.BASIC_PATH, BASIC_PLUGIN, BASIC_PLUGIN_NAME);
+		} catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+	}
 
 	@ClassRule
 	public static MeshContainer serverA = createDefaultMeshContainer()
@@ -49,7 +63,7 @@ public class PluginClusterTest extends AbstractClusterTest {
 		.withInitCluster()
 		.waitForStartup()
 		.withWriteQuorum(2)
-		.withPlugin(new File("../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar"), "basic.jar")
+		.withPlugin(new File(BASIC_PLUGIN), BASIC_PLUGIN_NAME)
 		.withClearFolders();
 
 	@BeforeClass
@@ -92,7 +106,7 @@ public class PluginClusterTest extends AbstractClusterTest {
 
 	private MeshContainer addSlave(String nodeName) throws InterruptedException {
 		MeshContainer server = prepareSlave(clusterPostFix, nodeName, randomToken(), true, 2)
-			.withPlugin(new File("../../core/target/test-plugins/basic/target/basic-plugin-0.0.1-SNAPSHOT.jar"), "basic.jar");
+			.withPlugin(new File(BASIC_PLUGIN), BASIC_PLUGIN_NAME);
 		server.start();
 		server.awaitStartup(STARTUP_TIMEOUT);
 		login(server);


### PR DESCRIPTION
## Abstract

As reaching the write quorum is not enough for the plugins to be initialized, when a DB usage is required, the restriction has been upgraded to wait for the local database node reported online.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
