### PR TITLE
Cluster test fixes

### DIFF
--- a/databases/orientdb/src/test/java/com/gentics/mesh/graphdb/orientdb/changelog/ChangelogSystemTest.java
+++ b/databases/orientdb/src/test/java/com/gentics/mesh/graphdb/orientdb/changelog/ChangelogSystemTest.java
@@ -44,6 +44,10 @@ import net.lingala.zip4j.exception.ZipException;
 @RunWith(value = Parameterized.class)
 public class ChangelogSystemTest {
 
+	static {
+		System.setProperty("memory.directMemory.preallocate", "false");
+	}
+
 	File targetDir = new File("target/dump");
 
 	private String version;
@@ -88,14 +92,13 @@ public class ChangelogSystemTest {
 
 		ReadableByteChannel rbc = Channels.newChannel(website.openStream());
 		File zipFile = new File("target" + File.separator + "dump.zip");
-		FileOutputStream fos = new FileOutputStream(zipFile);
-		try {
+
+		try (FileOutputStream fos = new FileOutputStream(zipFile)) {
 			fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-		} finally {
-			fos.close();
 		}
-		ZipFile zip = new ZipFile(zipFile);
-		zip.extractAll(targetDir.getAbsolutePath());
+		try (ZipFile zip = new ZipFile(zipFile)) {
+			zip.extractAll(targetDir.getAbsolutePath());
+		}
 		zipFile.delete();
 	}
 

--- a/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
+++ b/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
@@ -239,7 +239,7 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 			addEnv(ClusterOptions.MESH_CLUSTER_COORDINATOR_REGEX_ENV, coordinatorPlaneRegex);
 		}
 
-		String javaOpts = "-Dstorage.diskCache.bufferSize=1024 ";
+		String javaOpts = "-Dmemory.directMemory.preallocate=false ";
 		if (debugPort != null) {
 			javaOpts = "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n ";
 			exposedPorts.add(8000);

--- a/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
+++ b/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
@@ -238,7 +239,7 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 			addEnv(ClusterOptions.MESH_CLUSTER_COORDINATOR_REGEX_ENV, coordinatorPlaneRegex);
 		}
 
-		String javaOpts = null;
+		String javaOpts = "-Dstorage.diskCache.bufferSize=1024 ";
 		if (debugPort != null) {
 			javaOpts = "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n ";
 			exposedPorts.add(8000);
@@ -690,7 +691,7 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 		if (containerHost != null) {
 			return containerHost;
 		} else {
-			return super.getContainerIpAddress();
+			return DockerClientFactory.instance().dockerHostIpAddress();
 		}
 	}
 

--- a/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
+++ b/test-common/src/main/java/com/gentics/mesh/test/docker/MeshContainer.java
@@ -241,19 +241,14 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 
 		String javaOpts = "-Dmemory.directMemory.preallocate=false ";
 		if (debugPort != null) {
-			javaOpts = "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n ";
+			javaOpts += "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n ";
 			exposedPorts.add(8000);
 			setPortBindings(Arrays.asList("8000:8000"));
 		}
 		if (extraOpts != null) {
-			if (javaOpts == null) {
-				javaOpts = "";
-			}
 			javaOpts += extraOpts + " ";
 		}
-		if (javaOpts != null) {
-			addEnv("JAVAOPTS", javaOpts);
-		}
+		addEnv("JAVAOPTS", javaOpts);
 
 		exposedPorts.add(8600);
 		exposedPorts.add(8080);
@@ -686,17 +681,13 @@ public class MeshContainer extends GenericContainer<MeshContainer> {
 	}
 
 	@Override
-	public String getContainerIpAddress() {
+	public String getHost() {
 		String containerHost = System.getenv("CONTAINER_HOST");
 		if (containerHost != null) {
 			return containerHost;
 		} else {
-			return DockerClientFactory.instance().dockerHostIpAddress();
+			return super.getHost();
 		}
-	}
-
-	public String getHost() {
-		return getContainerIpAddress();
 	}
 
 	public int getPort() {

--- a/test-common/src/main/resources/Dockerfile.local
+++ b/test-common/src/main/resources/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM    java:openjdk-8-jre-alpine
+FROM openjdk:8-jdk-alpine
 
 USER root
 RUN mkdir /mesh

--- a/test-common/src/main/resources/Dockerfile.local
+++ b/test-common/src/main/resources/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.16.1_1
 
 USER root
 RUN mkdir /mesh


### PR DESCRIPTION
## Abstract

Since recent OrientDB update the hard RAM limits have to be set for the cluster envs. The Java 8 environment is updated, since the old one is not anymore hosted.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
