### PR TITLE
Add rsync to the server image

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.6.42]]
+== 1.6.42 (TBD)
+
+icon:check[] Docker: A `rsync` utility has been added to the Mesh server image, for data managenent in cluster environments.
+
 [[v1.6.41]]
 == 1.6.41 (26.01.2023)
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,8 @@
 FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.16.1_1
 
+# Install dependencies
+RUN apk update && apk add rsync
+
 ENV MESH_AUTH_KEYSTORE_PATH=/keystore/keystore.jks
 ENV MESH_GRAPH_BACKUP_DIRECTORY=/backups
 ENV MESH_GRAPH_DB_DIRECTORY=/graphdb

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,7 +25,7 @@ RUN adduser -D -u 1000 -G root -h /mesh mesh && \
     mkdir -p /mesh/elasticsearch/data && \
     chown 1000:0 /mesh -R && \
     chmod 770 /mesh -R && \
-    apk update && apk add rsync
+    apk update && apk add rsync && rm -rf /var/cache/apk/*
 ADD --chown=1000:0 ./live.sh /mesh/live.sh
 ADD --chown=1000:0 ./target/mesh-server*jar /mesh/mesh.jar
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,5 @@
 FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.16.1_1
 
-# Install dependencies
-RUN apk update && apk add rsync
-
 ENV MESH_AUTH_KEYSTORE_PATH=/keystore/keystore.jks
 ENV MESH_GRAPH_BACKUP_DIRECTORY=/backups
 ENV MESH_GRAPH_DB_DIRECTORY=/graphdb
@@ -27,7 +24,8 @@ RUN adduser -D -u 1000 -G root -h /mesh mesh && \
     mkdir /mesh/data && \
     mkdir -p /mesh/elasticsearch/data && \
     chown 1000:0 /mesh -R && \
-    chmod 770 /mesh -R
+    chmod 770 /mesh -R && \
+    apk update && apk add rsync
 ADD --chown=1000:0 ./live.sh /mesh/live.sh
 ADD --chown=1000:0 ./target/mesh-server*jar /mesh/mesh.jar
 


### PR DESCRIPTION
## Abstract

The rsync command is currently not available in the mesh container. For managing in openshift and backup purposes this is needed to reliably copy/backup the data from a container

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
