### PR TITLE
Update OrientDB to 3.2.18.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,13 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.10.6]]
+== 1.10.6 (TBD)
+
+icon:check[] OrientDB: The included OrientDB version has been updated to version `3.2.18`.
+
+icon:check[] OrientDB: The included OrientDB Studio has been updated to version `3.2.18`.
+
 [[v1.10.5]]
 == 1.10.5 (19.04.2023)
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 		<spring.security.version>5.5.7</spring.security.version>
 		<ferma.version>${project.version}</ferma.version>
 		<elasticsearch.client.version>1.1.1</elasticsearch.client.version>
-		<orientdb.version>3.2.10</orientdb.version>
+		<orientdb.version>3.2.18</orientdb.version>
 		<hazelcast.version>3.12.8</hazelcast.version>
 		<jackson.version>2.13.2</jackson.version>
 		<jackson-databind.version>2.13.2</jackson-databind.version>
@@ -501,6 +501,12 @@
 				<groupId>com.gentics.mesh</groupId>
 				<artifactId>mesh-orientdb</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.orientechnologies</groupId>
+				<artifactId>orientdb-studio</artifactId>
+				<version>${orientdb.version}</version>
+				<type>zip</type>
 			</dependency>
 			<dependency>
 				<groupId>com.tinkerpop.gremlin</groupId>

--- a/databases/orientdb/pom.xml
+++ b/databases/orientdb/pom.xml
@@ -114,6 +114,32 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<?m2e execute onConfiguration?>
+						<id>copy-plugin-dependencies</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>com.orientechnologies</groupId>
+									<artifactId>orientdb-studio</artifactId>
+									<type>zip</type>
+									<overWrite>true</overWrite>
+									<outputDirectory>${project.build.directory}/classes/plugins</outputDirectory>
+									<destFileName>orientdb-studio.zip</destFileName>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 
 	</build>

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/OrientDBDatabase.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/OrientDBDatabase.java
@@ -649,7 +649,7 @@ public class OrientDBDatabase extends AbstractDatabase {
 			ROLES newORole = isSelf ? ROLES.MASTER : ROLES.REPLICA;
 			newCfg.setServerRole(server, newORole);
 		}
-		plugin.updateCachedDatabaseConfiguration(GraphStorage.DB_NAME, newCfg, true);
+		plugin.updateCachedDatabaseConfiguration(GraphStorage.DB_NAME, newCfg);
 	}
 
 	@Override
@@ -693,7 +693,7 @@ public class OrientDBDatabase extends AbstractDatabase {
 			// the plugin won't detect them
 			// see https://github.com/orientechnologies/orientdb/blob/3.1.x/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java#L441
 			newCfg.override(newCfg.getDocument());
-			plugin.updateCachedDatabaseConfiguration(GraphStorage.DB_NAME, newCfg, true);
+			plugin.updateCachedDatabaseConfiguration(GraphStorage.DB_NAME, newCfg);
 		} else {
 			throw error(BAD_REQUEST, "error_cluster_status_only_available_in_cluster_mode");
 		}

--- a/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManagerImpl.java
+++ b/databases/orientdb/src/main/java/com/gentics/mesh/graphdb/cluster/OrientDBClusterManagerImpl.java
@@ -73,7 +73,7 @@ public class OrientDBClusterManagerImpl implements OrientDBClusterManager {
 
 	private static final String ORIENTDB_PLUGIN_FOLDERNAME = "orientdb-plugins";
 
-	private static final String ORIENTDB_STUDIO_ZIP = "orientdb-studio-3.1.6.zip";
+	private static final String ORIENTDB_STUDIO_ZIP = "orientdb-studio.zip";
 
 	private static final String ORIENTDB_DISTRIBUTED_CONFIG = "default-distributed-db-config.json";
 
@@ -347,7 +347,7 @@ public class OrientDBClusterManagerImpl implements OrientDBClusterManager {
 		ClusterStatusResponse response = new ClusterStatusResponse();
 		if (hazelcastPlugin != null) {
 			ODocument distribCfg = hazelcastPlugin.getClusterConfiguration();
-			ODocument dbConfig = (ODocument) hazelcastPlugin.getConfigurationMap().get("database.storage");
+			ODocument dbConfig = (ODocument) hazelcastPlugin.getOnlineDatabaseConfiguration("storage");
 			ODocument serverConfig = dbConfig.field("servers");
 
 			Collection<ODocument> members = distribCfg.field("members");


### PR DESCRIPTION
## Abstract

Embedded OrientDB and OrientDB Studio have been updated to 3.2.18.
OrientDB Studio is now a dependency, which will always match the current OrientDB version.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
