### PR TITLE
Add support for login with API token.

### DIFF
--- a/changelog/src/changelog/entries/2023/08/7532.GPU-942.enhancement
+++ b/changelog/src/changelog/entries/2023/08/7532.GPU-942.enhancement
@@ -1,0 +1,1 @@
+The endpoint `GET /auth/login` now also supports login via the Authentication Bearer request header (using an API token).

--- a/core/src/main/java/com/gentics/mesh/auth/MeshBasicAuthLoginHandler.java
+++ b/core/src/main/java/com/gentics/mesh/auth/MeshBasicAuthLoginHandler.java
@@ -3,16 +3,25 @@ package com.gentics.mesh.auth;
 import com.gentics.mesh.auth.provider.MeshJWTAuthProvider;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.context.impl.InternalRoutingActionContextImpl;
+import com.gentics.mesh.core.rest.auth.TokenResponse;
+import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.shared.SharedKeys;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.AuthenticationHandlerImpl;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Base64;
 
 /**
@@ -27,10 +36,13 @@ public class MeshBasicAuthLoginHandler extends AuthenticationHandlerImpl<MeshJWT
 
 	private MeshJWTAuthProvider authProvider;
 
+	private final MeshOptions meshOptions;
+
 	@Inject
-	public MeshBasicAuthLoginHandler(MeshJWTAuthProvider authProvider) {
+	public MeshBasicAuthLoginHandler(MeshJWTAuthProvider authProvider, MeshOptions meshOptions) {
 		super(authProvider);
 		this.authProvider = authProvider;
+		this.meshOptions = meshOptions;
 		this.realm = "Gentics Mesh";
 	}
 
@@ -64,14 +76,45 @@ public class MeshBasicAuthLoginHandler extends AuthenticationHandlerImpl<MeshJWT
 				try {
 					String[] parts = authorization.split(" ");
 					sscheme = parts[0];
-					String decoded = new String(Base64.getDecoder().decode(parts[1]));
-					int colonIdx = decoded.indexOf(":");
-					if (colonIdx != -1) {
-						suser = decoded.substring(0, colonIdx);
-						spass = decoded.substring(colonIdx + 1);
+
+					if (StringUtils.equalsIgnoreCase("Basic", sscheme)) {
+						String decoded = new String(Base64.getDecoder().decode(parts[1]));
+						int colonIdx = decoded.indexOf(":");
+						if (colonIdx != -1) {
+							suser = decoded.substring(0, colonIdx);
+							spass = decoded.substring(colonIdx + 1);
+						} else {
+							suser = decoded;
+							spass = null;
+						}
+
+						// We decoded the basic auth information and can now invoke the login call. The MeshAuthProvider will also set the JWT token in the cookie
+						// and return the response to the requestor.
+						InternalActionContext ac = new InternalRoutingActionContextImpl(context);
+						authProvider.login(ac, suser, spass, null);
+					} else if (StringUtils.equalsIgnoreCase("Bearer", sscheme)) {
+						// TODO check whether there are additional parts
+						String token = parts[1];
+						JsonObject authInfo = new JsonObject().put("token", token).put("options", new JsonObject());
+						authProvider.authenticateJWT(authInfo, res -> {
+
+							// Authentication was successful.
+							if (res.succeeded()) {
+								AuthenticationResult result = res.result();
+								User authenticatedUser = result.getUser();
+								context.setUser(authenticatedUser);
+
+								InternalActionContext ac = new InternalRoutingActionContextImpl(context);
+								String jwtToken = authProvider.generateToken(authenticatedUser);
+								ac.addCookie(Cookie.cookie(SharedKeys.TOKEN_COOKIE_KEY, jwtToken)
+										.setMaxAge(meshOptions.getAuthenticationOptions().getTokenExpirationTime()).setPath("/"));
+								ac.send(new TokenResponse(jwtToken).toJson());
+							} else {
+								handle401(context);
+							}
+						});
 					} else {
-						suser = decoded;
-						spass = null;
+						context.fail(400);
 					}
 				} catch (ArrayIndexOutOfBoundsException e) {
 					handle401(context);
@@ -80,15 +123,6 @@ public class MeshBasicAuthLoginHandler extends AuthenticationHandlerImpl<MeshJWT
 					// IllegalArgumentException includes PatternSyntaxException
 					context.fail(e);
 					return;
-				}
-
-				if (!"Basic".equals(sscheme)) {
-					context.fail(400);
-				} else {
-					// We decoded the basic auth information and can now invoke the login call. The MeshAuthProvider will also set the JWT token in the cookie
-					// and return the response to the requestor.
-					InternalActionContext ac = new InternalRoutingActionContextImpl(context);
-					authProvider.login(ac, suser, spass, null);
 				}
 			}
 		}

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/auth/AuthenticationEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/auth/AuthenticationEndpoint.java
@@ -61,8 +61,9 @@ public class AuthenticationEndpoint extends AbstractInternalEndpoint {
 		InternalEndpointRoute basicAuthLoginEndpoint = createRoute();
 		basicAuthLoginEndpoint.path("/login");
 		basicAuthLoginEndpoint.method(GET);
-		// basicAuthLoginEndpoint.produces(APPLICATION_JSON);
-		basicAuthLoginEndpoint.description("Login via basic authentication.");
+		basicAuthLoginEndpoint.produces(APPLICATION_JSON);
+		basicAuthLoginEndpoint.exampleResponse(OK, miscExamples.getAuthTokenResponse(), "Generated login token.");
+		basicAuthLoginEndpoint.description("Login via basic or bearer authentication.");
 		basicAuthLoginEndpoint.exampleResponse(OK, "Login was sucessful");
 		basicAuthLoginEndpoint.handler(basicAuthLoginHandler);
 


### PR DESCRIPTION
## Abstract

The request GET /auth/login will now also accept Authentication: Bearer headers (containing an API Token) and do a login (generate and return a login token).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
