### PR TITLE
SUP-15602: Fix the GraphQL metadata request for an empty (micro)schema.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,6 +26,8 @@ a "Bad Request" error is returned containing a proper error message.
 icon:check[] Java Rest Client: After logging in with the `login()` method, the login token was never refreshed, which caused it to expire after the configured token expiration time (per default 1 hour),
 even if the client was used to do requests. This has been changed now, so that the login token in the client will be refreshed on every request to mesh.
 
+icon:check[] GraphQL: The metadata request does not crash anymore on the empty (micro)schemas. The new related filter, `isEmpty`, has been added as well..
+
 [[v1.10.13]]
 == 1.10.13 (10.08.2023)
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -26,7 +26,7 @@ a "Bad Request" error is returned containing a proper error message.
 icon:check[] Java Rest Client: After logging in with the `login()` method, the login token was never refreshed, which caused it to expire after the configured token expiration time (per default 1 hour),
 even if the client was used to do requests. This has been changed now, so that the login token in the client will be refreshed on every request to mesh.
 
-icon:check[] GraphQL: The metadata request does not crash anymore on the empty (micro)schemas. The new related filter, `isEmpty`, has been added as well..
+icon:check[] GraphQL: The metadata request does not crash anymore on the empty (micro)schemas. The new related filter, `isEmpty`, has been added as well.
 
 [[v1.10.13]]
 == 1.10.13 (10.08.2023)

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
@@ -2,10 +2,8 @@ package com.gentics.mesh.graphql.type;
 
 import static com.gentics.mesh.core.action.DAOActionContext.context;
 import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PERM;
-import static com.gentics.mesh.core.data.perm.InternalPermission.READ_PUBLISHED_PERM;
-import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
-import static graphql.scalars.java.JavaPrimitives.GraphQLLong;
 import static graphql.Scalars.GraphQLString;
+import static graphql.scalars.java.JavaPrimitives.GraphQLLong;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
@@ -20,13 +18,14 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.gentics.graphqlfilter.filter.StartFilter;
 import com.gentics.mesh.core.action.DAOActions;
 import com.gentics.mesh.core.data.HibBaseElement;
 import com.gentics.mesh.core.data.HibCoreElement;
 import com.gentics.mesh.core.data.HibFieldContainer;
 import com.gentics.mesh.core.data.branch.HibBranch;
-import com.gentics.mesh.core.data.dao.ContentDao;
 import com.gentics.mesh.core.data.dao.NodeDao;
 import com.gentics.mesh.core.data.dao.UserDao;
 import com.gentics.mesh.core.data.node.NodeContent;
@@ -38,6 +37,8 @@ import com.gentics.mesh.core.data.schema.HibSchemaVersion;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.error.PermissionException;
+import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel;
 import com.gentics.mesh.error.MeshConfigurationException;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.graphql.context.GraphQLContext;
@@ -56,6 +57,7 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldDefinition.Builder;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLTypeReference;
+import io.vertx.core.json.JsonObject;
 
 public abstract class AbstractTypeProvider {
 
@@ -578,5 +580,79 @@ public abstract class AbstractTypeProvider {
 		} else {
 			return new DynamicStreamPageImpl<>(stream, pagingInfo);
 		}
+	}
+
+	/**
+	 * Create a dummy field for the schema type definition.
+	 * 
+	 * @param description
+	 * @return
+	 */
+	protected static final FieldSchema emptySchemaFieldDummy(String description) {
+		return new FieldSchema() {
+
+			@Override
+			public void validate() {
+			}
+
+			@Override
+			public FieldSchema setRequired(boolean isRequired) {
+				return this;
+			}
+
+			@Override
+			public FieldSchema setName(String name) {
+				return this;
+			}
+
+			@Override
+			public FieldSchema setLabel(String label) {
+				return this;
+			}
+
+			@Override
+			public FieldSchema setElasticsearch(JsonObject elasticsearch) {
+				return this;
+			}
+
+			@Override
+			public boolean isRequired() {
+				return false;
+			}
+
+			@Override
+			public String getType() {
+				return StringUtils.EMPTY;
+			}
+
+			@Override
+			public String getName() {
+				return "EMPTY";
+			}
+
+			@Override
+			public String getLabel() {
+				return description;
+			}
+
+			@Override
+			public JsonObject getElasticsearch() {
+				return null;
+			}
+
+			@Override
+			public Map<String, Object> getAllChangeProperties() {
+				return null;
+			}
+
+			@Override
+			public SchemaChangeModel compareTo(FieldSchema fieldSchema) {
+				return null;
+			}
+
+			@Override
+			public void apply(Map<String, Object> fieldProperties) {
+			}
+		};
 	}
 }

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/MicroschemaTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/MicroschemaTypeProvider.java
@@ -1,26 +1,44 @@
 package com.gentics.mesh.graphql.type;
 
 import static com.gentics.mesh.graphql.type.ProjectReferenceTypeProvider.PROJECT_REFERENCE_PAGE_TYPE_NAME;
