### PR TITLE
Hotfix 1.6.x sup 11468

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.35]]
+== 1.6.35 (TBD)
+
+icon:check[] Core: when an initial admin password is provided with an environment variable, its value won't be logged anymore.
+
 [[v1.6.34]]
 == 1.6.34 (22.09.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
@@ -157,7 +157,7 @@ public class MeshOptions implements Option {
 	private String livePath = "mesh.live";
 
 	@JsonIgnore
-	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_ENV, description = "Password which will be used during initial admin user creation.")
+	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_ENV, description = "Password which will be used during initial admin user creation.", isSensitive = true)
 	private String initialAdminPassword = PasswordUtil.humanPassword();
 
 	@JsonIgnore

--- a/api/src/main/java/com/gentics/mesh/etc/config/env/EnvironmentVariable.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/env/EnvironmentVariable.java
@@ -22,4 +22,10 @@ public @interface EnvironmentVariable {
 	 * @return
 	 */
 	String name();
+
+	/**
+	 * Whether this variable is sensitive (should not be logged)
+	 * @return
+	 */
+	boolean isSensitive() default false;
 }

--- a/api/src/main/java/com/gentics/mesh/etc/config/env/OptionUtils.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/env/OptionUtils.java
@@ -16,6 +16,7 @@ import io.vertx.core.logging.LoggerFactory;
 public class OptionUtils {
 	static final Logger log = LoggerFactory.getLogger(Option.class);
 	private static final Pattern SPLIT_PATTERN = Pattern.compile(",");
+	private static final String MASK = "********";
 
 	/**
 	 * Convert a string value to a type. Throws an runtime exception when the type is not supported
@@ -80,7 +81,7 @@ public class OptionUtils {
 		}
 		Class<?> typeClazz = method.getParameterTypes()[0];
 		try {
-			log.info("Setting env via method {" + name + "=" + value + "}");
+			log.info("Setting env via method {" + name + "=" + (envInfo.isSensitive() ? MASK : value) + "}");
 			method.invoke(target, convertValue(typeClazz, value));
 		} catch (IllegalAccessException | InvocationTargetException e) {
 			throw new RuntimeException("Could not set environment variable via method {" + name + "} with value {" + value + "}", e);
@@ -100,7 +101,7 @@ public class OptionUtils {
 			return;
 		}
 		try {
-			log.info("Setting env via field access {" + name + "=" + value + "}");
+			log.info("Setting env via field access {" + name + "=" + (envInfo.isSensitive() ? MASK : value) + "}");
 			field.setAccessible(true);
 			field.set(target, convertValue(field.getType(), value));
 		} catch (IllegalArgumentException | IllegalAccessException ex) {


### PR DESCRIPTION
## Abstract

By default every environment variable value is logged on startup. This merge requests add an option for sensitive variables, which value won't be logged.

## Checklist

### General

* [X] Added abstract that describes the change
* [X] Added changelog entry to `/CHANGELOG.adoc`
* [X] Ensured that the change is covered by tests
* [X] Ensured that the change is documented in the docs

### On API Changes

* [X] Checked if the changes are breaking or not
* [X] Added GraphQL API if applicable
* [X] Added Elasticsearch mapping if applicable
