### PR TITLE
SUP-14400: Filter out indices to be cleaned on resync

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,8 @@ icon:plus[] Rest: The new endpoints `/api/v2/.../rolePermissions` allow getting,
 
 icon:plus[] Core: The core Vert.x library was updated to version `4.3.2`.
 
+icon:check[] Core: On Elasticsearch index resync the indices for additional languages were deleted, ignoring the actual ES language schema setup. This has been fixed.
+
 [[v1.9.5]]
 == 1.9.5 (24.10.2022)
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandlerImpl.java
@@ -305,7 +305,7 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 						version.getSchema().findOverriddenSearchLanguages()
 								.forEach(language -> Stream.of(DRAFT, PUBLISHED).forEach(type -> {
 									activeIndices.add(ContentDao.composeIndexName(currentProject.getUuid(),
-											branch.getUuid(), version.getUuid(), type, language));
+											branch.getUuid(), version.getUuid(), type, language, version.getMicroschemaVersionHash(branch)));
 								}));
 
 						Arrays.asList(ContainerType.DRAFT, ContainerType.PUBLISHED).forEach(type -> {

--- a/tests/tests-core/src/main/resources/schemas/languageOverride/pageWithMicronode.json
+++ b/tests/tests-core/src/main/resources/schemas/languageOverride/pageWithMicronode.json
@@ -1,0 +1,74 @@
+{
+  "name": "page",
+  "elasticsearch": {
+    "_meshLanguageOverride": {
+      "de": {
+        "analysis": {
+          "analyzer": {
+            "my_stop_analyzer": {
+              "type": "stop",
+              "stopwords": "_german_"
+            }
+          }
+        }
+      },
+      "ja,zh,ko": {
+        "analysis": {
+          "analyzer": {
+            "my_stop_analyzer": {
+              "type": "stop",
+              "stopwords": ["_english_", "_cjk_"]
+            }
+          }
+        }
+      }
+    },
+    "analysis": {
+      "analyzer": {
+        "my_stop_analyzer": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      }
+    }
+  },
+  "fields": [
+    {
+	    "name": "mic",
+	    "label": "Micronode Field One",
+	    "required": false,
+	    "type": "micronode",
+	    "allow": [
+	        "micro"
+	    ]
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "elasticsearch": {
+        "basicsearch": {
+          "type": "text",
+          "analyzer": "my_stop_analyzer"
+        }
+      }
+    },
+    {
+      "name": "content",
+      "type": "string",
+      "elasticsearch": {
+        "_meshLanguageOverride": {
+          "fr": {
+            "basicsearch": {
+              "type": "text",
+              "analyzer": "standard"
+            }
+          }
+        },
+        "basicsearch": {
+          "type": "text",
+          "analyzer": "my_stop_analyzer"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Abstract
When you have a schema, which has different settings per language: elasticsearch._meshLanguageOverride.[langCode], then Mesh will create a separate index for it.
i.E. `mesh-node-<project>-<branch>-<schemaVersion>-<draft/published>[-langCode][-microSchemaHash]`

The default/fallback index simply does not include the additional [-langCode].

The issue is, when you trigger a sync POST /search/sync.
This should verify all indices and update the documents accordingly (Adding missing ones, updating not up to date ones, and deleting documents which shouldn't be there).

However, this only seems to work on the default/fallback index.
The content of these Language Indices are dropped entirely and will then be re-populated.
This is not how the sync should work and causes the search for these languages to be unavailable/not properly useable until everything has been re-populated.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
