### PR TITLE
Add method to check for conflicting webroot fields for a set of values

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,11 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.10.10]]
+== 1.10.10 (TBD)
+
+icon:check[] Core: The internal check for uniqueness of values in webroot fields has been improved.
+
 [[v1.10.9]]
 == 1.10.9 (12.06.2023)
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/ContentDao.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/dao/ContentDao.java
@@ -939,6 +939,18 @@ public interface ContentDao {
 	HibNodeFieldContainerEdge getConflictingEdgeOfWebrootField(HibNodeFieldContainer content, HibNodeFieldContainerEdge edge, String urlFieldValue, String branchUuid, ContainerType type);
 
 	/**
+	 * 	Retrieve a conflicting edge for one of the given urlFieldValues, branch uuid and type, or null if there's no conflicting
+	 * 	edge
+	 * @param content
+	 * @param edge
+	 * @param urlFieldValues
+	 * @param branchUuid
+	 * @param type
+	 * @return
+	 */
+	HibNodeFieldContainerEdge getConflictingEdgeOfWebrootField(HibNodeFieldContainer content, HibNodeFieldContainerEdge edge, Set<String> urlFieldValues, String branchUuid, ContainerType type);
+
+	/**
 	 * Set the segment info which consists of :nodeUuid + "-" + segment. The property is indexed and used for the webroot path resolving mechanism.
 	 *
 	 * @param parentNode

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
@@ -711,28 +711,25 @@ public interface PersistingContentDao extends ContentDao {
 	 */
 	private void updateWebrootUrlFieldsInfo(HibNodeFieldContainer content, HibNodeFieldContainerEdge edge, String branchUuid, Set<String> urlFieldValues, ContainerType type) {
 		if (urlFieldValues != null && !urlFieldValues.isEmpty()) {
-			// Individually check each url
-			for (String urlFieldValue : urlFieldValues) {
-				HibNodeFieldContainerEdge conflictingEdge = getConflictingEdgeOfWebrootField(content, edge, urlFieldValue, branchUuid, type);
-				if (conflictingEdge != null) {
-					HibNodeFieldContainer conflictingContainer = conflictingEdge.getNodeContainer();
-					HibNode conflictingNode = conflictingEdge.getNode();
-					if (log.isDebugEnabled()) {
-						log.debug(
-								"Found conflicting container with uuid {" + conflictingContainer.getUuid() + "} of node {" + conflictingNode.getUuid());
-					}
-					// We know that the found container already occupies the index with one of the given paths. Lets compare both sets of paths in order to
-					// determine
-					// which path caused the conflict.
-					Set<String> fromConflictingContainer = getUrlFieldValues(conflictingContainer).collect(Collectors.toSet());
-					@SuppressWarnings("unchecked")
-					Collection<String> conflictingValues = CollectionUtils.intersection(fromConflictingContainer, urlFieldValues);
-					String paths = String.join(",", conflictingValues);
-
-					throw nodeConflict(conflictingNode.getUuid(), conflictingContainer.getDisplayFieldValue(), conflictingContainer.getLanguageTag(),
-							"node_conflicting_urlfield_update", paths, conflictingContainer.getNode().getUuid(),
-							conflictingContainer.getLanguageTag());
+			HibNodeFieldContainerEdge conflictingEdge = getConflictingEdgeOfWebrootField(content, edge, urlFieldValues, branchUuid, type);
+			if (conflictingEdge != null) {
+				HibNodeFieldContainer conflictingContainer = conflictingEdge.getNodeContainer();
+				HibNode conflictingNode = conflictingEdge.getNode();
+				if (log.isDebugEnabled()) {
+					log.debug(
+							"Found conflicting container with uuid {" + conflictingContainer.getUuid() + "} of node {" + conflictingNode.getUuid());
 				}
+				// We know that the found container already occupies the index with one of the given paths. Lets compare both sets of paths in order to
+				// determine
+				// which path caused the conflict.
+				Set<String> fromConflictingContainer = getUrlFieldValues(conflictingContainer).collect(Collectors.toSet());
+				@SuppressWarnings("unchecked")
+				Collection<String> conflictingValues = CollectionUtils.intersection(fromConflictingContainer, urlFieldValues);
+				String paths = String.join(",", conflictingValues);
+
+				throw nodeConflict(conflictingNode.getUuid(), conflictingContainer.getDisplayFieldValue(), conflictingContainer.getLanguageTag(),
+						"node_conflicting_urlfield_update", paths, conflictingContainer.getNode().getUuid(),
+						conflictingContainer.getLanguageTag());
 			}
 			edge.setUrlFieldInfo(urlFieldValues);
 		} else {

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/ContentDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/ContentDaoWrapperImpl.java
@@ -14,6 +14,8 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 import com.gentics.mesh.core.data.user.HibUser;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.gentics.mesh.context.BulkActionContext;
@@ -232,6 +234,21 @@ public class ContentDaoWrapperImpl implements ContentDaoWrapper {
 	@Override
 	public HibNodeFieldContainerEdge getConflictingEdgeOfWebrootField(HibNodeFieldContainer content, HibNodeFieldContainerEdge edge, String urlFieldValue, String branchUuid, ContainerType type) {
 		return toGraph(content).getConflictingEdgeOfWebrootField(toGraph(edge), urlFieldValue, branchUuid, type);
+	}
+
+	@Override
+	public HibNodeFieldContainerEdge getConflictingEdgeOfWebrootField(HibNodeFieldContainer content,
+			HibNodeFieldContainerEdge edge, Set<String> urlFieldValues, String branchUuid, ContainerType type) {
+		if (CollectionUtils.isEmpty(urlFieldValues)) {
+			return null;
+		}
+		for (String value : urlFieldValues) {
+			HibNodeFieldContainerEdge conflictingEdge = getConflictingEdgeOfWebrootField(content, edge, value, branchUuid, type);
+			if (conflictingEdge != null) {
+				return conflictingEdge;
+			}
+		}
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
## Abstract

Add method to check for uniqueness of webroot field values for a set of strings. Other persistence implementations might implement this more efficiently.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
