### PR TITLE
Implement missing S3 binary support for index engine, causing publish process to fail

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,11 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.9.2]]
+== 1.9.2 (TBD)
+
+icon:check[] S3: A support of S3 fields has been added to the indexing engine.
+
 [[v1.9.1]]
 == 1.9.1 (19.08.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryMetadataExtractionHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/S3BinaryMetadataExtractionHandlerImpl.java
@@ -73,7 +73,8 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 
 	@Inject
 	public S3BinaryMetadataExtractionHandlerImpl(Database db, S3BinaryStorage s3BinaryStorage, HandlerUtilities utils,
-												 Vertx rxVertx, MeshOptions options, S3Binaries s3binaries, S3BinaryProcessorRegistryImpl s3binaryProcessorRegistry) {
+			Vertx rxVertx, MeshOptions options, S3Binaries s3binaries,
+			S3BinaryProcessorRegistryImpl s3binaryProcessorRegistry) {
 		this.db = db;
 		this.vertx = rxVertx;
 		this.s3BinaryStorage = s3BinaryStorage;
@@ -87,8 +88,8 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 	 * Handle a request to create a new field.
 	 *
 	 * @param ac
-	 * @param nodeUuid   UUID of the node which should be updated
-	 * @param fieldName  Name of the field which should be created
+	 * @param nodeUuid  UUID of the node which should be updated
+	 * @param fieldName Name of the field which should be created
 	 */
 	public void handleMetadataExtraction(InternalActionContext ac, String nodeUuid, String fieldName) {
 		validateParameter(nodeUuid, "uuid");
@@ -106,89 +107,84 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 		}
 
 		S3UploadContext ctx = new S3UploadContext();
-
-
 		String bucket = options.getS3Options().getBucket();
 		String objectKey = nodeUuid + "/" + fieldName;
-		s3BinaryStorage
-				.exists(bucket, objectKey)
-				//read from aws and return buffer with data
+		s3BinaryStorage.exists(bucket, objectKey)
+				// read from aws and return buffer with data
 				.flatMap(res -> {
 					if (res) {
 						return s3BinaryStorage.read(bucket, objectKey).singleOrError();
-					} else return Single.error(error(INTERNAL_SERVER_ERROR, "image_error_reading_failed"));
-				})
-				.onErrorResumeNext(e ->  Single.error(e))
+					} else {
+						return Single.error(error(BAD_REQUEST, "image_error_reading_failed"));
+					}
+				}).onErrorResumeNext(e -> Single.error(e))
 				.flatMap(fileBuffer -> {
-			if (nonNull(fileBuffer) && fileBuffer.getBytes().length > 0) {
-				return db.singleTx(tx -> s3binaries
-						.findByS3ObjectKey(nodeUuid + "/" + fieldName)
-						.runInExistingTx(tx)
-						.getFileName())
-						.flatMap(fileName -> {
-							String mimeTypeForFilename = MimeMapping.getMimeTypeForFilename(fileName);
-							File tmpFile = new File(System.getProperty("java.io.tmpdir"), fileName);
-							vertx.fileSystem().writeFileBlocking(tmpFile.getAbsolutePath(), fileBuffer);
-							byte[] fileData = fileBuffer.getBytes();
-							FileUpload fileUpload = new FileUpload() {
+					if (nonNull(fileBuffer) && fileBuffer.getBytes().length > 0) {
+						return db.singleTx(tx -> s3binaries.findByS3ObjectKey(nodeUuid + "/" + fieldName)
+								.runInExistingTx(tx).getFileName()).flatMap(fileName -> {
+									String mimeTypeForFilename = MimeMapping.getMimeTypeForFilename(fileName);
+									File tmpFile = new File(System.getProperty("java.io.tmpdir"), fileName);
+									vertx.fileSystem().writeFileBlocking(tmpFile.getAbsolutePath(), fileBuffer);
+									byte[] fileData = fileBuffer.getBytes();
+									FileUpload fileUpload = new FileUpload() {
 
-								@Override
-								public String uploadedFileName() {
-									return tmpFile.getAbsolutePath();
-								}
+										@Override
+										public String uploadedFileName() {
+											return tmpFile.getAbsolutePath();
+										}
 
-								@Override
-								public long size() {
-									return fileData.length;
-								}
+										@Override
+										public long size() {
+											return fileData.length;
+										}
 
-								@Override
-								public String name() {
-									return fileName;
-								}
+										@Override
+										public String name() {
+											return fileName;
+										}
 
-								@Override
-								public String fileName() {
-									return fileName;
-								}
+										@Override
+										public String fileName() {
+											return fileName;
+										}
 
-								@Override
-								public String contentType() {
-									return mimeTypeForFilename;
-								}
+										@Override
+										public String contentType() {
+											return mimeTypeForFilename;
+										}
 
-								@Override
-								public String contentTransferEncoding() {
-									// TODO Auto-generated method stub
-									return null;
-								}
+										@Override
+										public String contentTransferEncoding() {
+											// TODO Auto-generated method stub
+											return null;
+										}
 
-								@Override
-								public String charSet() {
-									// TODO Auto-generated method stub
-									return "UTF-8";
-								}
-							};
-							ctx.setFileUpload(fileUpload);
-							ctx.setS3ObjectKey(nodeUuid + "/" + fieldName);
-							ctx.setFileName(fileName);
-							ctx.setFileSize(fileData.length);
-							return Single.just(fileUpload);
-						}).flatMap(fileUpload -> postProcessUpload(new S3BinaryDataProcessorContext(ac, nodeUuid, fieldName, fileUpload))
-									.toList()).flatMap(postProcess ->  storeUploadInGraph(ac, postProcess, ctx, nodeUuid, languageTag, nodeVersion, fieldName));
-			} else {
-				log.error("Could not read input image");
-				return Single.error(error(INTERNAL_SERVER_ERROR, "image_error_reading_failed"));
-			}
-		}).onErrorResumeNext(e ->  Single.error(e))
-				.subscribe(model ->
-				ac.send(model, OK), ac::fail);
+										@Override
+										public String charSet() {
+											// TODO Auto-generated method stub
+											return "UTF-8";
+										}
+									};
+									ctx.setFileUpload(fileUpload);
+									ctx.setS3ObjectKey(nodeUuid + "/" + fieldName);
+									ctx.setFileName(fileName);
+									ctx.setFileSize(fileData.length);
+									return Single.just(fileUpload);
+								})
+								.flatMap(fileUpload -> postProcessUpload(
+										new S3BinaryDataProcessorContext(ac, nodeUuid, fieldName, fileUpload)).toList())
+								.flatMap(postProcess -> storeUploadInGraph(ac, postProcess, ctx, nodeUuid, languageTag,
+										nodeVersion, fieldName));
+					} else {
+						log.error("Could not read input image");
+						return Single.error(error(INTERNAL_SERVER_ERROR, "image_error_reading_failed"));
+					}
+				}).onErrorResumeNext(e -> Single.error(e)).subscribe(model -> ac.send(model, OK), ac::fail);
 	}
 
