### PR TITLE
Refresh login token in MeshRestClient

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -23,12 +23,15 @@ All fixes and changes in LTS releases will be released the next minor release. C
 icon:check[] Clustering: Calling cluster specific REST Endpoints on non-clustered instances could cause internal server errors. The behaviour has been changed so that
 a "Bad Request" error is returned containing a proper error message.
 
+icon:check[] Java Rest Client: After logging in with the `login()` method, the login token was never refreshed, which caused it to expire after the configured token expiration time (per default 1 hour),
+even if the client was used to do requests. This has been changed now, so that the login token in the client will be refreshed on every request to mesh.
+
 [[v1.10.13]]
 == 1.10.13 (10.08.2023)
 
 icon:check[] Core: All named instances have been presented an own cache.
 
-icon check[] Plugins: Logging fixed upon false triggering of a warning of inexisting role/group connection.
+icon:check[] Plugins: Logging fixed upon false triggering of a warning of inexisting role/group connection.
 
 [[v1.10.12]]
 == 1.10.12 (26.07.2023)

--- a/rest-client/src/main/java/com/gentics/mesh/rest/JWTAuthentication.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/JWTAuthentication.java
@@ -22,6 +22,11 @@ public class JWTAuthentication extends AbstractAuthenticationProvider {
 
 	private String token;
 
+	/**
+	 * Flag is set, if the token is a login token (was set via {@link #login(AbstractMeshRestHttpClient)})
+	 */
+	private boolean loginToken = false;
+
 	public JWTAuthentication() {
 	}
 
@@ -55,13 +60,16 @@ public class JWTAuthentication extends AbstractAuthenticationProvider {
 			loginRequest.setNewPassword(getNewPassword());
 
 			return meshRestClient.prepareRequest(HttpMethod.POST, "/auth/login", TokenResponse.class, loginRequest).toSingle();
-		}).doOnSuccess(response -> token = response.getToken())
-			.map(ignore -> new GenericMessageResponse("OK"));
+		}).doOnSuccess(response -> {
+			token = response.getToken();
+			loginToken = true;
+		}).map(ignore -> new GenericMessageResponse("OK"));
 	}
 
 	@Override
 	public Single<GenericMessageResponse> logout(AbstractMeshRestHttpClient meshRestClient) {
 		token = null;
+		loginToken = false;
 		// No need call any endpoint in JWT
 		return Single.just(new GenericMessageResponse("OK"));
 	}
