### PR TITLE
SUP-14448: Mesh: LivenessCheck returns 200 even if EventbusCheck fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ elasticsearch-6.1.2
 build.sh
 debuginfo.log
 /.run
+.asciidoctorconfig.adoc

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,7 +20,7 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.6.40]]
 == 1.6.40 (TBD)
 
-icon:check[] Clustering: Liveness check now marks an instance as dead, if the cluster manager (Hazelcast) reports it as unresponsive, even if the non-cluster liveness check passes.
+icon:check[] Clustering: Liveness check now marks an instance as dead, if the event bus did not get its own cluster pod ping within the timeout period, even if the non-cluster ping comes in time.
 
 [[v1.6.39]]
 == 1.6.39 (01.12.2022)

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.40]]
+== 1.6.40 (TBD)
+
+icon:check[] Clustering: Liveness check now marks an instance as dead, if the cluster manager (Hazelcast) reports it as unresponsive, even if the non-cluster liveness check passes.
+
 [[v1.6.39]]
 == 1.6.39 (01.12.2022)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,7 +20,7 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.6.40]]
 == 1.6.40 (TBD)
 
-icon:check[] Clustering: Liveness check now marks an instance as dead, if the event bus did not get its own cluster pod ping within the timeout period, even if the non-cluster ping comes in time.
+icon:check[] Clustering: Liveness check now marks an instance as dead, if the event bus did not get its own cluster instance ping within the timeout period, even if the non-cluster ping comes in time.
 
 [[v1.6.39]]
 == 1.6.39 (01.12.2022)

--- a/common/src/main/java/com/gentics/mesh/event/EventBusLivenessManagerImpl.java
+++ b/common/src/main/java/com/gentics/mesh/event/EventBusLivenessManagerImpl.java
@@ -161,7 +161,7 @@ public final class EventBusLivenessManagerImpl implements EventBusLivenessManage
 						long sinceLastPing = System.currentTimeMillis() - lastNodePingTimestamp;
 						if (errorThreshold > 0 && sinceLastPing > errorThreshold) {
 							log.error("Last ping from {} received {} ms ago", nodeName, sinceLastPing);
-							if (nodeName.equals(clusterManager.getHazelcast().getName())) {
+							if (nodeName.equals(options.getNodeName())) {
 								livenessManager.setLive(false, "Last own cluster ping received " + sinceLastPing + " ms ago");
 							}
 						} else if (warnThreshold > 0 && sinceLastPing > warnThreshold) {

--- a/common/src/main/java/com/gentics/mesh/event/EventBusLivenessManagerImpl.java
+++ b/common/src/main/java/com/gentics/mesh/event/EventBusLivenessManagerImpl.java
@@ -161,6 +161,9 @@ public final class EventBusLivenessManagerImpl implements EventBusLivenessManage
 						long sinceLastPing = System.currentTimeMillis() - lastNodePingTimestamp;
 						if (errorThreshold > 0 && sinceLastPing > errorThreshold) {
 							log.error("Last ping from {} received {} ms ago", nodeName, sinceLastPing);
+							if (nodeName.equals(clusterManager.getHazelcast().getName())) {
+								livenessManager.setLive(false, "Last own cluster ping received " + sinceLastPing + " ms ago");
+							}
 						} else if (warnThreshold > 0 && sinceLastPing > warnThreshold) {
 							log.warn("Last ping from {} received {} ms ago", nodeName, sinceLastPing);
 						} else {


### PR DESCRIPTION
## Abstract

If the cluster manager reports unresponsive pod on an own instance name, the instance should be considered "broken" and liveness check should fail so a restart can be triggered from an external System(Kubernetes, monitoring).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
