### PR TITLE
Hotfix 1.6.x sup 13991 check rootnode permission

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,13 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.32]]
+== 1.6.32 (TBD)
+
+icon:check[] GraphQL: The behaviour for getting a single node with `version`=`draft` using GraphQL has been changed. Before, if a user had only `read published` permissions
+and was requesting a draft node, the node content was returned in case the draft version matched the published version. Now a permission error will be returned
+without the actual content of the node.
+
 [[v1.6.31]]
 == 1.6.31 (21.07.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/impl/UserImpl.java
@@ -382,15 +382,14 @@ public class UserImpl extends AbstractMeshCoreVertex<UserResponse, User> impleme
 
 	@Override
 	public boolean hasReadPermission(NodeGraphFieldContainer container, String branchUuid, String requestedVersion) {
+		ContainerType type = ContainerType.forVersion(requestedVersion);
 		Node node = container.getParentNode();
-		if (hasPermission(node, READ_PERM)) {
-			return true;
+		if (ContainerType.PUBLISHED.equals(type)) {
+			boolean published = container.isPublished(branchUuid);
+			return published && hasPermission(node, READ_PUBLISHED_PERM);
 		}
-		boolean published = container.isPublished(branchUuid);
-		if (published && hasPermission(node, READ_PUBLISHED_PERM)) {
-			return true;
-		}
-		return false;
+
+		return hasPermission(node, READ_PERM);
 	}
 
 	@Override

--- a/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLPublishedMatchingDraftNodePermissionTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/graphql/GraphQLPublishedMatchingDraftNodePermissionTest.java
@@ -1,0 +1,141 @@
+package com.gentics.mesh.core.graphql;
+
+import com.gentics.mesh.FieldUtil;
+import com.gentics.mesh.core.rest.common.Permission;
+import com.gentics.mesh.core.rest.common.PermissionInfo;
+import com.gentics.mesh.core.rest.graphql.GraphQLRequest;
+import com.gentics.mesh.core.rest.graphql.GraphQLResponse;
+import com.gentics.mesh.core.rest.node.NodeUpdateRequest;
+import com.gentics.mesh.core.rest.role.RolePermissionRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.parameter.impl.PublishParametersImpl;
+import com.gentics.mesh.test.TestSize;
+import com.gentics.mesh.test.context.MeshTestSetting;
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.*;
+
+import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+
+/**
+ * Tests for node queries when having a node with published version equals to draft version.
+ */
+@RunWith(Parameterized.class)
+@MeshTestSetting(testSize = TestSize.FULL, startServer = true)
+public class GraphQLPublishedMatchingDraftNodePermissionTest extends AbstractGraphQLNodeTest {
+
+    private final String query;
+    private final String version;
+
+    public GraphQLPublishedMatchingDraftNodePermissionTest(String query, String version) {
+        this.query = query;
+        this.version = version;
+    }
+
+    @Parameterized.Parameters(name = "query={0}, version={1}")
+    public static Collection<Object[]> parameters() {
+        List<String> queries = Arrays.asList(
+                "rootNode",
+                "nodePerUuid",
+                "nodePerPath"
+        );
+        List<String> versions = Arrays.asList("draft", "published");
+
+        List<Object[]> data = new ArrayList<>();
+        for (String query : queries) {
+            for (String version : versions) {
+
+                data.add(new Object[]{query, version});
+            }
+        }
+
+        return data;
+    }
+
+    private void setupContent() {
+        String baseNodeUuid = tx(() -> project().getBaseNode().getUuid());
+
+        SchemaCreateRequest schemaRequest = new SchemaCreateRequest();
+        schemaRequest.setName(SCHEMA_NAME);
+        schemaRequest.setContainer(true);
+        schemaRequest.setSegmentField("name");
+        schemaRequest.addField(FieldUtil.createStringFieldSchema("name"));
+        schemaRequest.addField(FieldUtil.createStringFieldSchema("extra"));
+        schemaRequest.addField(FieldUtil.createNodeFieldSchema("node"));
+        schemaRequest.addField(FieldUtil.createListFieldSchema("nodeList").setListType("node"));
+
+        SchemaResponse schemaResponse = call(() -> client().createSchema(schemaRequest));
+        call(() -> client().assignSchemaToProject(PROJECT_NAME, schemaResponse.getUuid()));
+
+        NodeUpdateRequest rootNodeUpdateRequest = new NodeUpdateRequest();
+        rootNodeUpdateRequest.setLanguage("en");
+        rootNodeUpdateRequest.getFields().putString("name", "root");
+        call(() -> client().updateNode(PROJECT_NAME, baseNodeUuid, rootNodeUpdateRequest));
+        call(() -> client().publishNode(PROJECT_NAME, baseNodeUuid, new PublishParametersImpl().setRecursive(true)));
+    }
+
+    public void setupPermissions() {
+        // Apply permissions for test run
+        RolePermissionRequest permRequest = new RolePermissionRequest();
+        PermissionInfo permissionsInfo = permRequest.getPermissions();
+        permissionsInfo.set(Permission.READ_PUBLISHED, true);
+        permissionsInfo.setOthers(false);
+        permRequest.setRecursive(true);
+        adminCall(() -> client().updateRolePermissions(roleUuid(), "/projects/" + PROJECT_NAME + "/nodes", permRequest));
+    }
+
+    @Test
+    public void test() throws IOException {
+        setupContent();
+        setupPermissions();
+        GraphQLRequest request = new GraphQLRequest();
+        String queryName = "node/publishedmatchingdraft/" + query;
+        JsonObject var = new JsonObject();
+        var.put("uuid", tx(() -> project().getBaseNode().getUuid()));
+        var.put("type", version);
+        request.setVariables(var);
+        request.setQuery(getGraphQLQuery(queryName));
+        GraphQLResponse response = call(() -> client().graphql(PROJECT_NAME, request));
+        JsonObject jsonResponse = new JsonObject(response.toJson());
+        System.out.println(jsonResponse.encodePrettily());
+        System.out.println("Query: " + queryName);
+
+        compliesToAssertions(jsonResponse, queryName);
+    }
+
+    public static final String CHECK_PERM = "checkperm:";
+
+    private void compliesToAssertions(JsonObject jsonResponse, String queryName) throws IOException {
+        String query = getGraphQLQuery(queryName);
+
+        try (Scanner scanner = new Scanner(query)) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                line = line.trim();
+                if (line.startsWith("# [")) {
+                    int start = line.indexOf("# [") + 3;
+                    int end = line.lastIndexOf("]");
+                    String selector = line.substring(start, end);
+                    int ab = line.indexOf("=", end) + 1;
+                    String assertion = line.substring(ab);
+                    String currentSelector = "select_" + version;
+                    if (currentSelector.equalsIgnoreCase(selector)) {
+                        if (assertion.startsWith(CHECK_PERM)) {
+                            String permPath = assertion.substring(CHECK_PERM.length());
+                            assertThat(jsonResponse).hasPermFailure(permPath);
+                        } else {
+                            assertThat(jsonResponse).compliesTo(assertion);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/resources/graphql/node-perm-children-query.draft
+++ b/core/src/test/resources/graphql/node-perm-children-query.draft
@@ -34,7 +34,7 @@
 		}
 	}
 }
-# [$.errors.length()=2]
+# [$.errors.length()=3]
 # [$.errors[0].message=graphql_error_missing_perm]
 # [$.errors[1].message=graphql_error_missing_perm]
 # [$.errors[0].type=missing_perm]

--- a/core/src/test/resources/graphql/node/publishedmatchingdraft/nodePerPath
+++ b/core/src/test/resources/graphql/node/publishedmatchingdraft/nodePerPath
@@ -1,0 +1,24 @@
+query Test($type: NodeVersion) {
+  nodePerPath: node(path: "/", version: $type) {
+    uuid
+    path
+    version
+    ... on folder {
+        fields {
+            slug
+        }
+    }
+  }
+}
+
+# [select_published]=$.data.nodePerPath.uuid=<not-null>
+# [select_published]=$.data.nodePerPath.path=<not-null>
+# [select_published]=$.data.nodePerPath.version=<not-null>
+# [select_published]=$.data.nodePerPath.fields=<not-null>
+
+# [select_draft]=$.data.nodePerPath.uuid=<not-null>
+# [select_draft]=$.data.nodePerPath.path=<is-null>
+# [select_draft]=$.data.nodePerPath.version=<is-null>
+# [select_draft]=$.data.nodePerPath.fields=<is-null>
+# [select_draft]=checkperm:nodePerPath
+

--- a/core/src/test/resources/graphql/node/publishedmatchingdraft/nodePerUuid
+++ b/core/src/test/resources/graphql/node/publishedmatchingdraft/nodePerUuid
@@ -1,0 +1,24 @@
+query Test($type: NodeVersion, $uuid: String) {
+  nodePerUuid: node(uuid: $uuid, version: $type) {
+    uuid
+    path
+    version
+    ... on folder {
+        fields {
+            slug
+        }
+    }
+  }
+}
+
+# [select_published]=$.data.nodePerUuid.uuid=<not-null>
+# [select_published]=$.data.nodePerUuid.path=<not-null>
+# [select_published]=$.data.nodePerUuid.version=<not-null>
+# [select_published]=$.data.nodePerUuid.fields=<not-null>
+
+# [select_draft]=$.data.nodePerUuid.uuid=<not-null>
+# [select_draft]=$.data.nodePerUuid.path=<is-null>
+# [select_draft]=$.data.nodePerUuid.version=<is-null>
+# [select_draft]=$.data.nodePerUuid.fields=<is-null>
+# [select_draft]=checkperm:nodePerUuid
+

--- a/core/src/test/resources/graphql/node/publishedmatchingdraft/rootNode
+++ b/core/src/test/resources/graphql/node/publishedmatchingdraft/rootNode
@@ -1,0 +1,23 @@
+query Test($type: NodeVersion) {
+
+  rootNode(version: $type) {
+    uuid
+    path
+    version
+    ... on folder {
+        fields {
+            slug
+        }
+    }
+  }
+}
+# [select_published]=$.data.rootNode.uuid=<not-null>
+# [select_published]=$.data.rootNode.path=<not-null>
+# [select_published]=$.data.rootNode.version=<not-null>
+# [select_published]=$.data.rootNode.fields=<not-null>
+
+# [select_draft]=$.data.rootNode.uuid=<not-null>
+# [select_draft]=$.data.rootNode.path=<is-null>
+# [select_draft]=$.data.rootNode.version=<is-null>
+# [select_draft]=$.data.rootNode.fields=<is-null>
+# [select_draft]=checkperm:rootNode

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/context/GraphQLContext.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/context/GraphQLContext.java
@@ -7,6 +7,7 @@ import com.gentics.mesh.core.data.MeshCoreVertex;
 import com.gentics.mesh.core.data.NodeGraphFieldContainer;
 import com.gentics.mesh.core.data.node.NodeContent;
 import com.gentics.mesh.core.data.relationship.GraphPermission;
+import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.error.PermissionException;
 import com.gentics.mesh.plugin.graphql.GraphQLPluginContext;
 
@@ -30,29 +31,32 @@ public interface GraphQLContext extends InternalActionContext, GraphQLPluginCont
 
 	/**
 	 * Check whether the current user of the context has read permission on the container (via type and parent node).
-	 * 
+	 *
 	 * @param container
+	 * @param type
 	 * @return
 	 */
-	boolean hasReadPerm(NodeGraphFieldContainer container);
+	boolean hasReadPerm(NodeGraphFieldContainer container, ContainerType type);
 
 	/**
-	 * Check whether the current user of the context has read permission on the container (via type and parent node).
-	 * This method will not fail with an exception. Instead the perm error will be logged in the error list. Null will be returned in this case.
-	 * 
-	 * @param container
-	 * @param env Environment used to add perm errors
-	 * @return Provided container or null if permissions are lacking.
-	 */
-	NodeGraphFieldContainer requiresReadPermSoft(NodeGraphFieldContainer container, DataFetchingEnvironment env);
+     * Check whether the current user of the context has read permission on the container (via type and parent node).
+     * This method will not fail with an exception. Instead the perm error will be logged in the error list. Null will be returned in this case.
+     *
+     * @param container
+     * @param env       Environment used to add perm errors
+     * @param type
+     * @return Provided container or null if permissions are lacking.
+     */
+	NodeGraphFieldContainer requiresReadPermSoft(NodeGraphFieldContainer container, DataFetchingEnvironment env, ContainerType type);
 
 	/**
-	 * Check whether the content can be read by the current user. Please note that this method will not check READ perms on the node. It is only checking the content container of the node. 
-	 * 
+	 * Check whether the content can be read by the current user. Please note that this method will not check READ perms on the node. It is only checking the content container of the node.
+	 *
 	 * @param content
+	 * @param type
 	 * @return
 	 */
-	boolean hasReadPerm(NodeContent content);
+	boolean hasReadPerm(NodeContent content, ContainerType type);
 
 	/**
 	 * Gets a value from the context. If the value does not exist yet, the supplier will be called.

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/context/impl/GraphQLContextImpl.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/context/impl/GraphQLContextImpl.java
@@ -8,6 +8,7 @@ import com.gentics.mesh.core.data.NodeGraphFieldContainer;
 import com.gentics.mesh.core.data.node.Node;
 import com.gentics.mesh.core.data.node.NodeContent;
 import com.gentics.mesh.core.data.relationship.GraphPermission;
+import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.error.PermissionException;
 import com.gentics.mesh.graphql.context.GraphQLContext;
 
@@ -36,36 +37,26 @@ public class GraphQLContextImpl extends InternalRoutingActionContextImpl impleme
 	}
 
 	@Override
-	public boolean hasReadPerm(NodeContent content) {
+	public boolean hasReadPerm(NodeContent content, ContainerType type) {
 		NodeGraphFieldContainer container = content.getContainer();
 		if (container != null) {
-			return hasReadPerm(container);
+			return hasReadPerm(container, type);
 		} else {
 			return true;
 		}
 	}
 
 	@Override
-	public boolean hasReadPerm(NodeGraphFieldContainer container) {
-		Node node = container.getParentNode();
-		Object nodeId = node.id();
-		if (getUser().hasPermissionForId(nodeId, GraphPermission.READ_PERM)) {
-			return true;
-		}
-
-		boolean isPublished = container.isPublished(getBranch().getUuid());
-		if (isPublished && getUser().hasPermissionForId(nodeId, GraphPermission.READ_PUBLISHED_PERM)) {
-			return true;
-		}
-		return false;
+	public boolean hasReadPerm(NodeGraphFieldContainer container, ContainerType type) {
+		return getUser().hasReadPermission(container, getBranch().getUuid(), type.getHumanCode());
 	}
 
 	@Override
-	public NodeGraphFieldContainer requiresReadPermSoft(NodeGraphFieldContainer container, DataFetchingEnvironment env) {
+	public NodeGraphFieldContainer requiresReadPermSoft(NodeGraphFieldContainer container, DataFetchingEnvironment env, ContainerType type) {
 		if (container == null) {
 			return null;
 		}
-		if (hasReadPerm(container)) {
+		if (hasReadPerm(container, type)) {
 			return container;
 		} else {
 			PermissionException error = new PermissionException("node", container.getParentNode().getUuid());

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/model/NodeReferenceIn.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/model/NodeReferenceIn.java
@@ -48,7 +48,7 @@ public class NodeReferenceIn {
 					}
 					return false;
 				})
-				.filter(context::hasReadPerm)
+				.filter(container1 -> context.hasReadPerm(container1, type))
 				.findAny())
 					.map(referencingContent -> new NodeReferenceIn(
 						new NodeContent(null, referencingContent, content.getLanguageFallback(), type),

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
@@ -559,7 +559,7 @@ public abstract class AbstractTypeProvider {
 			.map(node -> new NodeContent(node, node.findVersion(gc, languageTags, type), languageTags, type))
 			// Filter nodes without a container
 			.filter(content -> content.getContainer() != null)
-			.filter(gc::hasReadPerm);
+			.filter(content1 -> gc.hasReadPerm(content1, type));
 
 		return applyNodeFilter(env, contents);
 	}

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
@@ -133,7 +133,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 		ContainerType type = getNodeVersion(env);
 
 		NodeGraphFieldContainer container = parentNode.findVersion(gc, languageTags, type);
-		container = gc.requiresReadPermSoft(container, env);
+		container = gc.requiresReadPermSoft(container, env, type);
 
 		return new NodeContent(parentNode, container, languageTags, type);
 	}
@@ -149,7 +149,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 		Node node = content.getNode();
 		ContainerType type = getNodeVersion(env);
 		NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
-		container = gc.requiresReadPermSoft(container, env);
+		container = gc.requiresReadPermSoft(container, env, type);
 		return new NodeContent(node, container, languageTags, type);
 	}
 
@@ -168,7 +168,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 			return new NodeContent(node, container, languageTags, type);
 		})
 			.filter(item -> item.getContainer() != null)
-			.filter(gc::hasReadPerm)
+			.filter(content1 -> gc.hasReadPerm(content1, type))
 			.collect(Collectors.toList());
 	}
 
@@ -184,7 +184,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 		Stream<? extends NodeGraphFieldContainer> stream = StreamSupport
 			.stream(content.getNode().getGraphFieldContainers(branch, type).spliterator(), false);
 		return stream
-			.filter(gc::hasReadPerm)
+			.filter(container1 -> gc.hasReadPerm(container1, type))
 			.map(container -> {
 				return new NodeContent(content.getNode(), container, content.getLanguageFallback(), type);
 			}).collect(Collectors.toList());
@@ -306,7 +306,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 						if (containerFromPath != null) {
 							nodeFromPath = containerFromPath.getParentNode();
 							gc.requiresPerm(nodeFromPath, READ_PERM, READ_PUBLISHED_PERM);
-							containerFromPath = gc.requiresReadPermSoft(containerFromPath, env);
+							containerFromPath = gc.requiresReadPermSoft(containerFromPath, env, type);
 						} else {
 							return null;
 						}
@@ -333,7 +333,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 				Stream<NodeContent> nodes = content.getNode().getChildrenStream(gc, type == PUBLISHED ? READ_PUBLISHED_PERM : READ_PERM)
 					.map(item -> new NodeContent(item, item.findVersion(gc, languageTags, type), languageTags, type))
 					.filter(item -> item.getContainer() != null)
-					.filter(item -> gc.hasReadPerm(item.getContainer()));
+					.filter(item -> gc.hasReadPerm(item.getContainer(), type));
 
 				return applyNodeFilter(env, nodes);
 			}, NODE_PAGE_TYPE_NAME)

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/ProjectTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/ProjectTypeProvider.java
@@ -61,7 +61,7 @@ public class ProjectTypeProvider extends AbstractTypeProvider {
 		ContainerType type = getNodeVersion(env);
 
 		NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
-		container = gc.requiresReadPermSoft(container, env);
+		container = gc.requiresReadPermSoft(container, env, type);
 		return new NodeContent(node, container, languageTags, type);
 	}
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/QueryTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/QueryTypeProvider.java
@@ -237,7 +237,7 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 				return new NodeContent(node, container, languageTags, type);
 			})
 			.filter(content -> content.getContainer() != null)
-			.filter(gc::hasReadPerm);
+			.filter(content1 -> gc.hasReadPerm(content1, type));
 
 		return applyNodeFilter(env, contents);
 	}
@@ -263,7 +263,7 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 			node = gc.requiresPerm(node, READ_PERM, READ_PUBLISHED_PERM);
 			NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
 			if (container != null) {
-				container = gc.requiresReadPermSoft(container, env);
+				container = gc.requiresReadPermSoft(container, env, type);
 			}
 			return new NodeContent(node, container, languageTags, type);
 		}
@@ -282,7 +282,7 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 			Node nodeOfContainer = container.getParentNode();
 
 			nodeOfContainer = gc.requiresPerm(nodeOfContainer, READ_PERM, READ_PUBLISHED_PERM);
-			container = gc.requiresReadPermSoft(container, env);
+			container = gc.requiresReadPermSoft(container, env, type);
 			List<String> langs = new ArrayList<>();
 			if (container != null) {
 				langs.add(container.getLanguageTag());
@@ -344,7 +344,7 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 			List<String> languageTags = getLanguageArgument(env);
 			ContainerType type = getNodeVersion(env);
 			NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
-			container = gc.requiresReadPermSoft(container, env);
+			container = gc.requiresReadPermSoft(container, env, type);
 			return new NodeContent(node, container, languageTags, type);
 		}
 		return null;

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/SchemaTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/SchemaTypeProvider.java
@@ -112,7 +112,7 @@ public class SchemaTypeProvider extends AbstractTypeProvider {
 				return new NodeContent(node, container, languageTags, type);
 			})
 			.filter(content -> content.getContainer() != null)
-			.filter(gc::hasReadPerm);
+			.filter(content1 -> gc.hasReadPerm(content1, type));
 
 			return applyNodeFilter(env, nodes);
 		}, NODE_PAGE_TYPE_NAME)

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/TagTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/TagTypeProvider.java
@@ -18,7 +18,6 @@ import javax.inject.Singleton;
 import com.gentics.mesh.core.data.Tag;
 import com.gentics.mesh.core.data.TagFamily;
 import com.gentics.mesh.core.data.node.NodeContent;
-import com.gentics.mesh.core.data.relationship.GraphPermission;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.graphql.context.GraphQLContext;
@@ -83,7 +82,7 @@ public class TagTypeProvider extends AbstractTypeProvider {
 						.map(node -> new NodeContent(node, node.findVersion(gc, languageTags, type), languageTags, type))
 						// Filter nodes without a container
 						.filter(content -> content.getContainer() != null)
-						.filter(gc::hasReadPerm);
+						.filter(content1 -> gc.hasReadPerm(content1, type));
 
 					return applyNodeFilter(env, contents);
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/UserTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/UserTypeProvider.java
@@ -133,7 +133,7 @@ public class UserTypeProvider extends AbstractTypeProvider {
 				ContainerType type = getNodeVersion(env);
 
 				NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
-				container = gc.requiresReadPermSoft(container, env);
+				container = gc.requiresReadPermSoft(container, env, type);
 				return new NodeContent(node, container, languageTags, type);
 			}));
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/FieldDefinitionProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/FieldDefinitionProvider.java
@@ -402,7 +402,7 @@ public class FieldDefinitionProvider extends AbstractTypeProvider {
 				}
 				return nodes
 					.filter(content -> content.getContainer() != null)
-					.filter(gc::hasReadPerm)
+					.filter(content1 -> gc.hasReadPerm(content1, nodeType))
 					.collect(Collectors.toList());
 			case "micronode":
 				MicronodeGraphFieldList micronodeList = container.getMicronodeList(schema.getName());
@@ -483,7 +483,7 @@ public class FieldDefinitionProvider extends AbstractTypeProvider {
 						// Check permissions for the linked node
 						gc.requiresPerm(node, READ_PERM, READ_PUBLISHED_PERM);
 						NodeGraphFieldContainer container = node.findVersion(gc, languageTags, type);
-						container = gc.requiresReadPermSoft(container, env);
+						container = gc.requiresReadPermSoft(container, env, type);
 						return new NodeContent(node, container, languageTags, type);
 					}
 				}


### PR DESCRIPTION
## Abstract

Rootnode informations was returned in graphql even if user requested a draft version without having draft permissions

## Checklist

### General

* [X] Added abstract that describes the change
* [X] Added changelog entry to `/CHANGELOG.adoc`
* [X] Ensured that the change is covered by tests
* [X] Ensured that the change is documented in the docs

### On API Changes

* [X] Checked if the changes are breaking or not
* [X] Added GraphQL API if applicable
* [X] Added Elasticsearch mapping if applicable
