### PR TITLE
SUP-15421: Move node publish to the separate nonlocked tx

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,11 @@ include::content/docs/variables.adoc-include[]
 
 * The `html` field type will be removed in the future. Instead the `string` type will be used in combination with an additional configuration property for this field in the schema. Of course, your existing schemas will be migrated for you.
 
+[[v1.10.11]]
+== 1.10.11 (TBD)
+
+icon:check[] Core: When using a "instant binary publishing" feature, the actual publishing was sharing the same database transaction, that the file upload, which could potentially cause the deadlock in the shared Hazelcast cache of clustered installations. This has now been fixed by removing the publish request to its own transaction.
+
 [[v1.10.10]]
 == 1.10.10 (28.06.2023)
 

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
@@ -449,7 +449,7 @@ public interface PersistingContentDao extends ContentDao {
 
 		// create published version
 		HibNodeFieldContainer newVersion = createFieldContainer(node, languageTag, branch, user);
-		Tx.get().contentDao().setVersion(newVersion, newVersion.getVersion().nextPublished());
+		setVersion(newVersion, newVersion.getVersion().nextPublished());
 
 		Tx.get().nodeDao().setPublished(node, ac, newVersion, branchUuid);
 		return newVersion;


### PR DESCRIPTION
## Abstract

In case of distributed Hazelcast cache, a deadlock may happen on large number of simultaneous file upload requests, caused by an attempt of deletion of an old content version, that has been locked by an upload process.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
