### PR TITLE
Hotfix 1.8.x sup 14120

### DIFF
--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -41,6 +41,12 @@
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-web-templ-handlebars</artifactId>
 		</dependency>
+
+		<!-- Required by SearchModelGenerator -->
+		<dependency>
+			<groupId>com.gentics.mesh</groupId>
+			<artifactId>mesh-test-common</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -36,20 +36,7 @@
 			<artifactId>mesh-mdm-orientdb-wrapper</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>com.gentics.mesh</groupId>
-			<artifactId>mesh-test-common</artifactId>
-		</dependency>
-
 		<!-- Generator dependencies -->
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.gentics.mesh</groupId>
-			<artifactId>tests-mesh-core</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-web-templ-handlebars</artifactId>


### PR DESCRIPTION
## Abstract
The documentation for environment variables (https://getmesh.io/docs/administration-guide/#env) is generated from code using reflection. Version 1.8 introduced some changes with the test dependencies that, as a side effect, made available some test environment variables in the classpath, leading to the generation of documentation for these bogus variables.
Removing the test dependency fixes the issue.


## Checklist

### General

* [X] Added abstract that describes the change
* [X] Added changelog entry to `/CHANGELOG.adoc`
* [X] Ensured that the change is covered by tests
* [X] Ensured that the change is documented in the docs

### On API Changes

* [X] Checked if the changes are breaking or not
* [X] Added GraphQL API if applicable
* [X] Added Elasticsearch mapping if applicable
