### PR TITLE
SUP-14417 Remove superfluous error logs for 4xx errors

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.38]]
+== 1.6.38 (TBD)
+
+icon:check[] Logging: Remove superfluous error messages for HTTP status 4xx errors. These are logged by the logger handler as warnings.
+
 [[v1.6.37]]
 == 1.6.37 (17.11.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshUploadOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshUploadOptions.java
@@ -27,7 +27,7 @@ public class MeshUploadOptions implements Option {
 	public static final String MESH_BINARY_METADATA_WHITELIST_ENV = "MESH_BINARY_METADATA_WHITELIST";
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The upload size limit in bytes. Default: " + DEFAULT_FILEUPLOAD_MB_LIMIT)
+	@JsonPropertyDescription("The upload size limit in bytes. Default: " + DEFAULT_FILEUPLOAD_BYTE_LIMIT + " (" + DEFAULT_FILEUPLOAD_MB_LIMIT + " MB)")
 	@EnvironmentVariable(name = MESH_BINARY_UPLOAD_LIMIT_ENV, description = "Override the configured binary byte upload limit.")
 	private long byteLimit = DEFAULT_FILEUPLOAD_BYTE_LIMIT;
 
@@ -59,7 +59,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Return the upload limit in bytes.
-	 * 
+	 *
 	 * @return Limit in bytes
 	 */
 	public long getByteLimit() {
@@ -68,7 +68,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Set the upload limit in bytes.
-	 * 
+	 *
 	 * @param byteLimit
 	 *            Limit in bytes
 	 * @return Fluent API
@@ -80,7 +80,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Return the binary storage directory.
-	 * 
+	 *
 	 * @return Binary storage filesystem directory
 	 */
 	public String getDirectory() {
@@ -89,7 +89,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Set the binary storage directory.
-	 * 
+	 *
 	 * @param directory
 	 *            Binary storage filesystem directory
 	 * @return Fluent API
@@ -101,7 +101,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Returns the upload temporary directory. New uploads are placed in this directory before those are processed and moved.
-	 * 
+	 *
 	 * @return Temporary filesystem directory
 	 */
 	public String getTempDirectory() {
@@ -110,7 +110,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Set the temporary upload directory. New uploads will be placed within this location before processing.
-	 * 
+	 *
 	 * @param tempDirectory
 	 *            Temporary filesystem directory
 	 * @return Fluent API
@@ -122,7 +122,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Return the configured parser limit.
-	 * 
+	 *
 	 * @return
 	 */
 	public int getParserLimit() {
@@ -131,7 +131,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Set the parser limit for uploaded documents.
-	 * 
+	 *
 	 * @param parserLimit
 	 * @return Fluent API
 	 */
@@ -142,7 +142,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Check whether the upload document parser is enabled.
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isParser() {
@@ -151,7 +151,7 @@ public class MeshUploadOptions implements Option {
 
 	/**
 	 * Set the document parser flag.
-	 * 
+	 *
 	 * @param parser
 	 * @return Fluent API
 	 */

--- a/common/src/main/java/com/gentics/mesh/router/route/FailureHandler.java
+++ b/common/src/main/java/com/gentics/mesh/router/route/FailureHandler.java
@@ -4,10 +4,6 @@ import static com.gentics.mesh.core.rest.error.Errors.error;
 import static com.gentics.mesh.http.HttpConstants.APPLICATION_JSON_UTF8;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 
-import java.nio.file.NoSuchFileException;
-import java.util.MissingResourceException;
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.context.impl.InternalRoutingActionContextImpl;
@@ -19,12 +15,15 @@ import com.gentics.mesh.error.MeshSchemaException;
 import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.json.MeshJsonException;
 import com.gentics.mesh.monitor.liveness.LivenessManager;
-
 import io.vertx.core.Handler;
 import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
+
+import java.nio.file.NoSuchFileException;
+import java.util.MissingResourceException;
+import java.util.Optional;
 
 /**
  * Central failure handler for REST API routes.
@@ -37,7 +36,7 @@ public class FailureHandler implements Handler<RoutingContext> {
 
 	/**
 	 * Create a new failure handler.
-	 * 
+	 *
 	 * @param livenessBean liveness bean
 	 * @return created failure handler
 	 */
@@ -55,7 +54,7 @@ public class FailureHandler implements Handler<RoutingContext> {
 
 	/**
 	 * Return the response status that may be stored within the exception.
-	 * 
+	 *
 	 * @param failure
 	 * @param code
 	 * @return
@@ -132,21 +131,17 @@ public class FailureHandler implements Handler<RoutingContext> {
 			int code = getResponseStatusCode(failure, rc.statusCode());
 			String failureMsg = failure != null ? failure.getMessage() : "-";
 			switch (code) {
+			case 400:
 			case 401:
-				log.error("Unauthorized - Request for path {" + toPath(rc) + "} was not authorized.");
-				break;
 			case 404:
-				log.error("Could not find resource for path {" + toPath(rc) + "}");
+				// No special handling needed, the Vert.x logger handler will
+				// output a single warning line with the status code.
 				break;
 			case 403:
 				ac.getSecurityLogger().info("Non-authorized access for path " + toPath(rc));
-				log.error("Request for request in path: " + toPath(rc) + " is not authorized.");
-				break;
-			case 400:
-				log.error("Bad request in path: " + toPath(rc) + " with message " + failureMsg);
 				break;
 			case 413:
-				log.error("Entity too large to be processed for path: " + toPath(rc));
+				// Payload Too Large will be handled later.
 				rc.next();
 				return;
 			default:
@@ -214,7 +209,7 @@ public class FailureHandler implements Handler<RoutingContext> {
 
 	/**
 	 * Try to translate the nested i18n message key.
-	 * 
+	 *
 	 * @param error
 	 * @param rc
 	 */


### PR DESCRIPTION
## Abstract

For requests which result in a 4xx HTTP status code, additional error messages are logged, which do not add information to the warnings logged by the logger handler. These messages are distracting when scanning the logs for errors, so they were removed.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
