### PR TITLE
SUP-12782

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,9 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] Core: when an initial admin password is provided with an environment variable, its value won't be logged anymore.
 
+icon:check[] Core: when a binary file was manually deleted from the file system and the same file was uploaded again through the rest api, the binary
+upload endpoint was returning a success response even though the binary wasn't actually uploaded. The file will now be uploaded correctly.
+
 [[v1.6.34]]
 == 1.6.34 (22.09.2022)
 

--- a/common/src/main/java/com/gentics/mesh/storage/BinaryStorage.java
+++ b/common/src/main/java/com/gentics/mesh/storage/BinaryStorage.java
@@ -118,4 +118,11 @@ public interface BinaryStorage {
 	 */
 	Completable purgeTemporaryUpload(String temporaryId);
 
+	/**
+	 * Return the local filesystem path for the binary.
+	 *
+	 * @param binaryUuid of the binary
+	 * @return Absolute path
+	 */
+	String getFilePath(String binaryUuid);
 }

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
@@ -187,19 +187,15 @@ public class BinaryUploadHandler extends AbstractHandler {
 			ctx.setHash(hash);
 
 			// Check whether the binary with the given hashsum was already stored
-			Tuple<Binary, String> binaryAndUuid = binaries.findByHash(hash)
-					.mapInTx(b -> {
-						return Tuple.tuple(b, b != null ? b.getUuid() : null);
-					})
+			String binaryUuid = binaries.findByHash(hash)
+					.mapInTx(b -> b != null ? b.getUuid() : null)
 					.runInNewTx();
-			Binary binary = binaryAndUuid.v1();
-			String binaryUuid = binaryAndUuid.v2();
 
 			// Create a new binary uuid if the data was not already stored
-			if (binary == null) {
+			if (binaryUuid == null) {
 				ctx.setBinaryUuid(UUIDUtil.randomUUID());
 				ctx.setInvokeStore();
-			} else if (binaryUuid != null && fileNotExists(binaryUuid)) {
+			} else if (fileNotExists(binaryUuid)) {
 				ctx.setBinaryUuid(binaryUuid);
 				ctx.setInvokeStore();
 			}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandler.java
@@ -8,6 +8,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -186,11 +187,20 @@ public class BinaryUploadHandler extends AbstractHandler {
 			ctx.setHash(hash);
 
 			// Check whether the binary with the given hashsum was already stored
-			Binary binary = binaries.findByHash(hash).runInNewTx();
+			Tuple<Binary, String> binaryAndUuid = binaries.findByHash(hash)
+					.mapInTx(b -> {
+						return Tuple.tuple(b, b != null ? b.getUuid() : null);
+					})
+					.runInNewTx();
+			Binary binary = binaryAndUuid.v1();
+			String binaryUuid = binaryAndUuid.v2();
 
 			// Create a new binary uuid if the data was not already stored
 			if (binary == null) {
 				ctx.setBinaryUuid(UUIDUtil.randomUUID());
+				ctx.setInvokeStore();
+			} else if (binaryUuid != null && fileNotExists(binaryUuid)) {
+				ctx.setBinaryUuid(binaryUuid);
 				ctx.setInvokeStore();
 			}
 
@@ -221,6 +231,10 @@ public class BinaryUploadHandler extends AbstractHandler {
 			}
 		}).subscribe(model -> ac.send(model, CREATED), ac::fail);
 
+	}
+
+	private boolean fileNotExists(String binaryUuid) {
+		return !new File(binaryStorage.getFilePath(binaryUuid)).exists();
 	}
 
 	private Completable storeUploadInTemp(UploadContext ctx, FileUpload ul, String hash) {

--- a/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldUploadEndpointTest.java
+++ b/core/src/test/java/com/gentics/mesh/core/field/binary/BinaryFieldUploadEndpointTest.java
@@ -20,11 +20,15 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Ignore;
@@ -527,6 +531,55 @@ public class BinaryFieldUploadEndpointTest extends AbstractMeshTest {
 			assertEquals("The expected length of the file did not match.", binaryLen, binaryFile.length());
 		}
 
+	}
+
+	@Test
+	public void testRepairUpload() throws Exception {
+		String contentType = "application/blub";
+		int binaryLen = 8000;
+		String fileName = "somefile.dat";
+		Node node = folder("news");
+		String uuid = tx(() -> node.getUuid());
+		Buffer data = TestUtils.randomBuffer(binaryLen);
+		try (Tx tx = tx()) {
+			prepareSchema(node, "", "binary");
+			tx.success();
+		}
+		MeshCoreAssertion.assertThat(testContext).hasUploads(0, 0).hasTempFiles(0).hasTempUploads(0);
+		call(() -> uploadData(data, node, "en", "binary", contentType, fileName));
+		MeshCoreAssertion.assertThat(testContext).hasUploads(1, 1).hasTempFiles(0).hasTempUploads(0);
+
+		MeshBinaryResponse downloadResponse = call(() -> client().downloadBinaryField(PROJECT_NAME, uuid, "en", "binary"));
+		assertNotNull(downloadResponse);
+		byte[] bytes = IOUtils.toByteArray(downloadResponse.getStream());
+		downloadResponse.close();
+		assertNotNull(bytes[0]);
+		assertNotNull(bytes[binaryLen - 1]);
+		assertEquals(binaryLen, bytes.length);
+		assertEquals(contentType, downloadResponse.getContentType());
+		assertEquals(fileName, downloadResponse.getFilename());
+
+		// delete file from file system
+		String dir = options().getUploadOptions().getDirectory();
+		Files.walk(Paths.get(dir))
+				.filter(Files::isRegularFile)
+				.findFirst().ifPresent(p -> {
+					try {
+						Files.delete(p);
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				});
+
+		// assert download fails
+		call(() -> client().downloadBinaryField(PROJECT_NAME, uuid, "en", "binary"), HttpResponseStatus.INTERNAL_SERVER_ERROR);
+
+		// re-upload file
+		call(() -> uploadData(data, node, "en", "binary", contentType, fileName));
+		MeshCoreAssertion.assertThat(testContext).hasUploads(1, 1).hasTempFiles(0).hasTempUploads(0);
+
+		// download now works
+		call(() -> client().downloadBinaryField(PROJECT_NAME, uuid, "en", "binary"));
 	}
 
 	/**

--- a/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
+++ b/core/src/test/java/com/gentics/mesh/test/context/TestHelper.java
@@ -606,14 +606,18 @@ public interface TestHelper extends EventHelper, ClientHelper {
 
 	default public MeshRequest<NodeResponse> uploadRandomData(Node node, String languageTag, String fieldKey, int binaryLen, String contentType,
 		String fileName) {
-
-		VersionNumber version = tx(() -> node.getGraphFieldContainer("en").getVersion());
-		String uuid = tx(() -> node.getUuid());
-
 		Buffer buffer = TestUtils.randomBuffer(binaryLen);
+		return uploadData(buffer, node, languageTag, fieldKey, contentType, fileName);
+	}
+
+	default MeshRequest<NodeResponse> uploadData(Buffer data, Node node, String languageTag, String fieldKey, String contentType,
+												 String fileName) {
+		String uuid = tx(() -> node.getUuid());
+		VersionNumber version = tx(() -> node.getGraphFieldContainer("en").getVersion());
+
 		return client().updateNodeBinaryField(PROJECT_NAME, uuid, languageTag, version.toString(), fieldKey,
-			new ByteArrayInputStream(buffer.getBytes()), buffer.length(), fileName, contentType,
-			new NodeParametersImpl().setResolveLinks(LinkType.FULL));
+				new ByteArrayInputStream(data.getBytes()), data.length(), fileName, contentType,
+				new NodeParametersImpl().setResolveLinks(LinkType.FULL));
 	}
 
 	default public File createTempFile() {

--- a/services/local-storage/src/main/java/com/gentics/mesh/storage/LocalBinaryStorage.java
+++ b/services/local-storage/src/main/java/com/gentics/mesh/storage/LocalBinaryStorage.java
@@ -155,6 +155,7 @@ public class LocalBinaryStorage extends AbstractBinaryStorage {
 		return binaryFile.getAbsolutePath();
 	}
 
+	@Override
 	public String getFilePath(String binaryUuid) {
 		Objects.requireNonNull(binaryUuid, "The binary uuid was not specified.");
 		File folder = new File(options.getDirectory(), getSegmentedPath(binaryUuid));


### PR DESCRIPTION
When a binary file was manually deleted from the file system and the same file was uploaded again through the rest api, the binary upload endpoint was returning a success response even though the binary wasn't actually uploaded. The file will now be uploaded correctly.

## Abstract

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
