### PR TITLE
SUP-14472: Two nodes with same path/segment field if binary is filled

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.8.15]]
+== 1.8.15 (TBD)
+
+icon:check[] Core: Having a binary non-segment field update might break the uniqueness of the segment field value, allowing creation of multiple nodes with the same segment/webroot value. This has now been fixed.
+
 [[v1.8.14]]
 == 1.8.14 (22.11.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandlerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/BinaryUploadHandlerImpl.java
@@ -372,6 +372,8 @@ public class BinaryUploadHandlerImpl extends AbstractHandler implements BinaryUp
 			newDraftVersion.removeField(oldField);
 
 			// If the binary field is the segment field, we need to update the webroot info in the node
+			// TODO FIXME This is already called in `PersistingContentDao.connectFieldContainer()`. Normally one should not update a container without reconnecting versions,
+			// but currently MeshLocalClient does this, which may be illegal. The check and call below should be removed, once MeshLocalClientImpl is improved.
 			if (field.getFieldKey().equals(contentDao.getSchemaContainerVersion(newDraftVersion).getSchema().getSegmentField())) {
 				contentDao.updateWebrootPathInfo(newDraftVersion, branch.getUuid(), "node_conflicting_segmentfield_upload");
 			}

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
@@ -235,10 +235,11 @@ public interface PersistingContentDao extends ContentDao {
 			// remove existing draft edge
 			if (draftEdge != null) {
 				removeEdge(draftEdge);
-				updateWebrootPathInfo(newContainer, branchUuid, "node_conflicting_segmentfield_update");
 			}
 			// create a new draft edge
 			createContainerEdge(node, newContainer, branchUuid, languageTag, DRAFT);
+
+			updateWebrootPathInfo(newContainer, branchUuid, "node_conflicting_segmentfield_update");
 		}
 
 		// if there is no initial edge, create one


### PR DESCRIPTION
## Abstract

Reproducible in the mesh-ui:

    Create a new Schema "test"
    with a field "id" type string and binary with name "binary"
    set segment field to id
    Create a new project "test" and link schema
    Create a new node with schema "test" and fill id with "1" -> save
    Create a new node and fill id with "1" again -> save -> ERROR because segment field already used
    Edit first created node and upload a binary in the binary field -> save
    Try again to create a new node with id "1" -> save -> WORKS
    => now you have two nodes with the same segment field

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
