### PR TITLE
Hotfix 1.8.x sup 14224

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -25,6 +25,9 @@ icon:check[] Core: when an initial admin password is provided with an environmen
 icon:check[] Core: when a binary file was manually deleted from the file system and the same file was uploaded again through the rest api, the binary
 upload endpoint was returning a success response even though the binary wasn't actually uploaded. The file will now be uploaded correctly.
 
+icon:check[] Core: when starting a cluster with the initCluster flag, caches were incorrectly initialized. This could lead to data consistency
+errors and various validations errors and has been fixed now.
+
 [[v1.8.10]]
 == 1.8.10 (22.09.2022)
 

--- a/common/src/main/java/com/gentics/mesh/cache/impl/EventAwareCacheFactory.java
+++ b/common/src/main/java/com/gentics/mesh/cache/impl/EventAwareCacheFactory.java
@@ -5,23 +5,21 @@ import javax.inject.Singleton;
 
 import com.gentics.mesh.cache.EventAwareCache;
 import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.event.EventBusStore;
 import com.gentics.mesh.metric.MetricsService;
-
-import io.vertx.core.Vertx;
 
 /**
  * Factory for {@link EventAwareCache} instances.
  */
 @Singleton
 public class EventAwareCacheFactory {
-
-	private final Vertx vertx;
+	private final EventBusStore eventBusStore;
 	private final MeshOptions meshOptions;
 	private final MetricsService metricsService;
 
 	@Inject
-	public EventAwareCacheFactory(Vertx vertx, MeshOptions meshOptions, MetricsService metricsService) {
-		this.vertx = vertx;
+	public EventAwareCacheFactory(EventBusStore eventBusStore, MeshOptions meshOptions, MetricsService metricsService) {
+		this.eventBusStore = eventBusStore;
 		this.meshOptions = meshOptions;
 		this.metricsService = metricsService;
 	}
@@ -35,7 +33,7 @@ public class EventAwareCacheFactory {
 	 */
 	public <K, V> EventAwareCacheImpl.Builder<K, V> builder() {
 		return new EventAwareCacheImpl.Builder<K, V>()
-			.vertx(vertx)
+			.eventBusStore(eventBusStore)
 			.meshOptions(meshOptions)
 			.setMetricsService(metricsService);
 	}

--- a/common/src/main/java/com/gentics/mesh/event/EventBusStore.java
+++ b/common/src/main/java/com/gentics/mesh/event/EventBusStore.java
@@ -1,0 +1,45 @@
+package com.gentics.mesh.event;
+
+import io.reactivex.Observable;
+import io.reactivex.subjects.BehaviorSubject;
+import io.vertx.core.eventbus.EventBus;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Wraps the event bus in an observable.
+ */
+@Singleton
+public class EventBusStore {
+    private BehaviorSubject<EventBus> eventBus = BehaviorSubject.create();
+    @Inject
+    public EventBusStore() {
+    }
+
+    /**
+     * The EventBus observable
+     * @return
+     */
+    public Observable<EventBus> eventBus() {
+        return eventBus;
+    }
+
+    /**
+     * Set the event bus
+     * @param eventBus
+     */
+    public void setEventBus(EventBus eventBus) {
+        this.eventBus.onNext(eventBus);
+    }
+
+    /**
+     * Get the current event bus (can be null)
+     * @return
+     */
+    @Nullable
+    public EventBus current() {
+        return eventBus.getValue();
+    }
+}

--- a/core/src/main/java/com/gentics/mesh/cache/PermissionCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/PermissionCacheImpl.java
@@ -18,7 +18,7 @@ import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.etc.config.MeshOptions;
 
-import io.vertx.core.Vertx;
+import com.gentics.mesh.event.EventBusStore;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -30,7 +30,7 @@ public class PermissionCacheImpl extends AbstractMeshCache<String, EnumSet<Inter
 
 	private static final Logger log = LoggerFactory.getLogger(PermissionCacheImpl.class);
 
-	private final Vertx vertx;
+	private final EventBusStore eventBusStore;
 
 	private final MeshOptions options;
 
@@ -50,9 +50,9 @@ public class PermissionCacheImpl extends AbstractMeshCache<String, EnumSet<Inter
 	private final Map<EnumSet<InternalPermission>, EnumSet<InternalPermission>> uniqueMap = Collections.synchronizedMap(new HashMap<>());
 
 	@Inject
-	public PermissionCacheImpl(EventAwareCacheFactory factory, Vertx vertx, CacheRegistry registry, MeshOptions options) {
+	public PermissionCacheImpl(EventAwareCacheFactory factory, EventBusStore eventBusStore, CacheRegistry registry, MeshOptions options) {
 		super(createCache(factory), registry, CACHE_SIZE);
-		this.vertx = vertx;
+		this.eventBusStore = eventBusStore;
 		this.options = options;
 	}
 
@@ -104,9 +104,9 @@ public class PermissionCacheImpl extends AbstractMeshCache<String, EnumSet<Inter
 	public void clear(boolean notify) {
 		// Invalidate locally
 		cache.invalidate();
-		if (notify && options.getClusterOptions().isEnabled()) {
+		if (notify && options.getClusterOptions().isEnabled() && eventBusStore.current() != null) {
 			// Send the event to inform other to purge the stored permissions
-			vertx.eventBus().publish(CLEAR_PERMISSION_STORE.address, null);
+			eventBusStore.current().publish(CLEAR_PERMISSION_STORE.address, null);
 			// log.error("Can't distribute cache clear event. Maybe Vert.x is stopping / starting right now");
 		}
 	}

--- a/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
+++ b/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import com.gentics.mesh.event.EventBusStore;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -162,6 +163,9 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 
 	@Inject
 	public EventBusLivenessManager eventbusLiveness;
+
+	@Inject
+	public EventBusStore eventBusStore;
 
 	// TODO: Changing the role name or deleting the role would cause code that utilizes this field to break.
 	// This is however a rare case.
@@ -563,6 +567,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 		}
 
 		this.vertx = vertx;
+		this.eventBusStore.setEventBus(vertx.eventBus());
 	}
 
 	/**

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/cli/OrientDBBootstrapInitializerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/cli/OrientDBBootstrapInitializerImpl.java
@@ -159,21 +159,18 @@ public class OrientDBBootstrapInitializerImpl extends AbstractBootstrapInitializ
 			// handles the clustering.
 			db.setupConnectionPool();
 
-			// TODO find a better way around the chicken and the egg issues.
-			// Vert.x is currently needed for eventQueueBatch creation.
-			// This process fails if vert.x has not been made accessible during local data setup.
-			vertx = Vertx.vertx();
 			initLocalData(flags, options, false);
 			db.closeConnectionPool();
 			db.shutdown();
-			vertx.close();
-			vertx = null;
 
 			// Start OrientDB Server which will open the previously created db and init hazelcast
 			db.clusterManager().startAndSync();
 
 			// Now since hazelcast is ready we can create Vert.x
 			initVertx(options);
+
+			// update the event bus store with the clustered event bus
+			eventBusStore.setEventBus(vertx.eventBus());
 
 			// Setup the connection pool in order to allow transactions to be used
 			db.setupConnectionPool();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/cache/EventAwareCacheTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/cache/EventAwareCacheTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.gentics.mesh.event.EventBusStore;
 import org.junit.Test;
 
 import com.gentics.mesh.cache.impl.EventAwareCacheImpl;
@@ -25,6 +26,8 @@ public class EventAwareCacheTest extends AbstractMeshTest {
 	public void testCustomHandler() {
 		MeshOptions options = getTestContext().getOptions();
 		options.getMonitoringOptions().setEnabled(false);
+		EventBusStore eventBusStore = new EventBusStore();
+		eventBusStore.setEventBus(vertx().eventBus());
 		EventAwareCache<String, Boolean> USER_STATE_CACHE = new EventAwareCacheImpl.Builder<String, Boolean>()
 			.maxSize(15_000)
 			.events(USER_UPDATED)
@@ -40,7 +43,7 @@ public class EventAwareCacheTest extends AbstractMeshTest {
 			.setMetricsService(mock(MetricsService.class))
 			.meshOptions(options)
 			.name("testcache")
-			.vertx(vertx())
+			.eventBusStore(eventBusStore)
 			.build();
 
 		// Set some values to the cache

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootClusteredEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootClusteredEndpointTest.java
@@ -1,0 +1,41 @@
+package com.gentics.mesh.core.webroot;
+
+import com.gentics.mesh.FieldUtil;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.node.NodeUpdateRequest;
+import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+
+import org.junit.Test;
+
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static org.junit.Assert.assertEquals;
+
+@MeshTestSetting(testSize = FULL, startServer = true, clusterMode = true)
+public class WebRootClusteredEndpointTest extends AbstractMeshTest {
+
+    @Test
+    public void testNodeCreateUpdate() {
+        NodeCreateRequest nodeCreateRequest = new NodeCreateRequest();
+        nodeCreateRequest.setLanguage("en");
+        nodeCreateRequest.setSchemaName("content");
+        nodeCreateRequest.getFields().put("teaser", FieldUtil.createStringField("some teaser"));
+        nodeCreateRequest.getFields().put("slug", FieldUtil.createStringField("new-page.html"));
+        nodeCreateRequest.getFields().put("content", FieldUtil.createStringField("Blessed mealtime again!"));
+
+        NodeResponse response = call(() -> client().webrootCreate(PROJECT_NAME, "/new-page.html", nodeCreateRequest));
+        assertEquals("0.1", response.getVersion());
+
+        NodeCreateRequest nodeUpdateRequest = new NodeCreateRequest();
+        nodeUpdateRequest.setLanguage("en");
+        nodeUpdateRequest.setSchemaName("content");
+        nodeUpdateRequest.getFields().put("teaser", FieldUtil.createStringField("some teaser"));
+        nodeUpdateRequest.getFields().put("slug", FieldUtil.createStringField("new-page.html"));
+        nodeUpdateRequest.getFields().put("content", FieldUtil.createStringField("Blessed mealtime again 2!"));
+
+        call(() -> client().webrootCreate(PROJECT_NAME, "/new-page.html", nodeUpdateRequest));
+    }
+}


### PR DESCRIPTION
## Abstract

Since 1.8.x, starting a cluster with initCluster flag set to true in clustered mode would initliaze caches too early, and as a result they are not connected to the event bus. This has been fixed by making sure the caches subscribe to the latest available event bus. As a consequence of the refactoring, we don't need to initialize vert.x twice anymore

## Checklist

### General

* [X] Added abstract that describes the change
* [X] Added changelog entry to `/CHANGELOG.adoc`
* [X] Ensured that the change is covered by tests
* [X] Ensured that the change is documented in the docs

### On API Changes

* [X] Checked if the changes are breaking or not
* [X] Added GraphQL API if applicable
* [X] Added Elasticsearch mapping if applicable
