### PR TITLE
Add timeout for waiting for async graphql results

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,9 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] Core: Updating the webroot info might throw a false conflict exception, when the segment field value is reset for a schema. This has been fixed.
 
+icon:check[] GraphQL: In rare cases, GraphQL statements could "hang" forever, which caused the corresponding worker thread to be blocked forever.
+This has been fixed now by introducing a configurable timeout.
+
 [[v1.6.40]]
 == 1.6.40 (15.12.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
@@ -13,12 +13,21 @@ import com.gentics.mesh.etc.config.env.Option;
 public class GraphQLOptions implements Option {
 	public static final long DEFAULT_SLOW_THRESHOLD = 60_000L;
 
+	public static final long DEFAULT_ASYNC_WAIT_TIMEOUT = 60_000L;
+
 	public static final String MESH_GRAPHQL_SLOW_THRESHOLD_ENV = "MESH_GRAPHQL_SLOW_THRESHOLD";
+
+	public static final String MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV = "MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Threshold for logging slow graphql queries. Default: " + DEFAULT_SLOW_THRESHOLD + "ms")
 	@EnvironmentVariable(name = MESH_GRAPHQL_SLOW_THRESHOLD_ENV, description = "Override the configured slow graphQl query threshold.")
 	private Long slowThreshold = DEFAULT_SLOW_THRESHOLD;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Threshold for waiting for asynchronous graphql queries. Default: " + DEFAULT_ASYNC_WAIT_TIMEOUT + "ms")
+	@EnvironmentVariable(name = MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV, description = "Override the configured graphQl async wait timeout.")
+	private Long asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
 
 	/**
 	 * Get the threshold for logging slow graphQl queries (in milliseconds)
@@ -35,6 +44,28 @@ public class GraphQLOptions implements Option {
 	 */
 	public GraphQLOptions setSlowThreshold(Long slowThreshold) {
 		this.slowThreshold = slowThreshold;
+		return this;
+	}
+
+	/**
+	 * Async wait timeout for graphQl queries (in milliseconds)
+	 * @return wait timeout in milliseconds
+	 */
+	public Long getAsyncWaitTimeout() {
+		return asyncWaitTimeout;
+	}
+
+	/**
+	 * Set the async wait timeout in milliseconds
+	 * @param asyncWaitTimeout timeout
+	 * @return fluent API
+	 */
+	public GraphQLOptions setAsyncWaitTimeout(Long asyncWaitTimeout) {
+		this.asyncWaitTimeout = asyncWaitTimeout;
+		// make sure the value is not set to null
+		if (this.asyncWaitTimeout == null) {
+			this.asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
+		}
 		return this;
 	}
 }

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/GraphQLHandler.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/GraphQLHandler.java
@@ -6,7 +6,9 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -91,28 +93,42 @@ public class GraphQLHandler {
 						.context(gc)
 						.variables(variables)
 						.build();
-					ExecutionResult result = graphQL.execute(executionInput);
-					List<GraphQLError> errors = result.getErrors();
-					JsonObject response = new JsonObject();
-					if (!errors.isEmpty()) {
-						addErrors(errors, response);
-						if (log.isDebugEnabled()) {
-							log.debug("Encountered {" + errors.size() + "} errors while executing query {" + query + "}");
-							for (GraphQLError error : errors) {
-								String loc = "unknown location";
-								if (error.getLocations() != null) {
-									loc = error.getLocations().stream().map(Object::toString).collect(Collectors.joining(","));
+					try {
+						// Implementation Note: GraphQL is implemented synchronously (no implemented datafetcher returns a CompletableFuture, which is not yet completed)
+						// Nonetheless, we see sometimes that the CompletableFuture is not completed (and never will be), when GraphQL joins it, which leads to endlessly
+						// blocked worker threads.
+						// Therefore, we use the "async approach" for calling GraphQL and wait for the result with a timeout.
+						ExecutionResult result = graphQL.executeAsync(executionInput)
+								.get(graphQLOptions.getAsyncWaitTimeout(), TimeUnit.MILLISECONDS);
+						List<GraphQLError> errors = result.getErrors();
+						JsonObject response = new JsonObject();
+						if (!errors.isEmpty()) {
+							addErrors(errors, response);
+							if (log.isDebugEnabled()) {
+								log.debug("Encountered {" + errors.size() + "} errors while executing query {" + query + "}");
+								for (GraphQLError error : errors) {
+									String loc = "unknown location";
+									if (error.getLocations() != null) {
+										loc = error.getLocations().stream().map(Object::toString).collect(Collectors.joining(","));
+									}
+									log.debug("Error: " + error.getErrorType() + ":" + error.getMessage() + ":" + loc);
 								}
-								log.debug("Error: " + error.getErrorType() + ":" + error.getMessage() + ":" + loc);
 							}
 						}
+						if (result.getData() != null) {
+							Map<String, Object> data = result.getData();
+							response.put("data", new JsonObject(data));
+						}
+						gc.send(response.encodePrettily(), OK);
+						promise.complete();
+					} catch (TimeoutException | InterruptedException | ExecutionException e) {
+						// If an error happens while "waiting" for the result, we log the GraphQL query here.
+						log.error("GraphQL query failed after {} ms with {}:\n{}\nvariables: {}",
+								graphQLOptions.getAsyncWaitTimeout(), e.getClass().getSimpleName(), loggableQuery.get(),
+								loggableVariables.get());
+						gc.fail(e);
+						promise.fail(e);
 					}
-					if (result.getData() != null) {
-						Map<String, Object> data = result.getData();
-						response.put("data", new JsonObject(data));
-					}
-					gc.send(response.encodePrettily(), OK);
-					promise.complete();
 				});
 			} catch (Exception e) {
 				promise.fail(e);


### PR DESCRIPTION
## Abstract

Although GraphQL is called synchronously, we sometimes see worker threads, which are blocked forever while waiting for the CompletableFuture to complete. Therefore, this change introduces a timeout while waiting for the CompletableFuture to complete.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
