### PR TITLE
Reset segment info, if segment field is null

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.41]]
+== 1.6.41 (TBD)
+
+icon:check[] Core: Updating the webroot info might throw a false conflict exception, when the segment field value is reset for a schema. This has been fixed.
+
 [[v1.6.40]]
 == 1.6.40 (15.12.2022)
 

--- a/core/src/main/java/com/gentics/mesh/core/data/container/impl/NodeGraphFieldContainerImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/container/impl/NodeGraphFieldContainerImpl.java
@@ -390,8 +390,8 @@ public class NodeGraphFieldContainerImpl extends AbstractGraphFieldContainerImpl
 		String segment = node.getPathSegment(branchUuid, type, getLanguageTag());
 
 		// The webroot uniqueness will be checked by validating that the string [segmentValue-branchUuid-parentNodeUuid] is only listed once within the given
-		// specific index for (drafts or published nodes)
-		if (segment != null) {
+		// specific index for (drafts or published nodes)Segment field should also be set, otherwise the segment info is treated as outdated and is subject to reset.
+		if (segment != null && StringUtils.isNotBlank(segmentFieldName)) {
 			Node parentNode = node.getParentNode(branchUuid);
 			String segmentInfo = GraphFieldContainerEdgeImpl.composeSegmentInfo(parentNode, segment);
 			Object webRootIndexKey = GraphFieldContainerEdgeImpl.composeWebrootIndexKey(db(), segmentInfo, branchUuid, type);


### PR DESCRIPTION
## Abstract

If the segment field name is empty, the segment info is treated as outdated and is subject to reset.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