@@ -83,7 +91,27 @@ public class JWTAuthentication extends AbstractAuthenticationProvider {
 	 */
 	public JWTAuthentication setToken(String token) {
 		this.token = token;
+		this.loginToken = false;
 		return this;
 	}
 
+	/**
+	 * Set the JWT token as login token
+	 * 
+	 * @param token
+	 * @return
+	 */
+	public JWTAuthentication setLoginToken(String token) {
+		this.token = token;
+		this.loginToken = true;
+		return this;
+	}
+
+	/**
+	 * Check whether the token is a login token
+	 * @return true for a login token
+	 */
+	public boolean isLoginToken() {
+		return loginToken;
+	}
 }

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestOkHttpClientImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestOkHttpClientImpl.java
@@ -32,7 +32,7 @@ public class MeshRestOkHttpClientImpl extends MeshRestHttpClientImpl {
 	@Override
 	public <T> MeshRequest<T> prepareRequest(HttpMethod method, String path, Class<? extends T> classOfT, InputStream bodyData, long fileSize,
 		String contentType) {
-		return MeshOkHttpRequestImpl.BinaryRequest(client, config, method.name(), getUrl(path), createHeaders(), classOfT, bodyData, fileSize, contentType);
+		return MeshOkHttpRequestImpl.BinaryRequest(this, client, config, method.name(), getUrl(path), createHeaders(), classOfT, bodyData, fileSize, contentType);
 	}
 
 	@Override
@@ -42,17 +42,17 @@ public class MeshRestOkHttpClientImpl extends MeshRestHttpClientImpl {
 
 	@Override
 	public <T> MeshRequest<T> prepareRequest(HttpMethod method, String path, Class<? extends T> classOfT) {
-		return MeshOkHttpRequestImpl.EmptyRequest(client, config, method.name(), getUrl(path), createHeaders(), classOfT);
+		return MeshOkHttpRequestImpl.EmptyRequest(this, client, config, method.name(), getUrl(path), createHeaders(), classOfT);
 	}
 
 	@Override
 	public <T> MeshRequest<T> handleRequest(HttpMethod method, String path, Class<? extends T> classOfT, String jsonBodyData) {
-		return MeshOkHttpRequestImpl.JsonRequest(client, config, method.name(), getUrl(path), createHeaders(), classOfT, jsonBodyData);
+		return MeshOkHttpRequestImpl.JsonRequest(this, client, config, method.name(), getUrl(path), createHeaders(), classOfT, jsonBodyData);
 	}
 
 	@Override
 	public <T> MeshRequest<T> handleTextRequest(HttpMethod method, String path, Class<? extends T> classOfT, String data) {
-		return MeshOkHttpRequestImpl.TextRequest(client, config, method.name(), getUrl(path), createHeaders(), classOfT, data);
+		return MeshOkHttpRequestImpl.TextRequest(this, client, config, method.name(), getUrl(path), createHeaders(), classOfT, data);
 	}
 
 	@Override

--- a/rest-client/src/main/java/com/gentics/mesh/rest/monitoring/impl/MonitoringOkHttpClientImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/monitoring/impl/MonitoringOkHttpClientImpl.java
@@ -61,7 +61,7 @@ public class MonitoringOkHttpClientImpl implements MonitoringRestClient {
 	}
 
 	private <T> MeshRequest<T> prepareRequest(HttpMethod method, String path, Class<? extends T> classOfT) {
-		return MeshOkHttpRequestImpl.EmptyRequest(client, null, method.name(), getUrl(path), Collections.emptyMap(), classOfT);
+		return MeshOkHttpRequestImpl.EmptyRequest(null, client, null, method.name(), getUrl(path), Collections.emptyMap(), classOfT);
 	}
 
 	@Override

--- a/tests/tests-core/src/main/java/com/gentics/mesh/client/MeshRestClientTokenTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/client/MeshRestClientTokenTest.java
@@ -1,0 +1,126 @@
+package com.gentics.mesh.client;
+
+import static com.gentics.mesh.assertj.MeshAssertions.assertThat;
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.ElasticsearchTestMode.NONE;
+import static com.gentics.mesh.test.TestSize.PROJECT;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gentics.mesh.demo.UserInfo;
+import com.gentics.mesh.etc.config.MeshOptions;
+import com.gentics.mesh.test.MeshOptionChanger;
+import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.test.TestDataProvider;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.reactivex.Flowable;
+
+/**
+ * Test cases for refreshing the login token in the MeshRestClient
+ */
+@MeshTestSetting(elasticsearch = NONE, testSize = PROJECT, startServer = true, customOptionChanger = MeshRestClientTokenTest.SetTokenExpirationTime.class)
+public class MeshRestClientTokenTest extends AbstractMeshTest {
+	/**
+	 * Token expiration time in seconds
+	 */
+	public final static int TOKEN_EXPIRATION_TIME_SECONDS = 5;
+
+	/**
+	 * API Token of the test user
+	 */
+	private String testUserApiToken;
+
+	/**
+	 * Username of the test user
+	 */
+	private String username;
+
+	/**
+	 * Password of the test user
+	 */
+	private String password;
+
+	@Before
+	public void setUp() throws Exception {
+		String userUuid = TestDataProvider.getInstance().getUserInfo().getUserUuid();
+		testUserApiToken = testContext.getHttpClient().issueAPIToken(userUuid).blockingGet().getToken();
+
+		UserInfo userInfo = TestDataProvider.getInstance().getUserInfo();
+		username = tx(tx -> {
+			return userInfo.getUser().getUsername();
+		});
+		password = userInfo.getPassword();
+
+		client().logout().blockingGet();
+	}
+
+	/**
+	 * Test using login credentials
+	 * @throws Exception
+	 */
+	@Test
+	public void testLogin() throws Exception {
+		client().setLogin(username, password).login().blockingGet();
+
+		// now get "me" for 10 seconds (once every second). This will fail, when the token expires
+		Flowable.intervalRange(0, 10, 0, 1, TimeUnit.SECONDS).flatMapSingle(v -> {
+			return client().me().toSingle();
+		}).doOnNext(response -> {
+			// assert that we still are the correct user
+			assertThat(response).hasName(username);
+		}).blockingSubscribe();
+	}
+
+	/**
+	 * Test using the API Token
+	 * @throws Exception
+	 */
+	@Test
+	public void testApiToken() throws Exception {
+		UserInfo userInfo = TestDataProvider.getInstance().getUserInfo();
+		String username = tx(tx -> {
+			return userInfo.getUser().getUsername();
+		});
+		client().setAPIKey(testUserApiToken);
+
+		// now get "me" for 10 seconds (once every second). This will fail, when the token expires
+		Flowable.intervalRange(0, 10, 0, 1, TimeUnit.SECONDS).flatMapSingle(v -> {
+			return client().me().toSingle();
+		}).doOnNext(response -> {
+			// assert that we still are the correct user
+			assertThat(response).hasName(username);
+			// assert that we still use the API Token
+			assertThat(client().getAPIKey()).as("API Token").isEqualTo(testUserApiToken);
+		}).blockingSubscribe();
+	}
+
+	/**
+	 * Test that the token expires if waiting too long
+	 * @throws Exception
+	 */
+	@Test
+	public void testExpiration() throws Exception {
+		client().setLogin(username, password).login().blockingGet();
+
+		// wait 1 second longer than the expiration time
+		Thread.sleep((TOKEN_EXPIRATION_TIME_SECONDS + 1) * 1000);
+
+		call(() -> client().me(), HttpResponseStatus.UNAUTHORIZED);
+	}
+
+	/**
+	 * Implementation of {@link MeshOptionChanger} which sets the token expiration time to 5 seconds
+	 */
+	public static class SetTokenExpirationTime implements MeshOptionChanger {
+		@Override
+		public void change(MeshOptions options) {
+			// set the login token to expire after 5 seconds
+			options.getAuthenticationOptions().setTokenExpirationTime(TOKEN_EXPIRATION_TIME_SECONDS);
+		}
+	}
+}


### PR DESCRIPTION
## Abstract

When doing a login, the returned login token will expire after some time (1 hour per default). If the login token is not refreshed,  all requests will be answered with 401 after expiration.
This change will now refresh the login token with the new one, which is sent as cookie in every response.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
