### PR TITLE
Make migration jobs more robust

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -25,6 +25,12 @@ be considered not live any more. This has been fixed now, during a restore, the 
 
 icon:check[] Monitoring: Failing calls to any `/health/...` endpoints will no longer log the whole stacktrace, since this does not contain useful information.
 
+icon:check[] Core: Migration jobs have been made more robust: Migration jobs will now be aborted, in cases were the storage is no longer ready to be written to
+(e.g. write quorum is not reached, or the storage is read-only due to insufficient disk space available). A periodic check (interval can be configured via setting `migrationTriggerInterval`)
+will continue processing of aborted jobs.
+
+icon:check[] Clustering: when running in CUD coordination mode, the requests to trigger job migration were not delegated to the current master. This has been fixed now.
+
 [[v1.8.20]]
 == 1.8.20 (22.03.2023)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
@@ -24,6 +24,7 @@ public abstract class MeshOptions implements Option {
 	public static final String DEFAULT_DIRECTORY_NAME = "graphdb";
 	public static final int DEFAULT_MAX_DEPTH = 10;
 	public static final int DEFAULT_PLUGIN_TIMEOUT = 120;
+	public static final long DEFAULT_MIGRATION_TRIGGER_INTERVAL = 60_000;
 
 	public static final String MESH_DEFAULT_LANG_ENV = "MESH_DEFAULT_LANG";
 	public static final String MESH_LANGUAGES_FILE_PATH_ENV = "MESH_LANGUAGES_FILE_PATH";
@@ -39,7 +40,9 @@ public abstract class MeshOptions implements Option {
 	public static final String MESH_INITIAL_ADMIN_PASSWORD_ENV = "MESH_INITIAL_ADMIN_PASSWORD";
 	public static final String MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET_ENV = "MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET";
 	public static final String MESH_MAX_PURGE_BATCH_SIZE = "MESH_MAX_PURGE_BATCH_SIZE";
-	private static final String MESH_MAX_MIGRATION_BATCH_SIZE = "MESH_MAX_MIGRATION_BATCH_SIZE";
+	public static final String MESH_MAX_MIGRATION_BATCH_SIZE = "MESH_MAX_MIGRATION_BATCH_SIZE";
+	public static final String MESH_MIGRATION_TRIGGER_INTERVAL = "MESH_MIGRATION_TRIGGER_INTERVAL";
+
 
 	// TODO remove this setting. There should not be a default max depth. This is no longer needed once we remove the expand all parameter
 	private int defaultMaxDepth = DEFAULT_MAX_DEPTH;
@@ -142,6 +145,11 @@ public abstract class MeshOptions implements Option {
 	@JsonPropertyDescription("The maximum amount of entities to be migrated in a single transaction. This setting affects schema, microschema and branch migrations")
 	@EnvironmentVariable(name = MESH_MAX_MIGRATION_BATCH_SIZE, description = "Override the maximum migration batch size")
 	private int migrationMaxBatchSize = 50;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Interval in ms for the automatic migration job trigger. Setting this to a non-positive value will disable automatic job triggering. Default: " + DEFAULT_MIGRATION_TRIGGER_INTERVAL + " ms.")
+	@EnvironmentVariable(name = MESH_MIGRATION_TRIGGER_INTERVAL, description = "Override the migration trigger interval")
+	private long migrationTriggerInterval = DEFAULT_MIGRATION_TRIGGER_INTERVAL;
 
 	@JsonProperty(required = true)
 	@JsonPropertyDescription("GraphQL options.")
@@ -518,6 +526,20 @@ public abstract class MeshOptions implements Option {
 	@Setter
 	public void setMigrationMaxBatchSize(int migrationMaxBatchSize) {
 		this.migrationMaxBatchSize = migrationMaxBatchSize;
+	}
+
+	/**
+	 * Get the automatic job migration trigger interval in ms.
+	 * @return interval in ms
+	 */
+	public long getMigrationTriggerInterval() {
+		return migrationTriggerInterval;
+	}
+
+	@Setter
+	public MeshOptions setMigrationTriggerInterval(long migrationTriggerInterval) {
+		this.migrationTriggerInterval = migrationTriggerInterval;
+		return this;
 	}
 
 	/**

--- a/mdm/api/src/main/java/com/gentics/mesh/core/jobs/JobProcessor.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/jobs/JobProcessor.java
@@ -12,4 +12,10 @@ public interface JobProcessor {
 	 * @return completable
 	 */
 	Completable process();
+
+	/**
+	 * Check whether jobs are currently being processed
+	 * @return true when jobs are processed, false if not
+	 */
+	boolean isProcessing();
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/migration/MigrationAbortedException.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/migration/MigrationAbortedException.java
@@ -1,0 +1,19 @@
+package com.gentics.mesh.core.migration;
+
+/**
+ * Exception that is thrown when a migration has been aborted
+ */
+public class MigrationAbortedException extends Exception {
+	/**
+	 * Serial Version UUID
+	 */
+	private static final long serialVersionUID = 2877461998431596437L;
+
+	/**
+	 * Create instance
+	 * @param reason reason for the abort
+	 */
+	public MigrationAbortedException(String reason) {
+		super(String.format("The migration job has been aborted. Reason: %s", reason));
+	}
+}

--- a/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
@@ -16,6 +16,7 @@ import com.gentics.mesh.core.db.CommonTx;
 import com.gentics.mesh.core.db.Database;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.endpoint.migration.MigrationStatusHandler;
+import com.gentics.mesh.core.migration.MigrationAbortedException;
 import com.gentics.mesh.core.rest.job.JobStatus;
 
 import com.gentics.mesh.core.rest.job.JobWarningList;
@@ -118,13 +119,17 @@ public class MigrationStatusHandlerImpl implements MigrationStatusHandler {
 	 * @param failureMessage
 	 */
 	public MigrationStatusHandler error(Throwable error, String failureMessage) {
-		HibJob job = getJob();
-		setStatus(FAILED);
-		log.error("Error handling migration", error);
+		if (error instanceof MigrationAbortedException) {
+			log.error("Migration has been aborted", error);
+		} else {
+			HibJob job = getJob();
+			setStatus(FAILED);
+			log.error("Error handling migration", error);
 
-		job.setStopTimestamp();
-		job.setError(error);
-		commit(job);
+			job.setStopTimestamp();
+			job.setError(error);
+			commit(job);
+		}
 		return this;
 	}
 


### PR DESCRIPTION
## Abstract

Execution of migration jobs has been made more robust: In cases, were the migration job is stopped unexpectedly (e.g. because the instance executing it was stopped, or is no longer the master in a cluster or the database turned read-only or write quorum is not reached), the execution will now automatically be triggered as soon as possible.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs
