### PR TITLE
Hotfix 1.8.x sup 14743

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,14 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.8.17]]
+== 1.8.17 (TBD)
+
+icon:check[] GraphQL: In rare cases, GraphQL statements could "hang" forever, which caused the corresponding worker thread to be blocked forever.
+This has been fixed now by introducing a configurable timeout.
+
+icon:check[] GraphQL: The graphql library has been updated to version 20.0.
+
 [[v1.8.16]]
 == 1.8.16 (15.12.2022)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
@@ -13,12 +13,21 @@ import com.gentics.mesh.etc.config.env.Option;
 public class GraphQLOptions implements Option {
 	public static final long DEFAULT_SLOW_THRESHOLD = 60_000L;
 
+	public static final long DEFAULT_ASYNC_WAIT_TIMEOUT = 60_000L;
+
 	public static final String MESH_GRAPHQL_SLOW_THRESHOLD_ENV = "MESH_GRAPHQL_SLOW_THRESHOLD";
+
+	public static final String MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV = "MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Threshold for logging slow graphql queries. Default: " + DEFAULT_SLOW_THRESHOLD + "ms")
 	@EnvironmentVariable(name = MESH_GRAPHQL_SLOW_THRESHOLD_ENV, description = "Override the configured slow graphQl query threshold.")
 	private Long slowThreshold = DEFAULT_SLOW_THRESHOLD;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Threshold for waiting for asynchronous graphql queries. Default: " + DEFAULT_ASYNC_WAIT_TIMEOUT + "ms")