-	private Single<NodeResponse> storeUploadInGraph(InternalActionContext ac, List<Consumer<S3HibBinaryField>> fieldModifier, S3UploadContext context,
-													String nodeUuid,
-													String languageTag, String nodeVersion,
-													String fieldName) {
+	private Single<NodeResponse> storeUploadInGraph(InternalActionContext ac,
+			List<Consumer<S3HibBinaryField>> fieldModifier, S3UploadContext context, String nodeUuid,
+			String languageTag, String nodeVersion, String fieldName) {
 		FileUpload upload = context.getFileUpload();
 		String s3ObjectKey = context.getS3ObjectKey();
 		String fileName = context.getFileName();
@@ -211,11 +207,14 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 			}
 
 			// Load the current latest draft
-			HibNodeFieldContainer latestDraftVersion = contentDao.getFieldContainer(node, languageTag, branch, ContainerType.DRAFT);
+			HibNodeFieldContainer latestDraftVersion = contentDao.getFieldContainer(node, languageTag, branch,
+					ContainerType.DRAFT);
 
 			if (latestDraftVersion == null) {
-				// latestDraftVersion = node.createGraphFieldContainer(language, branch, ac.getUser());
-				// TODO Maybe it would be better to just create a new field container for the language?
+				// latestDraftVersion = node.createGraphFieldContainer(language, branch,
+				// ac.getUser());
+				// TODO Maybe it would be better to just create a new field container for the
+				// language?
 				// In that case we would also need to:
 				// * check for segment field conflicts
 				// * update display name
@@ -224,24 +223,28 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 			}
 
 			// Load the base version field container in order to create the diff
-			HibNodeFieldContainer baseVersionContainer = contentDao.findVersion(node, languageTag, branch.getUuid(), nodeVersion);
+			HibNodeFieldContainer baseVersionContainer = contentDao.findVersion(node, languageTag, branch.getUuid(),
+					nodeVersion);
 			if (baseVersionContainer == null) {
 				throw error(BAD_REQUEST, "node_error_draft_not_found", nodeVersion, languageTag);
 			}
 
 			List<FieldContainerChange> baseVersionDiff = contentDao.compareTo(baseVersionContainer, latestDraftVersion);
-			List<FieldContainerChange> requestVersionDiff = Arrays.asList(new FieldContainerChange(fieldName, FieldChangeTypes.UPDATED));
+			List<FieldContainerChange> requestVersionDiff = Arrays
+					.asList(new FieldContainerChange(fieldName, FieldChangeTypes.UPDATED));
 
 			// Compare both sets of change sets
 			List<FieldContainerChange> intersect = baseVersionDiff.stream().filter(requestVersionDiff::contains)
 					.collect(Collectors.toList());
 
-			// Check whether the update was not based on the latest draft version. In that case a conflict check needs to occur.
+			// Check whether the update was not based on the latest draft version. In that
+			// case a conflict check needs to occur.
 			if (!latestDraftVersion.getVersion().equals(nodeVersion)) {
 
 				// Check whether a conflict has been detected
 				if (intersect.size() > 0) {
-					NodeVersionConflictException conflictException = new NodeVersionConflictException("node_error_conflict_detected");
+					NodeVersionConflictException conflictException = new NodeVersionConflictException(
+							"node_error_conflict_detected");
 					conflictException.setOldVersion(baseVersionContainer.getVersion().toString());
 					conflictException.setNewVersion(latestDraftVersion.getVersion().toString());
 					for (FieldContainerChange fcc : intersect) {
@@ -261,12 +264,12 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 			}
 
 			// Create a new node version field container to store the upload
-			HibNodeFieldContainer newDraftVersion = contentDao.createFieldContainer(node, languageTag, branch, ac.getUser(),
-					latestDraftVersion,
-					true);
+			HibNodeFieldContainer newDraftVersion = contentDao.createFieldContainer(node, languageTag, branch,
+					ac.getUser(), latestDraftVersion, true);
 
 			// Get the potential existing field
-			S3HibBinaryField oldField = (S3HibBinaryField) contentDao.detachField(newDraftVersion.getS3Binary(fieldName));
+			S3HibBinaryField oldField = (S3HibBinaryField) contentDao
+					.detachField(newDraftVersion.getS3Binary(fieldName));
 
 			// Create the new field
 			S3HibBinaryField field = newDraftVersion.createS3Binary(fieldName, s3binary);
@@ -275,7 +278,8 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 			if (oldField != null) {
 				oldField.copyTo(field);
 
-				// If the old field was an image and the current upload is not an image we need to reset the custom image specific attributes.
+				// If the old field was an image and the current upload is not an image we need
+				// to reset the custom image specific attributes.
 				if (oldField.hasProcessableImage() && !NodeUtil.isProcessableImage(upload.contentType())) {
 					field.setImageDominantColor(null);
 				}
@@ -292,17 +296,21 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 			// Now get rid of the old field
 			newDraftVersion.removeField(oldField);
 
-			// If the binary field is the segment field, we need to update the webroot info in the node
-			if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
-				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
+			// If the binary field is the segment field, we need to update the webroot info
+			// in the node
+			if (field.getFieldKey()
+					.equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
+				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(),
+						"node_conflicting_segmentfield_upload");
 			}
 
-			if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion) && contentDao.isPurgeable(latestDraftVersion)) {
+			if (ac.isPurgeAllowed() && contentDao.isAutoPurgeEnabled(newDraftVersion)
+					&& contentDao.isPurgeable(latestDraftVersion)) {
 				contentDao.purge(latestDraftVersion);
 			}
 
 			batch.add(contentDao.onUpdated(newDraftVersion, branch.getUuid(), DRAFT));
-			batch.add(s3binary.onMetadataExtracted(nodeUuid,s3ObjectKey));
+			batch.add(s3binary.onMetadataExtracted(nodeUuid, s3ObjectKey));
 
 			return nodeDao.transformToRestSync(node, ac, 0);
 		});
