### PR TITLE
SUP-15553: Erratic logging upon OAUth plugins run

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,8 @@ include::content/docs/variables.adoc-include[]
 
 icon:check[] Core: All named instances have been presented an own cache.
 
+icon check[] Plugins: Logging fixed upon false triggering of a warning of inexisting role/group connection.
+
 [[v1.10.10]]
 == 1.10.10 (28.06.2023)
 

--- a/services/jwt-auth/src/main/java/com/gentics/mesh/auth/oauth2/MeshOAuth2ServiceImpl.java
+++ b/services/jwt-auth/src/main/java/com/gentics/mesh/auth/oauth2/MeshOAuth2ServiceImpl.java
@@ -472,13 +472,15 @@ public class MeshOAuth2ServiceImpl implements MeshOAuthService {
 								}
 
 								// Add the role if it is missing
-								if (role != null && !groupDao.hasRole(group, role)) {
-									requiresWrite();
-									log.debug("Adding role {} to group {} via mapping request.", role.getName(), group.getName());
-									groupDao.addRole(group, role);
-									group.setLastEditedTimestamp();
-									group.setEditor(admin);
-									batch.add(groupDao.createRoleAssignmentEvent(group, role, ASSIGNED));
+								if (role != null) {
+									if (!groupDao.hasRole(group, role)) {
+										requiresWrite();
+										log.debug("Adding role {} to group {} via mapping request.", role.getName(), group.getName());
+										groupDao.addRole(group, role);
+										group.setLastEditedTimestamp();
+										group.setEditor(admin);
+										batch.add(groupDao.createRoleAssignmentEvent(group, role, ASSIGNED));
+									}
 								} else {
 									log.warn("Unable to map role to group. The role with name {} / uuid {} could not be found", roleName, roleUuid);
 								}
@@ -522,10 +524,12 @@ public class MeshOAuth2ServiceImpl implements MeshOAuthService {
 								}
 
 								// Add the role if it is missing
-								if (group != null && !groupDao.hasRole(group, role)) {
-									requiresWrite();
-									groupDao.addRole(group, role);
-									batch.add(groupDao.createRoleAssignmentEvent(group, role, ASSIGNED));
+								if (group != null) {
+									if (!groupDao.hasRole(group, role)) {
+										requiresWrite();
+										groupDao.addRole(group, role);
+										batch.add(groupDao.createRoleAssignmentEvent(group, role, ASSIGNED));
+									}
 								} else {
 									log.error("Could not find group in role->group mapping of role {}", role.getName());
 								}


### PR DESCRIPTION
## Abstract

The OAuth plugin run triggers a log warning about missing role/group connection, which may not be true.

## Checklist

### General

* [x] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
