### PR TITLE
Add readonly patterns for search endpoints

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,13 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.8.18]]
+== 1.8.18 (TBD)
+
+icon:check[] Search: The search endpoints (like e.g. `/api/v1/search/nodes`) were incorrectly treated as not "read-only", which caused them to fail during a cluster topology change,
+if the setting `cluster.topologyChangeReadOnly` was set to `true`. This has been changed now, the real search endpoints are read-only now. It is important to note, that this does still
+not apply to the index maintenance endpoints `/api/v1/search/sync`, `/api/v1/search/clear` and `/api/v1/search/status`.
+
 [[v1.8.17]]
 == 1.8.17 (26.01.2023)
 

--- a/common/src/main/java/com/gentics/mesh/distributed/DistributionUtils.java
+++ b/common/src/main/java/com/gentics/mesh/distributed/DistributionUtils.java
@@ -93,8 +93,12 @@ public class DistributionUtils {
 		patterns.add(Pattern.compile("/api/v[0-9]+/.*/graphql/?"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/search/?"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/rawSearch/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/search/.*"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/rawSearch/.*"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/.*/search/?"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/.*/rawSearch/?"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/.*/search/.*"));
+		patterns.add(Pattern.compile("/api/v[0-9]+/.*/rawSearch/.*"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/utilities/linkResolver/?"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/utilities/validateSchema/?"));
 		patterns.add(Pattern.compile("/api/v[0-9]+/utilities/validateMicroschema/?"));

--- a/tests/tests-distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/RequestDelegatorRegexTest.java
+++ b/tests/tests-distributed-coordinator/src/main/java/com/gentics/mesh/distributed/coordinator/RequestDelegatorRegexTest.java
@@ -24,14 +24,25 @@ public class RequestDelegatorRegexTest {
 		assertReadOnly("/api/v1/demo/graphql/");
 		assertReadOnly("/api/v1/search");
 		assertReadOnly("/api/v1/rawSearch");
+		assertReadOnly("/api/v1/search/nodes");
+		assertReadOnly("/api/v1/rawSearch/nodes");
 		assertReadOnly("/api/v1/demo/search");
 		assertReadOnly("/api/v1/demo/search/");
 		assertReadOnly("/api/v1/demo/rawSearch");
 		assertReadOnly("/api/v1/demo/rawSearch/");
+		assertReadOnly("/api/v1/demo/search/nodes");
+		assertReadOnly("/api/v1/demo/rawSearch/nodes");
 		assertReadOnly("/api/v1/utilities/linkResolver");
 		assertReadOnly("/api/v1/utilities/validateMicroschema");
 		assertReadOnly("/api/v1/plugins/hello-world");
 		assertReadOnly("/api/v1/some-project/plugins/hello-world");
+	}
+
+	@Test
+	public void testBlacklist() {
+		assertBlackListed("/api/v1/search/sync");
+		assertBlackListed("/api/v1/search/clear");
+		assertBlackListed("/api/v1/search/status");
 	}
 
 	private void assertWhiteListed(String path) {
@@ -40,6 +51,10 @@ public class RequestDelegatorRegexTest {
 
 	private void assertReadOnly(String path) {
 		assertEquals("The path {" + path + "} is not read only.", true, DistributionUtils.isReadOnly(path));
+	}
+
+	private void assertBlackListed(String path) {
+		assertEquals("The path {" + path + "} is not blacklisted.", true, DistributionUtils.isBlackListed(path));
 	}
 
 }


### PR DESCRIPTION
## Abstract

Search endpoints should be treated read-only (and should therefore neither be forwarded to the master nor blocked due to topology change), but were not, because the patterns for checking were incorrect.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
