### PR TITLE
API for permission cache fine tuning

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,11 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.10.9]]
+== 1.10.9 (TBD)
+
+icon:check[] Core: An API for permission cache fine tuning (distinct items management) has been added.
+
 [[v1.10.8]]
 == 1.10.8 (30.05.2023)
 

--- a/core/src/main/java/com/gentics/mesh/cache/PermissionCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/PermissionCacheImpl.java
@@ -17,8 +17,8 @@ import com.gentics.mesh.cache.impl.EventAwareCacheFactory;
 import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.etc.config.MeshOptions;
-
 import com.gentics.mesh.event.EventBusStore;
+
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -73,8 +73,7 @@ public class PermissionCacheImpl extends AbstractMeshCache<String, EnumSet<Inter
 
 	@Override
 	public Boolean hasPermission(Object userId, InternalPermission permission, Object elementId) {
-		String key = createCacheKey(userId, elementId);
-		EnumSet<InternalPermission> cachedPermissions = cache.get(key);
+		EnumSet<InternalPermission> cachedPermissions = get(userId, elementId);
 		if (cachedPermissions != null) {
 			return cachedPermissions.contains(permission);
 		} else {
@@ -120,6 +119,11 @@ public class PermissionCacheImpl extends AbstractMeshCache<String, EnumSet<Inter
 	}
 
 	@Override
+	public EnumSet<InternalPermission> get(Object userId, Object elementId) {
+		return get(createCacheKey(userId, elementId));
+	}
+
+	@Override
 	public void store(Object userId, EnumSet<InternalPermission> permission, Object elementId) {
 		// deduplicate the permission EnumSet and put it into the cache
 		cache.put(createCacheKey(userId, elementId), deduplicate(permission));
@@ -138,5 +142,10 @@ public class PermissionCacheImpl extends AbstractMeshCache<String, EnumSet<Inter
 
 		// either get the already used instance from the map or put the clone in the map, if this is the first occurrance
 		return uniqueMap.computeIfAbsent(clone, key -> clone);
+	}
+
+	@Override
+	public void invalidate(Object userId, Object elementId) {
+		cache.invalidate(createCacheKey(userId, elementId));
 	}
 }

--- a/mdm/api/src/main/java/com/gentics/mesh/cache/PermissionCache.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/cache/PermissionCache.java
@@ -37,4 +37,20 @@ public interface PermissionCache extends MeshCache<String, EnumSet<InternalPermi
 	 */
 	void store(Object userId, EnumSet<InternalPermission> permissions, Object elementId);
 
+	/**
+	 * Get all permissions of a given element for the given user ID.
+	 * 
+	 * @param userId
+	 * @param elementId
+	 * @return
+	 */
+	EnumSet<InternalPermission> get(Object userId, Object elementId);
+
+	/**
+	 * Invalidate cached permissions of a given element for the given user ID.
+	 * 
+	 * @param userId
+	 * @param elementId
+	 */
+	void invalidate(Object userId, Object elementId);
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLPermissionQueryTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLPermissionQueryTest.java
@@ -3,17 +3,36 @@ package com.gentics.mesh.core.graphql;
 import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
 import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
+import com.gentics.mesh.FieldUtil;
+import com.gentics.mesh.core.data.project.HibProject;
+import com.gentics.mesh.core.rest.common.ObjectPermissionGrantRequest;
 import com.gentics.mesh.core.rest.graphql.GraphQLRequest;
 import com.gentics.mesh.core.rest.graphql.GraphQLResponse;
+import com.gentics.mesh.core.rest.group.GroupCreateRequest;
+import com.gentics.mesh.core.rest.group.GroupResponse;
+import com.gentics.mesh.core.rest.node.NodeCreateRequest;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.role.RoleCreateRequest;
+import com.gentics.mesh.core.rest.role.RoleReference;
 import com.gentics.mesh.core.rest.role.RoleResponse;
+import com.gentics.mesh.core.rest.user.NodeReference;
 import com.gentics.mesh.test.MeshTestSetting;
 import com.gentics.mesh.test.TestSize;
 import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.jayway.jsonpath.JsonPath;
 
 import io.vertx.core.json.JsonObject;
 
