### PR TITLE
Enhance REST endpoints to create/modify nodes to optionally publish the node and set permissions to roles

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,13 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.10.8]]
+== 1.10.8 (TBD)
+
+icon:check[] Core: The requests to create, update or upsert a node have been extended to allow immediate publishing of the modified/created node and to set role permissions on the node.
+
+icon:check[] Core: The request to upload binary data into a binary field has been extended to allow immediate publishing of the modified/created node.
+
 [[v1.10.7]]
 == 1.10.7 (22.05.2023)
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/node/NodeEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/node/NodeEndpoint.java
@@ -183,6 +183,7 @@ public class NodeEndpoint extends RolePermissionHandlingProjectEndpoint {
 		fieldUpdate.path("/:nodeUuid/binary/:fieldName");
 		fieldUpdate.addUriParameter("nodeUuid", "Uuid of the node.", NODE_DELOREAN_UUID);
 		fieldUpdate.addUriParameter("fieldName", "Name of the field which should be created.", "stringField");
+		fieldUpdate.addUriParameter("publish", "Whether the node shall be published after updating the binary field", "true");
 		fieldUpdate.method(POST);
 		fieldUpdate.produces(APPLICATION_JSON);
 		fieldUpdate.exampleRequest(nodeExamples.getExampleBinaryUploadFormParameters());

--- a/core/src/main/java/com/gentics/mesh/rest/MeshLocalClientImpl.java
+++ b/core/src/main/java/com/gentics/mesh/rest/MeshLocalClientImpl.java
@@ -1234,7 +1234,7 @@ public class MeshLocalClientImpl implements MeshLocalClient {
 
 	@Override
 	public MeshRequest<NodeResponse> updateNodeBinaryField(String projectName, String nodeUuid, String languageTag, String nodeVersion,
-		String fieldKey, InputStream fileData, long fileSize, String fileName, String contentType, ParameterProvider... parameters) {
+		String fieldKey, InputStream fileData, long fileSize, String fileName, String contentType, boolean publish, ParameterProvider... parameters) {
 		try {
 			return updateNodeBinaryField(projectName, nodeUuid, languageTag, nodeVersion, fieldKey, IOUtils.toByteArray(fileData), fileName,
 				contentType, parameters);

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
@@ -3,6 +3,7 @@ package com.gentics.mesh.core.data.dao;
 import static com.gentics.mesh.core.data.perm.InternalPermission.CREATE_PERM;
 import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PERM;
 import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PUBLISHED_PERM;
+import static com.gentics.mesh.core.data.perm.InternalPermission.UPDATE_PERM;
 import static com.gentics.mesh.core.rest.MeshEvent.NODE_MOVED;
 import static com.gentics.mesh.core.rest.MeshEvent.NODE_REFERENCE_UPDATED;
 import static com.gentics.mesh.core.rest.MeshEvent.NODE_TAGGED;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -55,6 +57,7 @@ import com.gentics.mesh.core.data.node.field.nesting.HibNodeField;
 import com.gentics.mesh.core.data.page.Page;
 import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.data.project.HibProject;
+import com.gentics.mesh.core.data.role.HibRole;
 import com.gentics.mesh.core.data.schema.HibSchema;
 import com.gentics.mesh.core.data.schema.HibSchemaVersion;
 import com.gentics.mesh.core.data.tag.HibTag;
@@ -63,6 +66,7 @@ import com.gentics.mesh.core.db.CommonTx;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.link.WebRootLinkReplacer;
 import com.gentics.mesh.core.rest.common.ContainerType;
+import com.gentics.mesh.core.rest.common.ObjectPermissionGrantRequest;
 import com.gentics.mesh.core.rest.error.NodeVersionConflictException;
 import com.gentics.mesh.core.rest.error.NotModifiedException;
 import com.gentics.mesh.core.rest.event.node.NodeMeshEventModel;
@@ -80,6 +84,7 @@ import com.gentics.mesh.core.rest.node.PublishStatusResponse;
 import com.gentics.mesh.core.rest.node.field.Field;
 import com.gentics.mesh.core.rest.node.version.NodeVersionsResponse;
 import com.gentics.mesh.core.rest.node.version.VersionInfo;
+import com.gentics.mesh.core.rest.role.RoleReference;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
 import com.gentics.mesh.core.rest.schema.SchemaModel;
 import com.gentics.mesh.core.rest.schema.SchemaReferenceInfo;
@@ -101,6 +106,7 @@ import com.gentics.mesh.parameter.NodeParameters;
 import com.gentics.mesh.parameter.PublishParameters;
 import com.gentics.mesh.parameter.VersioningParameters;
 import com.gentics.mesh.parameter.impl.NavigationParametersImpl;
+import com.gentics.mesh.parameter.impl.PagingParametersImpl;
 import com.gentics.mesh.parameter.value.FieldsSet;
 import com.gentics.mesh.path.Path;
 import com.gentics.mesh.path.PathSegment;
@@ -1003,6 +1009,16 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			updateTags(node, ac, batch, requestModel.getTags());
 		}
 
+		if (requestModel.getGrant() != null) {
+			grantRolePermissions(node, ac, requestModel.getGrant());
+		}
+
+		if (requestModel.isPublish()) {
+			HibNodeFieldContainer publishedContainer = contentDao.publish(node, ac, language.getLanguageTag(), branch, ac.getUser());
+			// Invoke a store of the document since it must now also be added to the published index
+			batch.add(contentDao.onPublish(publishedContainer, branch.getUuid()));
+		}
+
 		return node;
 	}
 
@@ -1414,6 +1430,17 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 			latestDraftVersion = contentDao.createFieldContainer(node, languageTag, branch, ac.getUser());
 			latestDraftVersion.updateFieldsFromRest(ac, requestModel.getFields());
 			batch.add(contentDao.onCreated(latestDraftVersion, branch.getUuid(), DRAFT));
+
+			if (requestModel.getGrant() != null) {
+				grantRolePermissions(node, ac, requestModel.getGrant());
+			}
+
+			if (requestModel.isPublish()) {
+				HibNodeFieldContainer publishedContainer = contentDao.publish(node, ac, language.getLanguageTag(), branch, ac.getUser());
+				// Invoke a store of the document since it must now also be added to the published index
+				batch.add(contentDao.onPublish(publishedContainer, branch.getUuid()));
+			}
+
 			return true;
 		} else {
 			String version = requestModel.getVersion();
@@ -1490,6 +1517,17 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 
 				latestDraftVersion = newDraftVersion;
 				batch.add(contentDao.onUpdated(newDraftVersion, branch.getUuid(), DRAFT));
+
+				if (requestModel.getGrant() != null) {
+					grantRolePermissions(node, ac, requestModel.getGrant());
+				}
+
+				if (requestModel.isPublish()) {
+					HibNodeFieldContainer publishedContainer = contentDao.publish(node, ac, language.getLanguageTag(), branch, ac.getUser());
+					// Invoke a store of the document since it must now also be added to the published index
+					batch.add(contentDao.onPublish(publishedContainer, branch.getUuid()));
+				}
+
 				return true;
 			}
 		}
