### PR TITLE
fix permission checks for root node

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.32]]
+== 1.6.32 (TBD)
+
+icon:check[] GraphQL: When a node with the root webpath was retrieved in a specific branch, a permission error was returned, even if user had permission for it. This has been fixed.
+
 [[v1.6.31]]
 == 1.6.31 (21.07.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/service/WebRootServiceImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/service/WebRootServiceImpl.java
@@ -4,6 +4,7 @@ import static com.gentics.mesh.core.data.GraphFieldContainerEdge.WEBROOT_URLFIEL
 import static com.gentics.mesh.util.URIUtils.decodeSegment;
 
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Stack;
 import java.util.stream.IntStream;
 
@@ -80,14 +81,14 @@ public class WebRootServiceImpl implements WebRootService {
 
 		// Handle path to project root (baseNode)
 		if ("/".equals(strippedPath) || strippedPath.isEmpty()) {
-			// TODO Why this container? Any other container would also be fine?
-			Iterator<? extends NodeGraphFieldContainer> it = baseNode.getDraftGraphFieldContainers().iterator();
-			NodeGraphFieldContainer container = it.next();
-			nodePath.addSegment(new PathSegment(container, null, null, "/"));
-			stack.push("/");
-			nodePath.setInitialStack(stack);
-			pathStore.store(project, branch, type, path, nodePath);
-			return nodePath;
+			Optional<? extends NodeGraphFieldContainer> container = baseNode.getGraphFieldContainers(branch, type).stream().findFirst();
+			if (container.isPresent()) {
+				nodePath.addSegment(new PathSegment(container.get(), null, null, "/"));
+				stack.push("/");
+				nodePath.setInitialStack(stack);
+				pathStore.store(project, branch, type, path, nodePath);
+				return nodePath;
+			}
 		}
 
 		// Prepare the stack which we use for resolving

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLWebrootTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLWebrootTest.java
@@ -6,12 +6,21 @@ import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 
 import java.io.IOException;
 
+import com.gentics.mesh.core.rest.branch.BranchCreateRequest;
+import com.gentics.mesh.core.rest.common.Permission;
 import com.gentics.mesh.core.rest.graphql.GraphQLRequest;
+import com.gentics.mesh.core.rest.job.JobStatus;
 import com.gentics.mesh.core.rest.node.NodeCreateRequest;
 import com.gentics.mesh.core.rest.node.NodeResponse;
 import com.gentics.mesh.core.rest.node.field.impl.StringFieldImpl;
+import com.gentics.mesh.core.rest.project.ProjectResponse;
+import com.gentics.mesh.core.rest.role.RolePermissionRequest;
+import com.gentics.mesh.core.rest.role.RolePermissionResponse;
 import com.gentics.mesh.parameter.LinkType;
+import com.gentics.mesh.parameter.ParameterProvider;
 import com.gentics.mesh.parameter.impl.NodeParametersImpl;
+import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import com.gentics.mesh.core.rest.branch.BranchUpdateRequest;
@@ -65,6 +74,48 @@ public class GraphQLWebrootTest extends AbstractMeshTest {
 
 		response = singleParameterQuery(getUuidByPath, "path", resultPath);
 		assertThat(response.getData().getJsonObject("node").getString("uuid")).isEqualTo(uuid);
+	}
+
+	@Test
+	public void testRootNodeInBranch() throws IOException {
+		final String getUuidByPath = "webroot/get-uuid-by-path";
+		final String projectName = "testProject";
+		final String newBranchName = "test1";
+
+		// create project
+		ProjectResponse project = createProject(projectName);
+
+		// create branch
+		grantAdmin();
+		waitForJobs(() -> {
+			BranchCreateRequest branchCreateRequest = new BranchCreateRequest();
+			branchCreateRequest.setName(newBranchName);
+			branchCreateRequest.setLatest(false);
+			call(() -> client().createBranch(projectName, branchCreateRequest));
+		}, JobStatus.COMPLETED, 1);
+		revokeAdmin();
+
+		NodeResponse request = new NodeResponse();
+		request.setUuid(project.getRootNode().getUuid());
+		// publish node in initial branch
+		call(() -> client().publishNode(projectName, project.getRootNode().getUuid()));
+		// publish node in new branch
+		call(() -> client().publishNode(projectName, project.getRootNode().getUuid(), new VersioningParametersImpl().setBranch(newBranchName)));
+
+		// assign only publish permission to root node
+		RolePermissionRequest permissionRequest = new RolePermissionRequest();
+		permissionRequest.getPermissions().setOthers(false, true).add(Permission.READ_PUBLISHED);
+		call(() -> client().updateRolePermissions(roleUuid(), "projects/" + projectName + "/nodes/" + project.getRootNode().getUuid(), permissionRequest));
+
+		// query
+		GraphQLResponse response = client().graphql(projectName, new GraphQLRequest()
+						.setQuery(getGraphQLQuery(getUuidByPath))
+						.setVariables(new JsonObject().put("path", "/")),
+						new VersioningParametersImpl().draft().setBranch(newBranchName)
+		).blockingGet();
+
+		assertThat(response.getErrors()).isNull();
+		assertThat(response.getData().getJsonObject("node").getString("uuid")).isEqualTo(project.getRootNode().getUuid());
 	}
 
 	private GraphQLResponse singleParameterQuery(String queryName, String parameterName, String parameterValue) throws IOException {


### PR DESCRIPTION
## Abstract
The webroot service root container resolution was flawed, since it didn't take into account branch and container type. This could cause permission issues in graphql when retrieving the root node in a branch that wasn't the default one

## Checklist

### General

* [X] Added abstract that describes the change
* [X] Added changelog entry to `/CHANGELOG.adoc`
* [X] Ensured that the change is covered by tests
* [X] Ensured that the change is documented in the docs

### On API Changes

* [X] Checked if the changes are breaking or not
* [X] Added GraphQL API if applicable
* [X] Added Elasticsearch mapping if applicable
