### PR TITLE
Extend test framework with custom options changer support

### DIFF
--- a/tests/context-api/src/main/java/com/gentics/mesh/test/MeshCoreOptionChanger.java
+++ b/tests/context-api/src/main/java/com/gentics/mesh/test/MeshCoreOptionChanger.java
@@ -1,0 +1,47 @@
+package com.gentics.mesh.test;
+
+import java.net.ServerSocket;
+import java.util.function.Consumer;
+
+import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.etc.config.search.MappingMode;
+
+public enum MeshCoreOptionChanger implements MeshOptionChanger {
+
+	NO_CHANGE(ignore -> {
+	}), SMALL_EVENT_BUFFER(options -> {
+		options.getSearchOptions().setEventBufferSize(100);
+	}), NO_PATH_CACHE(options -> {
+		options.getCacheConfig().setPathCacheSize(0);
+	}), NO_UPLOAD_PARSER(options -> {
+		options.getUploadOptions().setParser(false);
+	}), EXCLUDE_BINARY_SEARCH(options -> {
+		options.getSearchOptions().setIncludeBinaryFields(false);
+	}), INITIAL_ADMIN_PASSWORD(options -> {
+		options.setInitialAdminPassword("debug99");
+	}), ES_STRICT_MODE(options -> {
+		options.getSearchOptions().setMappingMode(MappingMode.STRICT);
+	}), RANDOM_ES_PORT(options -> {
+		try {
+			try (ServerSocket s = new ServerSocket(0)) {
+				options.getSearchOptions().setTimeout(500L);
+				options.getSearchOptions().setUrl("http://localhost:" + s.getLocalPort());
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Could not find free port", e);
+		}
+	}), BATCH_MIGRATION(options -> {
+		options.getContentOptions().setBatchSize(2);
+	});
+
+	private final Consumer<MeshOptions> changer;
+
+	MeshCoreOptionChanger(Consumer<MeshOptions> changer) {
+		this.changer = changer;
+	}
+
+	@Override
+	public void change(MeshOptions options) {
+		changer.accept(options);
+	}
+}

--- a/tests/context-api/src/main/java/com/gentics/mesh/test/MeshOptionChanger.java
+++ b/tests/context-api/src/main/java/com/gentics/mesh/test/MeshOptionChanger.java
@@ -1,42 +1,22 @@
 package com.gentics.mesh.test;
 
-import java.net.ServerSocket;
-import java.util.function.Consumer;
-
 import com.gentics.mesh.etc.config.MeshOptions;
-import com.gentics.mesh.etc.config.search.MappingMode;
 
-public enum MeshOptionChanger {
+/**
+ * Change Mesh options before starting the test class.
+ * 
+ * @author plyhun
+ *
+ */
+public interface MeshOptionChanger {
 
-	NO_CHANGE(ignore -> {
-	}), SMALL_EVENT_BUFFER(options -> {
-		options.getSearchOptions().setEventBufferSize(100);
-	}), NO_PATH_CACHE(options -> {
-		options.getCacheConfig().setPathCacheSize(0);
-	}), NO_UPLOAD_PARSER(options -> {
-		options.getUploadOptions().setParser(false);
-	}), EXCLUDE_BINARY_SEARCH(options -> {
-		options.getSearchOptions().setIncludeBinaryFields(false);
-	}), INITIAL_ADMIN_PASSWORD(options -> {
-		options.setInitialAdminPassword("debug99");
-	}), ES_STRICT_MODE(options -> {
-		options.getSearchOptions().setMappingMode(MappingMode.STRICT);
-	}), RANDOM_ES_PORT(options -> {
-		try {
-			try (ServerSocket s = new ServerSocket(0)) {
-				options.getSearchOptions().setTimeout(500L);
-				options.getSearchOptions().setUrl("http://localhost:" + s.getLocalPort());
-			}
-		} catch (Exception e) {
-			throw new RuntimeException("Could not find free port", e);
-		}
-	}), BATCH_MIGRATION(options -> {
-		options.getContentOptions().setBatchSize(2);
-	});
+	void change(MeshOptions options);
 
-	public final Consumer<MeshOptions> changer;
+	static final class NoOptionChanger implements MeshOptionChanger {
 
-	MeshOptionChanger(Consumer<MeshOptions> changer) {
-		this.changer = changer;
+		@Override
+		public void change(MeshOptions options) {
+			MeshCoreOptionChanger.NO_CHANGE.change(options);
+		}		
 	}
 }

--- a/tests/context-api/src/main/java/com/gentics/mesh/test/MeshTestSetting.java
+++ b/tests/context-api/src/main/java/com/gentics/mesh/test/MeshTestSetting.java
@@ -3,6 +3,8 @@ package com.gentics.mesh.test;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import com.gentics.mesh.test.MeshOptionChanger.NoOptionChanger;
+
 /**
  * 
  */
@@ -84,5 +86,7 @@ public @interface MeshTestSetting {
 	 * 
 	 * @return
 	 */
-	MeshOptionChanger optionChanger() default MeshOptionChanger.NO_CHANGE;
+	MeshCoreOptionChanger optionChanger() default MeshCoreOptionChanger.NO_CHANGE;
+
+	Class<? extends MeshOptionChanger> customOptionChanger() default NoOptionChanger.class;
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/UploadNoParserTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/UploadNoParserTest.java
@@ -1,7 +1,7 @@
 package com.gentics.mesh.core.field.binary;
 
 import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.MeshOptionChanger.NO_UPLOAD_PARSER;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.NO_UPLOAD_PARSER;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
 import static org.junit.Assert.assertNull;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/user/InitialAdminPasswordTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/user/InitialAdminPasswordTest.java
@@ -3,7 +3,7 @@ package com.gentics.mesh.core.user;
 import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
 import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.ElasticsearchTestMode.TRACKING;
-import static com.gentics.mesh.test.MeshOptionChanger.INITIAL_ADMIN_PASSWORD;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.INITIAL_ADMIN_PASSWORD;
 import static com.gentics.mesh.test.TestSize.PROJECT_AND_NODE;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootEndpointNoCacheTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webroot/WebRootEndpointNoCacheTest.java
@@ -2,7 +2,7 @@ package com.gentics.mesh.core.webroot;
 
 import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
 import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.MeshOptionChanger.NO_PATH_CACHE;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.NO_PATH_CACHE;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/webrootfield/WebRootFieldEndpointNoCacheTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/webrootfield/WebRootFieldEndpointNoCacheTest.java
@@ -1,7 +1,7 @@
 package com.gentics.mesh.core.webrootfield;
 
 import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.MeshOptionChanger.NO_PATH_CACHE;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.NO_PATH_CACHE;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/AbstractMultiESTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/AbstractMultiESTest.java
@@ -12,6 +12,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.gentics.mesh.test.AWSTestMode;
 import com.gentics.mesh.test.ElasticsearchTestMode;
+import com.gentics.mesh.test.MeshCoreOptionChanger;
 import com.gentics.mesh.test.MeshOptionChanger;
 import com.gentics.mesh.test.MeshTestSetting;
 import com.gentics.mesh.test.SSLTestMode;
@@ -164,8 +165,13 @@ public abstract class AbstractMultiESTest implements TestHttpMethods, TestGraphH
 		}
 
 		@Override
-		public MeshOptionChanger optionChanger() {
+		public MeshCoreOptionChanger optionChanger() {
 			return delegate.optionChanger();
+		}
+
+		@Override
+		public Class<? extends MeshOptionChanger> customOptionChanger() {
+			return delegate.customOptionChanger();
 		}
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
@@ -2,7 +2,7 @@ package com.gentics.mesh.search;
 
 import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.ElasticsearchTestMode.CONTAINER_ES6;
-import static com.gentics.mesh.test.MeshOptionChanger.RANDOM_ES_PORT;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.RANDOM_ES_PORT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 
 import java.io.IOException;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/NodeBinaryDisabledSearchTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/NodeBinaryDisabledSearchTest.java
@@ -1,7 +1,7 @@
 package com.gentics.mesh.search;
 
 import static com.gentics.mesh.test.ClientHelper.call;
-import static com.gentics.mesh.test.MeshOptionChanger.EXCLUDE_BINARY_SEARCH;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.EXCLUDE_BINARY_SEARCH;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static com.gentics.mesh.test.TestSize.FULL;
 import static com.gentics.mesh.test.context.MeshTestHelper.getRangeQuery;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/NodeSearchEndpointStrictModeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/NodeSearchEndpointStrictModeTest.java
@@ -16,13 +16,13 @@ import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.parameter.impl.PagingParametersImpl;
 import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
 import com.gentics.mesh.test.ElasticsearchTestMode;
-import com.gentics.mesh.test.MeshOptionChanger;
+import com.gentics.mesh.test.MeshCoreOptionChanger;
 import com.gentics.mesh.test.MeshTestSetting;
 
 import io.vertx.core.json.JsonObject;
 
 @RunWith(Parameterized.class)
-@MeshTestSetting(testSize = FULL, startServer = true, optionChanger = MeshOptionChanger.ES_STRICT_MODE)
+@MeshTestSetting(testSize = FULL, startServer = true, optionChanger = MeshCoreOptionChanger.ES_STRICT_MODE)
 public class NodeSearchEndpointStrictModeTest extends AbstractNodeSearchEndpointTest {
 
 	public NodeSearchEndpointStrictModeTest(ElasticsearchTestMode elasticsearch) throws Exception {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/migration/BatchedNodeMigrationSearchTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/migration/BatchedNodeMigrationSearchTest.java
@@ -19,12 +19,12 @@ import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
 import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
 import com.gentics.mesh.core.rest.schema.impl.SchemaUpdateRequest;
 import com.gentics.mesh.test.ElasticsearchTestMode;
-import com.gentics.mesh.test.MeshOptionChanger;
+import com.gentics.mesh.test.MeshCoreOptionChanger;
 import com.gentics.mesh.test.MeshTestSetting;
 import com.gentics.mesh.util.IndexOptionHelper;
 
 @RunWith(Parameterized.class)
-@MeshTestSetting(testSize = FULL, startServer = true, optionChanger = MeshOptionChanger.BATCH_MIGRATION)
+@MeshTestSetting(testSize = FULL, startServer = true, optionChanger = MeshCoreOptionChanger.BATCH_MIGRATION)
 public class BatchedNodeMigrationSearchTest extends NodeMigrationSearchTest {
 
 	public BatchedNodeMigrationSearchTest(ElasticsearchTestMode elasticsearch) throws Exception {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/resilience/ElasticsearchEventBufferTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/resilience/ElasticsearchEventBufferTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 import static com.gentics.mesh.core.rest.MeshEvent.INDEX_SYNC_REQUEST;
 import static com.gentics.mesh.test.ElasticsearchTestMode.CONTAINER_ES6_TOXIC;
-import static com.gentics.mesh.test.MeshOptionChanger.SMALL_EVENT_BUFFER;
+import static com.gentics.mesh.test.MeshCoreOptionChanger.SMALL_EVENT_BUFFER;
 import static com.gentics.mesh.test.TestSize.FULL;
 import static org.junit.Assert.assertEquals;
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -3,7 +3,6 @@ package com.gentics.mesh.test.context;
 import static com.gentics.mesh.MeshVersion.CURRENT_API_BASE_PATH;
 import static com.gentics.mesh.MeshVersion.CURRENT_API_VERSION;
 import static com.gentics.mesh.test.ElasticsearchTestMode.UNREACHABLE;
-import static com.gentics.mesh.test.context.MeshTestHelper.noopConsumer;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -19,7 +18,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import javax.net.ssl.SSLContext;
@@ -62,8 +60,8 @@ import com.gentics.mesh.rest.monitoring.MonitoringRestClient;
 import com.gentics.mesh.search.TrackingSearchProvider;
 import com.gentics.mesh.search.TrackingSearchProviderImpl;
 import com.gentics.mesh.search.verticle.ElasticsearchProcessVerticle;
+import com.gentics.mesh.test.MeshCoreOptionChanger;
 import com.gentics.mesh.test.MeshInstanceProvider;
-import com.gentics.mesh.test.MeshOptionChanger;
 import com.gentics.mesh.test.MeshTestActions;
 import com.gentics.mesh.test.MeshTestContextProvider;
 import com.gentics.mesh.test.MeshTestSetting;
@@ -127,8 +125,6 @@ public class MeshTestContext implements TestRule {
 	private CountDownLatch idleLatch;
 	private MessageConsumer<Object> idleConsumer;
 
-	private Consumer<MeshOptions> optionChanger = noopConsumer();
-
 	private Mesh mesh;
 
 	private MeshTestContextProvider meshTestContextProvider;
@@ -164,7 +160,7 @@ public class MeshTestContext implements TestRule {
 	public void setup(MeshTestSetting settings) throws Exception {
 		meshTestContextProvider.getInstanceProvider().initMeshData(settings, meshDagger);
 		initFolders(mesh.getOptions());
-		boolean setAdminPassword = settings.optionChanger() != MeshOptionChanger.INITIAL_ADMIN_PASSWORD;
+		boolean setAdminPassword = settings.optionChanger() != MeshCoreOptionChanger.INITIAL_ADMIN_PASSWORD;
 		setupData(mesh.getOptions(), setAdminPassword);
 		listenToSearchIdleEvent();
 		switch (settings.elasticsearch()) {
@@ -290,7 +286,6 @@ public class MeshTestContext implements TestRule {
 			toxiproxy.stop();
 			network.close();
 		}
-		optionChanger = noopConsumer();
 		meshTestContextProvider.getInstanceProvider().teardownStorage();
 	}
 
@@ -664,8 +659,8 @@ public class MeshTestContext implements TestRule {
 			Set<JsonObject> jwks = KeycloakUtils.loadJWKs("http", keycloak.getHost(), keycloak.getMappedPort(8080), realmName);
 			meshOptions.getAuthenticationOptions().setPublicKeys(jwks);
 		}
-		settings.optionChanger().changer.accept(meshOptions);
-		optionChanger.accept(meshOptions);
+		settings.optionChanger().change(meshOptions);
+		settings.customOptionChanger().getConstructor().newInstance().change(meshOptions);
 		return meshOptions;
 	}
 
@@ -808,11 +803,6 @@ public class MeshTestContext implements TestRule {
 
 	public static ElasticsearchContainer elasticsearchContainer() {
 		return elasticsearch;
-	}
-
-	public MeshTestContext setOptionChanger(Consumer<MeshOptions> optionChanger) {
-		this.optionChanger = optionChanger;
-		return this;
 	}
 
 	public MeshComponent getMeshComponent() {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestHelper.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestHelper.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CyclicBarrier;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.commons.io.IOUtils;
@@ -97,11 +96,6 @@ public final class MeshTestHelper {
 		json.put("query", new JsonObject().put("range", new JsonObject().put(fieldName,
 			new JsonObject().put("from", from).put("to", to).put("include_lower", true).put("include_upper", true).put("boost", 1))));
 		return json.encodePrettily();
-	}
-
-	public static <T> Consumer<T> noopConsumer() {
-		return t -> {
-		};
 	}
 	
 	public static File extractResource(String path) throws IOException {


### PR DESCRIPTION
## Abstract

Add an API for custom extension of Mesh Options for a particular test.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