@@ -1664,6 +1702,86 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 	default String getParentNodeUuid(HibNode node, String branchUuid) {
 		HibNode parentNode = getParentNode(node, branchUuid);
 		return parentNode != null ? parentNode.getUuid() : null;
+	}
+
+	/**
+	 * Grant role permissions on the give node according to the grant request
+	 * @param node node to grant permissions on
+	 * @param ac action context
+	 * @param grant request
+	 */
+	default void grantRolePermissions(HibNode node, InternalActionContext ac, ObjectPermissionGrantRequest grant) {
+		HibUser requestUser = ac.getUser();
+		Tx tx = Tx.get();
+		RoleDao roleDao = tx.roleDao();
+		UserDao userDao = tx.userDao();
+
+		Set<HibRole> allRoles = roleDao.findAll(ac, new PagingParametersImpl().setPerPage(Long.MAX_VALUE)).stream().collect(Collectors.toSet());
+		Map<String, HibRole> allRolesByUuid = allRoles.stream().collect(Collectors.toMap(HibRole::getUuid, Function.identity()));
+		Map<String, HibRole> allRolesByName = allRoles.stream().collect(Collectors.toMap(HibRole::getName, Function.identity()));
+
+		InternalPermission[] possiblePermissions = node.hasPublishPermissions()
+				? InternalPermission.values()
+				: InternalPermission.basicPermissions();
+
+		for (InternalPermission perm : possiblePermissions) {
+			List<RoleReference> roleRefsToSet = grant.get(perm.getRestPerm());
+			if (roleRefsToSet != null) {
+				Set<HibRole> rolesToSet = new HashSet<>();
+				for (RoleReference roleRef : roleRefsToSet) {
+					// find the role for the role reference
+					HibRole role = null;
+					if (!StringUtils.isEmpty(roleRef.getUuid())) {
+						role = allRolesByUuid.get(roleRef.getUuid());
+
+						if (role == null) {
+							throw error(NOT_FOUND, "object_not_found_for_uuid", roleRef.getUuid());
+						}
+					} else if (!StringUtils.isEmpty(roleRef.getName())) {
+						role = allRolesByName.get(roleRef.getName());
+
+						if (role == null) {
+							throw error(NOT_FOUND, "object_not_found_for_name", roleRef.getName());
+						}
+					} else {
+						throw error(BAD_REQUEST, "role_reference_uuid_or_name_missing");
+					}
+
+					// check update permission
+					if (!userDao.hasPermission(requestUser, role, UPDATE_PERM)) {
+						throw error(FORBIDDEN, "error_missing_perm", role.getUuid(), UPDATE_PERM.getRestPerm().getName());
+					}
+
+					rolesToSet.add(role);
+				}
+
+				roleDao.grantPermissions(rolesToSet, node, false, perm);
+
+				// handle "exclusive" flag by revoking perm from all "other" roles
+				if (grant.isExclusive()) {
+					// start with all roles, the user can see
+					Set<HibRole> rolesToRevoke = new HashSet<>(allRoles);
+					// remove all roles, which get the permission granted
+					rolesToRevoke.removeAll(rolesToSet);
+
+					// remove all roles, which should be ignored
+					if (grant.getIgnore() != null) {
+						rolesToRevoke.removeIf(role -> {
+							return grant.getIgnore().stream().filter(ign -> {
+								return StringUtils.equals(ign.getUuid(), role.getUuid()) || StringUtils.equals(ign.getName(), role.getName());
+							}).findAny().isPresent();
+						});
+					}
+
+					// remove all roles without UPDATE_PERM
+					rolesToRevoke.removeIf(role -> !userDao.hasPermission(requestUser, role, UPDATE_PERM));
+
+					if (!rolesToRevoke.isEmpty()) {
+						roleDao.revokePermissions(rolesToRevoke, node, perm);
+					}
+				}
+			}
+		}
 	}
 
 	@Override

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestHttpClientImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestHttpClientImpl.java
@@ -1074,7 +1074,7 @@ public abstract class MeshRestHttpClientImpl extends AbstractMeshRestHttpClient 
 
 	@Override
 	public MeshRequest<NodeResponse> updateNodeBinaryField(String projectName, String nodeUuid, String languageTag, String version, String fieldKey,
-		InputStream fileData, long fileSize, String fileName, String contentType, ParameterProvider... parameters) {
+		InputStream fileData, long fileSize, String fileName, String contentType, boolean publish, ParameterProvider... parameters) {
 		Objects.requireNonNull(projectName, "projectName must not be null");
 		Objects.requireNonNull(nodeUuid, "nodeUuid must not be null");
 		Objects.requireNonNull(fileData, "fileData must not be null");
@@ -1098,6 +1098,13 @@ public abstract class MeshRestHttpClientImpl extends AbstractMeshRestHttpClient 
 		multiPartFormData.append("Content-Disposition: form-data; name=\"language\"\r\n");
 		multiPartFormData.append("\r\n");
 		multiPartFormData.append(languageTag).append("\r\n");
+
+		if (publish) {
+			multiPartFormData.append("--").append(boundary).append("\r\n");
+			multiPartFormData.append("Content-Disposition: form-data; name=\"publish\"\r\n");
+			multiPartFormData.append("\r\n");
+			multiPartFormData.append("true").append("\r\n");
+		}
 
 		multiPartFormData.append("--").append(boundary).append("\r\n");
 		multiPartFormData.append("Content-Disposition: form-data; name=\"" + "shohY6d" + "\"; filename=\"").append(fileName).append("\"\r\n");

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/method/NodeBinaryFieldClientMethods.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/method/NodeBinaryFieldClientMethods.java
@@ -34,8 +34,37 @@ public interface NodeBinaryFieldClientMethods {
 	 * @param contentType
 	 * @return
 	 */
+	default MeshRequest<NodeResponse> updateNodeBinaryField(String projectName, String nodeUuid, String languageTag, String nodeVersion,
+													String fieldKey, InputStream fileData, long fileSize, String fileName, String contentType, ParameterProvider... parameters) {
+		return updateNodeBinaryField(projectName, nodeUuid, languageTag, nodeVersion, fieldKey, fileData, fileSize, fileName, contentType, false, parameters);
+	}
+
+	/**
+	 * Update the binary field for the node with the given nodeUuid in the given project using the provided input stream.
+	 *
+	 * This reads the entire stream and closes it after the content has been read.
+	 *
+	 * @param projectName
+	 *            Name of the project which contains the node
+	 * @param nodeUuid
+	 *            Uuid of the node
+	 * @param languageTag
+	 *            Language tag of the node
+	 * @param nodeVersion
+	 *            Node version
+	 * @param fieldKey
+	 *            Key of the field which holds the binary data
+	 * @param fileData
+	 *            InputStream that serves the binary data
+	 * @param fileSize
+	 * @param fileName
+	 * @param contentType
+	 * @param publish true to also publish the node
+	 * @param parameters
+	 * @return
+	 */
 	MeshRequest<NodeResponse> updateNodeBinaryField(String projectName, String nodeUuid, String languageTag, String nodeVersion,
-													String fieldKey, InputStream fileData, long fileSize, String fileName, String contentType, ParameterProvider... parameters);
+			String fieldKey, InputStream fileData, long fileSize, String fileName, String contentType, boolean publish, ParameterProvider... parameters);
 
 	/**
 	 * Download the binary field of the given node in the given project.

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/NodeCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/NodeCreateRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.gentics.mesh.core.rest.common.FieldContainer;
+import com.gentics.mesh.core.rest.common.ObjectPermissionGrantRequest;
 import com.gentics.mesh.core.rest.schema.SchemaReference;
 import com.gentics.mesh.core.rest.schema.impl.SchemaReferenceImpl;
 import com.gentics.mesh.core.rest.tag.TagReference;
@@ -36,6 +37,14 @@ public class NodeCreateRequest implements FieldContainer {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("List of tags that should be used to tag the node.")
 	private List<TagReference> tags;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Whether the publish the node after creation.")
+	private boolean publish = false;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Permissions to be granted to roles on the created node.")
+	private ObjectPermissionGrantRequest grant;
 
 	public NodeCreateRequest() {
 	}
@@ -164,4 +173,39 @@ public class NodeCreateRequest implements FieldContainer {
 		return this;
 	}
 
+	/**
+	 * Whether the created node shall be published
+	 * @return true to publish
+	 */
+	public boolean isPublish() {
+		return publish;
+	}
+
+	/**
+	 * Set the publish flag
+	 * @param publish flag
+	 * @return Fluent API
+	 */
+	public NodeCreateRequest setPublish(boolean publish) {
+		this.publish = publish;
+		return this;
+	}
+
+	/**
+	 * Get the request to grant role permissions
+	 * @return optional request
+	 */
+	public ObjectPermissionGrantRequest getGrant() {
+		return grant;
+	}
+
+	/**
+	 * Set the request to grant role permissions
+	 * @param grant optional request
+	 * @return Fluent API
+	 */
+	public NodeCreateRequest setGrant(ObjectPermissionGrantRequest grant) {
+		this.grant = grant;
+		return this;
+	}
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/NodeUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/NodeUpdateRequest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.common.FieldContainer;
+import com.gentics.mesh.core.rest.common.ObjectPermissionGrantRequest;
 import com.gentics.mesh.core.rest.tag.TagReference;
 
 /**
@@ -27,6 +28,14 @@ public class NodeUpdateRequest implements FieldContainer {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("List of tags that should be used to tag the node.")
 	private List<TagReference> tags;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Whether the publish the node after updating.")
+	private boolean publish = false;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Permissions to be granted to roles on the updated node.")
+	private ObjectPermissionGrantRequest grant;
 
 	public NodeUpdateRequest() {
 	}
@@ -109,4 +118,39 @@ public class NodeUpdateRequest implements FieldContainer {
 		return this;
 	}
 
+	/**
+	 * Whether the created node shall be published
+	 * @return true to publish
+	 */
+	public boolean isPublish() {
+		return publish;
+	}
+
+	/**
+	 * Set the publish flag
+	 * @param publish flag
+	 * @return Fluent API
+	 */
+	public NodeUpdateRequest setPublish(boolean publish) {
+		this.publish = publish;
+		return this;
+	}
+
+	/**
+	 * Get the request to grant role permissions
+	 * @return optional request
+	 */
+	public ObjectPermissionGrantRequest getGrant() {
+		return grant;
+	}
+
+	/**
+	 * Set the request to grant role permissions
+	 * @param grant optional request
+	 * @return Fluent API
+	 */
+	public NodeUpdateRequest setGrant(ObjectPermissionGrantRequest grant) {
+		this.grant = grant;
+		return this;
+	}
 }

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/NodeUpsertRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/NodeUpsertRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.gentics.mesh.core.rest.common.FieldContainer;
+import com.gentics.mesh.core.rest.common.ObjectPermissionGrantRequest;
 import com.gentics.mesh.core.rest.schema.SchemaReference;
 import com.gentics.mesh.core.rest.schema.impl.SchemaReferenceImpl;
 import com.gentics.mesh.core.rest.tag.TagReference;