@@ -313,17 +321,13 @@ public class S3BinaryMetadataExtractionHandlerImpl extends AbstractHandler {
 		String contentType = upload.contentType();
 		List<S3BinaryDataProcessor> processors = s3binaryProcessorRegistry.getProcessors(contentType);
 
-		return Observable.fromIterable(processors).flatMapMaybe(p -> p.process(ctx)
-				.doOnSuccess(s -> {
-					log.info(
-							"Processing of upload {" + upload.fileName() + "/" + upload.uploadedFileName() + "} in handler {" + p.getClass()
-									+ "} completed.");
-				})
-				.doOnComplete(() -> {
-					log.warn(
-							"Processing of upload {" + upload.fileName() + "/" + upload.uploadedFileName() + "} in handler {" + p.getClass()
-									+ "} completed.");
-				}));
+		return Observable.fromIterable(processors).flatMapMaybe(p -> p.process(ctx).doOnSuccess(s -> {
+			log.info("Processing of upload {" + upload.fileName() + "/" + upload.uploadedFileName() + "} in handler {"
+					+ p.getClass() + "} completed.");
+		}).doOnComplete(() -> {
+			log.warn("Processing of upload {" + upload.fileName() + "/" + upload.uploadedFileName() + "} in handler {"
+					+ p.getClass() + "} completed.");
+		}));
 	}
 
 }

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
@@ -200,6 +200,9 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 		case DATE:
 			addDataFieldMapping(fieldInfo, customIndexOptions);
 			break;