@@ -40,6 +59,73 @@ public class GraphQLPermissionQueryTest extends AbstractMeshTest {
 		assertThat(json).compliesToAssertions(queryName);
 	}
 
-	
+	/**
+	 * Test reading children of a node, when the read permissions come from different roles
+	 * @throws IOException
+	 */
+	@Test
+	public void testReadChildrenPermissionsFromDifferentRoles() throws IOException {
+		HibProject project = project();
+		String baseNodeUuid = tx(() -> project.getBaseNode().getUuid());
+
+		String userUuid = tx(() -> user().getUuid());
+
+		// create node and assign read permission to anonymous role
+		NodeCreateRequest create = new NodeCreateRequest();
+		create.setParentNode(new NodeReference().setUuid(baseNodeUuid));
+		create.setLanguage("en");
+		create.setSchemaName("folder");
+		create.setGrant(new ObjectPermissionGrantRequest().setExclusive(true).setReadPublished(Arrays.asList(new RoleReference().setName("anonymous"))));
+		NodeResponse testNode = call(() -> client().createNode(PROJECT_NAME, create));
+
+		Map<String, String> nodeUuids = new HashMap<>();
+		for (String name : Arrays.asList("role_one", "role_two", "role_three")) {
+			// create role
+			RoleResponse role = call(() -> client().createRole(new RoleCreateRequest().setName(name)));
+
+			// create group
+			GroupResponse group = call(() -> client().createGroup(new GroupCreateRequest().setName(name)));
+
+			// add role to group
+			call(() -> client().addRoleToGroup(group.getUuid(), role.getUuid()));
+
+			// add user to group
+			call(() -> client().addUserToGroup(group.getUuid(), userUuid));
+
+			// create node and set permission
+			create.setParentNode(new NodeReference().setUuid(testNode.getUuid()));
+			create.setLanguage("en");
+			create.setSchemaName("folder");
+			create.getFields().put("name", FieldUtil.createStringField(name));
+			create.setGrant(new ObjectPermissionGrantRequest().setExclusive(true)
+					.setRead(Arrays.asList(new RoleReference().setName(name)))
+					.setOthers(true));
+			NodeResponse node = call(() -> client().createNode(PROJECT_NAME, create));
+			nodeUuids.put(name, node.getUuid());
+		}
+
+		// grant update permissions to the "wrong" nodes
+		for (Map.Entry<String, String> entry : nodeUuids.entrySet()) {
+			String name = entry.getKey();
+			String nodeUuid = entry.getValue();
+			List<String> granted = new ArrayList<>(Arrays.asList("role_one", "role_two", "role_three"));
+			granted.remove(name);
+			List<RoleReference> grantedRoles = granted.stream().map(n -> new RoleReference().setName(n)).collect(Collectors.toList());
+
+			call(() -> client().grantNodeRolePermissions(PROJECT_NAME, nodeUuid, new ObjectPermissionGrantRequest().setExclusive(true).setUpdate(grantedRoles)));
+		}
+
+		GraphQLRequest request = new GraphQLRequest();
+		request.setQuery(getGraphQLQuery("childrenPerms"));
+		request.setVariables(new JsonObject().put("nodeUuid", testNode.getUuid()));
+
+		GraphQLResponse response = call(() -> client().graphql(PROJECT_NAME, request));
+		JsonObject json = new JsonObject(response.toJson());
+
+		assertThat(json).compliesToAssertions("childrenPerms");
+
+		Collection<String> nodeNames = JsonPath.read(json.encodePrettily(), "$.data.node.children.elements[*].fields.name");
+		assertThat(nodeNames).as("Returned nodes").containsOnly("role_one", "role_two", "role_three");
+	}
 
 }

--- a/tests/tests-core/src/main/resources/graphql/childrenPerms
+++ b/tests/tests-core/src/main/resources/graphql/childrenPerms
@@ -1,0 +1,14 @@
+query ($nodeUuid: String!) {
+	node (uuid: $nodeUuid) {
+		children {
+			elements {
+				... on folder {
+					fields {
+						name
+					}
+				}
+			}
+		}
+	}
+}
+# [$.errors=<is-undefined>]


### PR DESCRIPTION
## Abstract

Provides an API for managing the distinct cache items.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