+	@EnvironmentVariable(name = MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV, description = "Override the configured graphQl async wait timeout.")
+	private Long asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
 
 	/**
 	 * Get the threshold for logging slow graphQl queries (in milliseconds)
@@ -35,6 +44,28 @@ public class GraphQLOptions implements Option {
 	 */
 	public GraphQLOptions setSlowThreshold(Long slowThreshold) {
 		this.slowThreshold = slowThreshold;
+		return this;
+	}
+
+	/**
+	 * Async wait timeout for graphQl queries (in milliseconds)
+	 * @return wait timeout in milliseconds
+	 */
+	public Long getAsyncWaitTimeout() {
+		return asyncWaitTimeout;
+	}
+
+	/**
+	 * Set the async wait timeout in milliseconds
+	 * @param asyncWaitTimeout timeout
+	 * @return fluent API
+	 */
+	public GraphQLOptions setAsyncWaitTimeout(Long asyncWaitTimeout) {
+		this.asyncWaitTimeout = asyncWaitTimeout;
+		// make sure the value is not set to null
+		if (this.asyncWaitTimeout == null) {
+			this.asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
+		}
 		return this;
 	}
 }

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
@@ -13,7 +13,7 @@ import com.gentics.mesh.etc.config.env.Option;
 public class GraphQLOptions implements Option {
 	public static final long DEFAULT_SLOW_THRESHOLD = 60_000L;
 
-	public static final long DEFAULT_ASYNC_WAIT_TIMEOUT = 60_000L;
+	public static final long DEFAULT_ASYNC_WAIT_TIMEOUT = 120_000L;
 
 	public static final String MESH_GRAPHQL_SLOW_THRESHOLD_ENV = "MESH_GRAPHQL_SLOW_THRESHOLD";
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- when updating version, don't forget to update administration-guide.asciidoc -->
-		<graphql.version>12.0</graphql.version>
+		<graphql.version>20.0</graphql.version>
 		<graphql-dataloader.version>3.1.2</graphql-dataloader.version>
 		<pf4j.version>3.1.0</pf4j.version>
 		<asm.version>3.3.1</asm.version>
@@ -670,6 +670,11 @@
 			<dependency>
 				<groupId>com.graphql-java</groupId>
 				<artifactId>graphql-java</artifactId>
+				<version>${graphql.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.graphql-java</groupId>
+				<artifactId>graphql-java-extended-scalars</artifactId>
 				<version>${graphql.version}</version>
 			</dependency>
 			<dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -685,7 +685,7 @@
 			<dependency>
 				<groupId>com.gentics.graphqlfilter</groupId>
 				<artifactId>graphql-java-filter</artifactId>
-				<version>1.0.1</version>
+				<version>2.0.0</version>
 			</dependency>
 
 		</dependencies>

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -36,6 +36,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
 
 import com.gentics.mesh.Mesh;
 import com.gentics.mesh.auth.util.KeycloakUtils;
@@ -602,7 +603,9 @@ public class MeshTestContext implements TestRule {
 			network = Network.newNetwork();
 			elasticsearch = new ElasticsearchContainer(version).withNetwork(network);
 			elasticsearch.waitingFor(Wait.forHttp(("/")));
-			toxiproxy = new ToxiproxyContainer(System.getProperty("mesh.container.image.prefix", "") + "shopify/toxiproxy:2.1.0").withNetwork(network);
+			toxiproxy = new ToxiproxyContainer(DockerImageName
+					.parse(System.getProperty("mesh.container.image.prefix", "") + "shopify/toxiproxy:2.1.0")
+					.asCompatibleSubstituteFor("shopify/toxiproxy:2.1.0")).withNetwork(network);
 			if (!toxiproxy.isRunning()) {
 				toxiproxy.start();
 			}

--- a/tests/tests-rest-client/src/main/java/com/gentics/mesh/rest/RestClientTest.java
+++ b/tests/tests-rest-client/src/main/java/com/gentics/mesh/rest/RestClientTest.java
@@ -2,7 +2,6 @@ package com.gentics.mesh.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,8 +63,8 @@ public class RestClientTest {
 
 		latch.await(10, TimeUnit.SECONDS);
 		assertThat(success.get()).isFalse();
-		assertThat(caught.get()).as("Caught exception").isNotNull().hasMessage(
-				"I/O Error in GET http://does.not.exist:4711/api/v1/ : UnknownHostException (does.not.exist: Name or service not known)");
+		assertThat(caught.get()).as("Caught exception").isNotNull().hasMessageStartingWith(
+				"I/O Error in GET http://does.not.exist:4711/api/v1/ : UnknownHostException");
 	}
 
 	/**
@@ -88,7 +87,7 @@ public class RestClientTest {
 
 		latch.await(10, TimeUnit.SECONDS);
 		assertThat(success.get()).isFalse();
-		assertThat(caught.get()).as("Caught exception").isNotNull().hasMessage(
-				"I/O Error in GET http://localhost:4711/api/v1/ : ConnectException (Failed to connect to localhost/127.0.0.1:4711)");
+		assertThat(caught.get()).as("Caught exception").isNotNull().hasMessageStartingWith(
+				"I/O Error in GET http://localhost:4711/api/v1/ : ConnectException");
 	}
 }

--- a/verticles/graphql/pom.xml
+++ b/verticles/graphql/pom.xml
@@ -34,6 +34,10 @@
 			<artifactId>graphql-java</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.graphql-java</groupId>
+			<artifactId>graphql-java-extended-scalars</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.gentics.mesh</groupId>
 			<artifactId>mesh-elasticsearch</artifactId>
 		</dependency>

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/GraphQLHandler.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/GraphQLHandler.java
@@ -111,14 +111,13 @@ public class GraphQLHandler {
 						.context(gc)
 						.variables(variables)
 						.build();
-//					try {
+					try {
 						// Implementation Note: GraphQL is implemented synchronously (no implemented datafetcher returns a CompletableFuture, which is not yet completed)
 						// Nonetheless, we see sometimes that the CompletableFuture is not completed (and never will be), when GraphQL joins it, which leads to endlessly
 						// blocked worker threads.
 						// Therefore, we use the "async approach" for calling GraphQL and wait for the result with a timeout.
-//						ExecutionResult result = graphQL.executeAsync(executionInput)
-//								.get(graphQLOptions.getAsyncWaitTimeout(), TimeUnit.MILLISECONDS);
-						ExecutionResult result = graphQL.execute(executionInput);
+						ExecutionResult result = graphQL.executeAsync(executionInput)
+								.get(graphQLOptions.getAsyncWaitTimeout(), TimeUnit.MILLISECONDS);
 						List<GraphQLError> errors = result.getErrors();
 						JsonObject response = new JsonObject();
 						if (!errors.isEmpty()) {
@@ -140,14 +139,14 @@ public class GraphQLHandler {
 						}
 						gc.send(response.encodePrettily(), OK);
 						promise.complete();
-//					} catch (TimeoutException | InterruptedException | ExecutionException e) {
-//						// If an error happens while "waiting" for the result, we log the GraphQL query here.
-//						log.error("GraphQL query failed after {} ms with {}:\n{}\nvariables: {}",
-//								graphQLOptions.getAsyncWaitTimeout(), e.getClass().getSimpleName(), loggableQuery.get(),
-//								loggableVariables.get());
-//						gc.fail(e);
-//						promise.fail(e);
-//					}
+					} catch (TimeoutException | InterruptedException | ExecutionException e) {
+						// If an error happens while "waiting" for the result, we log the GraphQL query here.
+						log.error("GraphQL query failed after {} ms with {}:\n{}\nvariables: {}",
+								graphQLOptions.getAsyncWaitTimeout(), e.getClass().getSimpleName(), loggableQuery.get(),
+								loggableVariables.get());
+						gc.fail(e);
+						promise.fail(e);
+					}
 				});
 			} catch (Exception e) {
 				promise.fail(e);

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/filter/SchemaFilter.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/filter/SchemaFilter.java
@@ -46,10 +46,20 @@ public class SchemaFilter extends MainFilter<HibSchema> {
 		List<GraphQLEnumValueDefinition> values = StreamSupport.stream(schemaDao.findAll(project).spliterator(), false)
 			.map(schema -> {
 				String name = schema.getName();
-				return new GraphQLEnumValueDefinition(name, name, schema.getUuid());
+				return GraphQLEnumValueDefinition
+						.newEnumValueDefinition()
+						.name(name)
+						.description(name)
+						.value(schema.getUuid())
+						.build();
 			}).collect(Collectors.toList());
 
-		return new GraphQLEnumType("SchemaEnum", "Enumerates all schemas", values);
+		return GraphQLEnumType
+				.newEnum()
+				.name("SChemaEnum")
+				.description("Enumerates all schemas")
+				.values(values)
+				.build();
 	}
 
 	@Override

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
@@ -4,7 +4,7 @@ import static com.gentics.mesh.core.action.DAOActionContext.context;
 import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PERM;
 import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PUBLISHED_PERM;
 import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
-import static graphql.Scalars.GraphQLLong;
+import static graphql.scalars.java.JavaPrimitives.GraphQLLong;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/QueryTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/QueryTypeProvider.java
@@ -29,7 +29,7 @@ import static com.gentics.mesh.graphql.type.TagTypeProvider.TAG_TYPE_NAME;
 import static com.gentics.mesh.graphql.type.UserTypeProvider.USER_PAGE_TYPE_NAME;
 import static com.gentics.mesh.graphql.type.UserTypeProvider.USER_TYPE_NAME;
 import static graphql.Scalars.GraphQLBoolean;
-import static graphql.Scalars.GraphQLLong;
+import static graphql.scalars.java.JavaPrimitives.GraphQLLong;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/FieldDefinitionProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/FieldDefinitionProvider.java
@@ -5,12 +5,12 @@ import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PUBLISHED_
 import static com.gentics.mesh.core.rest.error.Errors.error;
 import static com.gentics.mesh.graphql.type.NodeTypeProvider.NODE_TYPE_NAME;
 import static com.gentics.mesh.graphql.type.field.MicronodeFieldTypeProvider.MICRONODE_TYPE_NAME;
-import static graphql.Scalars.GraphQLBigDecimal;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLFloat;
 import static graphql.Scalars.GraphQLInt;
-import static graphql.Scalars.GraphQLLong;
 import static graphql.Scalars.GraphQLString;
+import static graphql.scalars.java.JavaPrimitives.GraphQLBigDecimal;
+import static graphql.scalars.java.JavaPrimitives.GraphQLLong;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 


### PR DESCRIPTION
## Abstract

Although GraphQL is called synchronously, we sometimes see worker threads, which are blocked forever while waiting for the CompletableFuture to complete. Therefore, this change introduces a timeout while waiting for the CompletableFuture to complete.
Also, the GraphQL Library has been updated to the most recent version (20.0).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