+import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.gentics.mesh.core.data.branch.HibBranch;
 import com.gentics.mesh.core.data.dao.UserDao;
 import com.gentics.mesh.core.data.perm.InternalPermission;
 import com.gentics.mesh.core.data.schema.HibMicroschema;
+import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
 import com.gentics.mesh.core.db.Tx;
+import com.gentics.mesh.core.rest.microschema.MicroschemaVersionModel;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaModelImpl;
+import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.graphql.context.GraphQLContext;
+import com.gentics.mesh.json.JsonUtil;
 
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLObjectType.Builder;
+import graphql.schema.GraphQLOutputType;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * GraphQL type provider for microschema types.
@@ -28,9 +46,13 @@ import graphql.schema.GraphQLObjectType.Builder;
 @Singleton
 public class MicroschemaTypeProvider extends AbstractTypeProvider {
 
+	private static final Logger log = LoggerFactory.getLogger(MicroschemaTypeProvider.class);
+
 	public static final String MICROSCHEMA_TYPE_NAME = "Microschema";
 
 	public static final String MICROSCHEMA_PAGE_TYPE_NAME = "MicroschemasPage";
+
+	public static final String MICROSCHEMA_FIELD_TYPE = "MicroschemaFieldType";
 
 	protected final InterfaceTypeProvider interfaceTypeProvider;
 
@@ -69,11 +91,55 @@ public class MicroschemaTypeProvider extends AbstractTypeProvider {
 				.collect(Collectors.toList());
 		}, PROJECT_REFERENCE_PAGE_TYPE_NAME));
 
-		// .fields
+		// .isEmpty
+		schemaType.field(newFieldDefinition().name("isEmpty").type(GraphQLBoolean).dataFetcher((env) -> {
+			MicroschemaVersionModel model = loadModelWithFallback(env);
+			return model == null || model.getFields() == null || model.getFields().isEmpty();
+		}));
 
-		// TODO add fields
+		// .fields
+		Builder fieldListBuilder = newObject().name(MICROSCHEMA_FIELD_TYPE).description("List of schema fields");
+
+		// .name
+		fieldListBuilder.field(newFieldDefinition().name("name").type(GraphQLString).description("Name of the field"));
+
+		// .label
+		fieldListBuilder.field(newFieldDefinition().name("label").type(GraphQLString).description("Label of the field"));
+
+		// .required
+		fieldListBuilder.field(newFieldDefinition().name("required").type(GraphQLBoolean).description("Whether this field is required"));
+
+		// .type
+		fieldListBuilder.field(newFieldDefinition().name("type").type(GraphQLString).description("The type of the field"));
+		// TODO add "allow" and "indexSettings"
+
+		GraphQLOutputType type = GraphQLList.list(fieldListBuilder.build());
+
+		// .fields
+		schemaType.field(newFieldDefinition().name("fields").type(type).dataFetcher(env -> {
+			List<FieldSchema> fields = loadModelWithFallback(env).getFields();
+			if (fields.isEmpty()) {
+				fields = Collections.singletonList(emptySchemaFieldDummy("This microschema has no fields. Do not use this filter."));
+			}
+			return fields;
+		}));
 
 		return schemaType.build();
 	}
 