+		case S3BINARY:
+			addS3BinaryFieldMapping(fieldInfo, customIndexOptions);
+			break;
 		case BINARY:
 			addBinaryFieldMapping(fieldInfo, customIndexOptions);
 			break;
@@ -218,7 +221,7 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 			addMicronodeMapping(fieldInfo, fieldSchema, branch, language, customIndexOptions);
 			break;
 		default:
-			throw new RuntimeException("Mapping type  for field type {" + type + "} unknown.");
+			throw new RuntimeException("Mapping type for field type {" + type + "} unknown.");
 		}
 		return Optional.of(fieldInfo);
 	}
@@ -332,16 +335,32 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 		}
 	}
 
+	private void addS3BinaryFieldMapping(JsonObject fieldInfo, JsonObject customIndexOptions) {
+		if (!isStrictMode) {
+			JsonObject binaryProps = new JsonObject();
+
+			// .s3ObjectKey
+			binaryProps.put("s3ObjectKey", notAnalyzedType(KEYWORD));
+			addCommonBinaryFieldMapping(fieldInfo, customIndexOptions, binaryProps);
+		}
+	}
+
 	private void addBinaryFieldMapping(JsonObject fieldInfo, JsonObject customIndexOptions) {
+		if (!isStrictMode) {
+			JsonObject binaryProps = new JsonObject();
+
+			// .sha512sum
+			binaryProps.put("sha512sum", notAnalyzedType(KEYWORD));
+			addCommonBinaryFieldMapping(fieldInfo, customIndexOptions, binaryProps);
+		}
+	}
+
+	private void addCommonBinaryFieldMapping(JsonObject fieldInfo, JsonObject customIndexOptions, JsonObject binaryProps) {
 		if (isStrictMode) {
 			fieldInfo.mergeIn(customIndexOptions);
 		} else {
 			fieldInfo.put("type", OBJECT);
-			JsonObject binaryProps = new JsonObject();
 			fieldInfo.put("properties", binaryProps);
-
-			// .sha512sum
-			binaryProps.put("sha512sum", notAnalyzedType(KEYWORD));
 
 			// .filename
 			JsonObject customFilenameMapping = null;

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/FieldDefinitionProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/FieldDefinitionProvider.java
@@ -122,6 +122,13 @@ public class FieldDefinitionProvider extends AbstractTypeProvider {
 				return field.getBinary().getSHA512Sum();
 			}));
 
+		// .s3objectKey
+		type.field(
+			newFieldDefinition().name("s3ObjectKey").description("S3 object key of the S3 storage binary data.").type(GraphQLString).dataFetcher(fetcher -> {
+				S3HibBinaryField field = fetcher.getSource();
+				return field.getBinary().getS3ObjectKey();
+			}));
+
 		// .fileSize
 		type.field(newFieldDefinition().name("fileSize").description("Size of the binary data in bytes").type(GraphQLLong).dataFetcher(fetcher -> {
 			HibBinaryField field = fetcher.getSource();


### PR DESCRIPTION
## Abstract

Manipulating S3 fields with an index engine ends up in various errors within Mesh and its callers. This fixes the index engine support.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