@@ -40,6 +41,14 @@ public class NodeUpsertRequest implements FieldContainer {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("List of tags that should be used to tag the node.")
 	private List<TagReference> tags;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Whether the publish the node after creation/updating.")
+	private boolean publish = false;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Permissions to be granted to roles on the node.")
+	private ObjectPermissionGrantRequest grant;
 
 	public NodeUpsertRequest() {
 	}
@@ -168,4 +177,39 @@ public class NodeUpsertRequest implements FieldContainer {
 		return this;
 	}
 
+	/**
+	 * Whether the created node shall be published
+	 * @return true to publish
+	 */
+	public boolean isPublish() {
+		return publish;
+	}
+
+	/**
+	 * Set the publish flag
+	 * @param publish flag
+	 * @return Fluent API
+	 */
+	public NodeUpsertRequest setPublish(boolean publish) {
+		this.publish = publish;
+		return this;
+	}
+
+	/**
+	 * Get the request to grant role permissions
+	 * @return optional request
+	 */
+	public ObjectPermissionGrantRequest getGrant() {
+		return grant;
+	}
+
+	/**
+	 * Set the request to grant role permissions
+	 * @param grant optional request
+	 * @return Fluent API
+	 */
+	public NodeUpsertRequest setGrant(ObjectPermissionGrantRequest grant) {
+		this.grant = grant;
+		return this;
+	}
 }

--- a/tests/common/src/main/java/com/gentics/mesh/assertj/impl/NodeResponseAssert.java
+++ b/tests/common/src/main/java/com/gentics/mesh/assertj/impl/NodeResponseAssert.java
@@ -149,4 +149,17 @@ public class NodeResponseAssert extends AbstractAssert<NodeResponseAssert, NodeR
 		assertEquals("The schema name did not match.", name, actual.getSchema().getName());
 		return this;
 	}
+
+	/**
+	 * Assert that the given node has the expected language variant
+	 * @param language expected language code
+	 * @param published expected published status
+	 * @return Fluent API
+	 */
+	public NodeResponseAssert hasLanguageVariant(String language, boolean published) {
+		assertThat(actual.getAvailableLanguages()).as(descriptionText() + " available languages").containsKey(language);
+		assertThat(actual.getAvailableLanguages().get(language)).as(descriptionText() + " variant " + language)
+				.hasFieldOrPropertyWithValue("published", published);
+		return this;
+	}
 }


### PR DESCRIPTION
## Abstract

Creating/updating a node, setting role permissions and publishing afterwards is a common use-case and it is more efficient to do this in a single request than doing it in three separate requests.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