+	private MicroschemaModelImpl loadModelWithFallback(DataFetchingEnvironment env) {
+		Object source = env.getSource();
+		if (source instanceof HibMicroschema) {
+			HibMicroschema schema = env.getSource();
+			MicroschemaModelImpl model = JsonUtil.readValue(schema.getLatestVersion().getJson(), MicroschemaModelImpl.class);
+			return model;
+		}
+		if (source instanceof HibMicroschemaVersion) {
+			HibMicroschemaVersion schema = env.getSource();
+			MicroschemaModelImpl model = JsonUtil.readValue(schema.getJson(), MicroschemaModelImpl.class);
+			return model;
+		}
+		log.error("Invalid type {" + source + "}.");
+		return null;
+	}
 }

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
@@ -812,53 +812,55 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 			root.name(schema.getName());
 			root.description(schema.getDescription());
 
-			GraphQLFieldDefinition.Builder fieldsField = GraphQLFieldDefinition.newFieldDefinition();
-			GraphQLObjectType.Builder fieldsType = newObject();
-			fieldsType.name(nodeTypeName(schema.getName()));
-			fieldsField.dataFetcher(env -> {
-				NodeContent content = env.getSource();
-				return content.getContainer();
-			});
+			if (!schema.getFields().isEmpty()) {
+				GraphQLFieldDefinition.Builder fieldsField = GraphQLFieldDefinition.newFieldDefinition();
+				GraphQLObjectType.Builder fieldsType = newObject();
+				fieldsType.name(nodeTypeName(schema.getName()));
+				fieldsField.dataFetcher(env -> {
+					NodeContent content = env.getSource();
+					return content.getContainer();
+				});
 
-			// TODO add link resolving argument / code
-			for (FieldSchema fieldSchema : schema.getFields()) {
-				FieldTypes type = FieldTypes.valueByName(fieldSchema.getType());
-				switch (type) {
-				case STRING:
-					fieldsType.field(fields.createStringDef(fieldSchema));
-					break;
-				case HTML:
-					fieldsType.field(fields.createHtmlDef(fieldSchema));
-					break;
-				case NUMBER:
-					fieldsType.field(fields.createNumberDef(fieldSchema));
-					break;
-				case DATE:
-					fieldsType.field(fields.createDateDef(fieldSchema));
-					break;
-				case BOOLEAN:
-					fieldsType.field(fields.createBooleanDef(fieldSchema));
-					break;
-				case NODE:
-					fieldsType.field(fields.createNodeDef(fieldSchema));
-					break;
-				case BINARY:
-					fieldsType.field(fields.createBinaryDef(fieldSchema));
-					break;
-				case S3BINARY:
-					root.field(fields.createS3BinaryDef(fieldSchema));
-					break;
-				case LIST:
-					ListFieldSchema listFieldSchema = ((ListFieldSchema) fieldSchema);
-					fieldsType.field(fields.createListDef(context, listFieldSchema));
-					break;
-				case MICRONODE:
-					fieldsType.field(fields.createMicronodeDef(fieldSchema, project));
-					break;
+				// TODO add link resolving argument / code
+				for (FieldSchema fieldSchema : schema.getFields()) {
+					FieldTypes type = FieldTypes.valueByName(fieldSchema.getType());
+					switch (type) {
+					case STRING:
+						fieldsType.field(fields.createStringDef(fieldSchema));
+						break;
+					case HTML:
+						fieldsType.field(fields.createHtmlDef(fieldSchema));
+						break;
+					case NUMBER:
+						fieldsType.field(fields.createNumberDef(fieldSchema));
+						break;
+					case DATE:
+						fieldsType.field(fields.createDateDef(fieldSchema));
+						break;
+					case BOOLEAN:
+						fieldsType.field(fields.createBooleanDef(fieldSchema));
+						break;
+					case NODE:
+						fieldsType.field(fields.createNodeDef(fieldSchema));
+						break;
+					case BINARY:
+						fieldsType.field(fields.createBinaryDef(fieldSchema));
+						break;
+					case S3BINARY:
+						root.field(fields.createS3BinaryDef(fieldSchema));
+						break;
+					case LIST:
+						ListFieldSchema listFieldSchema = ((ListFieldSchema) fieldSchema);
+						fieldsType.field(fields.createListDef(context, listFieldSchema));
+						break;
+					case MICRONODE:
+						fieldsType.field(fields.createMicronodeDef(fieldSchema, project));
+						break;
+					}
 				}
+				fieldsField.name("fields").type(fieldsType);
+				root.field(fieldsField);
 			}
-			fieldsField.name("fields").type(fieldsType);
-			root.field(fieldsField);
 			root.fields(createNodeInterfaceFields(context).forVersion(context));
 			interfaceTypeProvider.addCommonFields(root, true);
 			return root.build();

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/SchemaTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/SchemaTypeProvider.java
@@ -6,6 +6,7 @@ import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -13,8 +14,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.gentics.mesh.core.data.HibNamedElement;
-import com.gentics.mesh.core.data.HibNodeFieldContainer;
-import com.gentics.mesh.core.data.dao.ContentDao;
 import com.gentics.mesh.core.data.dao.NodeDao;
 import com.gentics.mesh.core.data.dao.SchemaDao;
 import com.gentics.mesh.core.data.node.NodeContent;
@@ -22,6 +21,7 @@ import com.gentics.mesh.core.data.schema.HibSchema;
 import com.gentics.mesh.core.data.schema.HibSchemaVersion;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
+import com.gentics.mesh.core.rest.schema.FieldSchema;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 import com.gentics.mesh.core.rest.schema.impl.SchemaModelImpl;
 import com.gentics.mesh.etc.config.MeshOptions;
@@ -75,6 +75,12 @@ public class SchemaTypeProvider extends AbstractTypeProvider {
 		// .filter(it -> gc.getUser().hasPermission(it, GraphPermission.READ_PERM)).collect(Collectors.toList());
 		// }, PROJECT_REFERENCE_PAGE_TYPE_NAME));
 
+		// .isEmpty
+		schemaType.field(newFieldDefinition().name("isEmpty").type(GraphQLBoolean).dataFetcher((env) -> {
+			SchemaVersionModel model = loadModelWithFallback(env);
+			return model == null || model.getFields() == null || model.getFields().isEmpty();
+		}));
+
 		// .isContainer
 		schemaType.field(newFieldDefinition().name("isContainer").type(GraphQLBoolean).dataFetcher((env) -> {
 			SchemaVersionModel model = loadModelWithFallback(env);
@@ -103,7 +109,6 @@ public class SchemaTypeProvider extends AbstractTypeProvider {
 		schemaType
 			.field(newPagingFieldWithFetcherBuilder("nodes", "Load nodes with this schema", env -> {
 				Tx tx = Tx.get();
-				ContentDao contentDao = tx.contentDao();
 				NodeDao nodeDao = tx.nodeDao();
 				GraphQLContext gc = env.getContext();
 				List<String> languageTags = getLanguageArgument(env);
@@ -134,7 +139,13 @@ public class SchemaTypeProvider extends AbstractTypeProvider {
 		GraphQLOutputType type = GraphQLList.list(fieldListBuilder.build());
 
 		// .fields
-		schemaType.field(newFieldDefinition().name("fields").type(type).dataFetcher(env -> loadModelWithFallback(env).getFields()));
+		schemaType.field(newFieldDefinition().name("fields").type(type).dataFetcher(env -> {
+			List<FieldSchema> fields = loadModelWithFallback(env).getFields();
+			if (fields.isEmpty()) {
+				fields = Collections.singletonList(emptySchemaFieldDummy("This schema has no fields. Do not use this filter."));
+			}
+			return fields;
+		}));
 
 		return schemaType.build();
 	}

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/MicronodeFieldTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/field/MicronodeFieldTypeProvider.java
@@ -189,45 +189,47 @@ public class MicronodeFieldTypeProvider extends AbstractTypeProvider {
 				microschemaType.name(microschemaName);
 				microschemaType.description(microschemaModel.getDescription());
 
-				GraphQLFieldDefinition.Builder fieldsField = newFieldDefinition();
-				Builder fieldsType = newObject();
-				fieldsType.name(nodeTypeName(microschemaName));
-				fieldsField.dataFetcher(micronodeFetcher(Function.identity()));
+				if (!microschemaModel.getFields().isEmpty()) {
+					GraphQLFieldDefinition.Builder fieldsField = newFieldDefinition();
+					Builder fieldsType = newObject();
+					fieldsType.name(nodeTypeName(microschemaName));
+					fieldsField.dataFetcher(micronodeFetcher(Function.identity()));
 
-				for (FieldSchema fieldSchema : microschemaModel.getFields()) {
-					FieldTypes type = FieldTypes.valueByName(fieldSchema.getType());
-					switch (type) {
-					case STRING:
-						fieldsType.field(fields.get().createStringDef(fieldSchema));
-						break;
-					case HTML:
-						fieldsType.field(fields.get().createHtmlDef(fieldSchema));
-						break;
-					case NUMBER:
-						fieldsType.field(fields.get().createNumberDef(fieldSchema));
-						break;
-					case DATE:
-						fieldsType.field(fields.get().createDateDef(fieldSchema));
-						break;
-					case BOOLEAN:
-						fieldsType.field(fields.get().createBooleanDef(fieldSchema));
-						break;
-					case NODE:
-						fieldsType.field(fields.get().createNodeDef(fieldSchema));
-						break;
-					case LIST:
-						ListFieldSchema listFieldSchema = ((ListFieldSchema) fieldSchema);
-						fieldsType.field(fields.get().createListDef(context, listFieldSchema));
-						break;
-					default:
-						log.error("Micronode field type {" + type + "} is not supported.");
-						// TODO throw exception for unsupported type
-						break;
+					for (FieldSchema fieldSchema : microschemaModel.getFields()) {
+						FieldTypes type = FieldTypes.valueByName(fieldSchema.getType());
+						switch (type) {
+						case STRING:
+							fieldsType.field(fields.get().createStringDef(fieldSchema));
+							break;
+						case HTML:
+							fieldsType.field(fields.get().createHtmlDef(fieldSchema));
+							break;
+						case NUMBER:
+							fieldsType.field(fields.get().createNumberDef(fieldSchema));
+							break;
+						case DATE:
+							fieldsType.field(fields.get().createDateDef(fieldSchema));
+							break;
+						case BOOLEAN:
+							fieldsType.field(fields.get().createBooleanDef(fieldSchema));
+							break;
+						case NODE:
+							fieldsType.field(fields.get().createNodeDef(fieldSchema));
+							break;
+						case LIST:
+							ListFieldSchema listFieldSchema = ((ListFieldSchema) fieldSchema);
+							fieldsType.field(fields.get().createListDef(context, listFieldSchema));
+							break;
+						default:
+							log.error("Micronode field type {" + type + "} is not supported.");
+							// TODO throw exception for unsupported type
+							break;
+						}
+
 					}
-
+					fieldsField.name("fields").type(fieldsType);
+					microschemaType.field(fieldsField);
 				}
-				fieldsField.name("fields").type(fieldsType);
-				microschemaType.field(fieldsField);
 				microschemaType.fields(createMicronodeFields());
 				return microschemaType.build();
 			}).collect(Collectors.toList());


### PR DESCRIPTION
## Abstract

If a microschema with no fields exists in Mesh, the GraphQL metadata request crashes with HTTP500.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
