### PR TITLE
Update Version of OkHttp Client

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -116,7 +116,7 @@
 			<dependency>
 				<groupId>com.squareup.okhttp3</groupId>
 				<artifactId>okhttp</artifactId>
-				<version>3.12.1</version>
+				<version>3.14.9</version>
 			</dependency>
 
 			<!-- SSL -->

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/AbstractMeshRestHttpClient.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/AbstractMeshRestHttpClient.java
@@ -1,6 +1,7 @@
 package com.gentics.mesh.rest.client;
 
 import java.io.InputStream;
+import java.util.Map;
 
 import com.gentics.mesh.core.rest.common.GenericMessageResponse;
 import com.gentics.mesh.core.rest.common.RestModel;
@@ -72,24 +73,21 @@ public abstract class AbstractMeshRestHttpClient implements MeshRestClient {
 	}
 
 	/**
-	 * Prepare the request using the provides information and return a mesh request which is ready to be invoked.
-	 *
-	 * @param method
-	 *            Http method
-	 * @param path
-	 *            Request path
-	 * @param classOfT
-	 *            POJO class for the response
-	 * @param bodyData
-	 *            Buffer which contains the body data which should be send to the server
-	 * @param fileSize
-	 *            Total size of the data in bytes
-	 * @param contentType
-	 *            Content type of the posted data
-	 * @return
+	 * Prepare a request for uploading a file as multipart/form-data
+	 * @param <T> type of the response
+	 * @param method Http method
+	 * @param path Request path
+	 * @param classOfT POJO class for the response
+	 * @param fileName file name
+	 * @param contentType content type
+	 * @param fileData file data as input stream
+	 * @param fileSize file size
+	 * @param fields map containing additional fields which should be contained in the form
+	 * @return request
 	 */
-	abstract public <T> MeshRequest<T> prepareRequest(HttpMethod method, String path, Class<? extends T> classOfT, InputStream bodyData,
-		long fileSize, String contentType);
+	abstract public <T> MeshRequest<T> prepareFileuploadRequest(HttpMethod method, String path,
+			Class<? extends T> classOfT, String fileName, String contentType, InputStream fileData, long fileSize,
+			Map<String, String> fields);
 
 	/**
 	 * Prepare the request using the provides information and return a mesh request which is ready to be invoked.

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
@@ -37,6 +37,8 @@ import okhttp3.Cookie;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.MultipartBody.Builder;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -76,35 +78,31 @@ public class MeshOkHttpRequestImpl<T> implements MeshRequest<T> {
 	}
 
 	/**
-	 * Create a new binary request.
-	 * 
-	 * @param <T>
-	 *            Response type
-	 * @param meshClient
-	 *            Mesh Client
-	 * @param client
-	 *            Client to be used
-	 * @param config
-	 *            Configuration
-	 * @param method
-	 *            Request method
-	 * @param url
-	 *            Request url
-	 * @param headers
-	 *            Additional headers
-	 * @param classOfT
-	 *            Response model class
-	 * @param data
-	 *            stream for the binary data
-	 * @param fileSize
-	 *            expected length of the data
-	 * @param contentType
-	 *            Posted content type
-	 * @return
+	 * Create a {@link MeshOkHttpRequestImpl} using the request parameters that sends a multipart/form-data request for uploading a file
+	 * @param <T> type of the response
+	 * @param meshClient mesh client
+	 * @param client okhttp client
+	 * @param config client configuration
+	 * @param method request method
+	 * @param url request url
+	 * @param headers request headers
+	 * @param classOfT class of the response
+	 * @param fileName file name
+	 * @param contentType content type
+	 * @param fileData file data
+	 * @param fileSize file size
+	 * @param fields additional fields to be contained in the form
+	 * @return request implementation
 	 */
-	public static <T> MeshOkHttpRequestImpl<T> BinaryRequest(MeshRestClient meshClient, OkHttpClient client, MeshRestClientConfig config, String method, String url, Map<String, String> headers,
-		Class<? extends T> classOfT, InputStream data, long fileSize, String contentType) {
-		return new MeshOkHttpRequestImpl<>(meshClient, client, config, classOfT, method, url, headers, new RequestBody() {
+	public static <T> MeshOkHttpRequestImpl<T> FileUploadRequest(MeshRestClient meshClient, OkHttpClient client, MeshRestClientConfig config, String method, String url, Map<String, String> headers,
+		Class<? extends T> classOfT, String fileName, String contentType, InputStream fileData, long fileSize, Map<String, String> fields) {
+		// create request body containing the file
+		RequestBody fileBody = new RequestBody() {
+			@Override
+			public long contentLength() throws IOException {
+				return fileSize;
+			}
+
 			@Override
 			public MediaType contentType() {
 				return MediaType.get(contentType);
@@ -113,12 +111,24 @@ public class MeshOkHttpRequestImpl<T> implements MeshRequest<T> {
 			@Override
 			public void writeTo(BufferedSink sink) throws IOException {
 				try {
-					sink.writeAll(Okio.source(data));
+					sink.writeAll(Okio.source(fileData));
 				} finally {
-					data.close();
+					fileData.close();
 				}
 			}
-		});
+		};
+
+		// build request body for the whole request
+		Builder builder = new MultipartBody.Builder()
+			.setType(MultipartBody.FORM)
+			.addFormDataPart("shohY6d", fileName, fileBody);
+		if (fields != null) {
+			fields.entrySet().forEach(entry -> {
+				builder.addFormDataPart(entry.getKey(), entry.getValue());
+			});
+		}
+
+		return new MeshOkHttpRequestImpl<>(meshClient, client, config, classOfT, method, url, headers, builder.build());
 	}
 
 	/**

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestOkHttpClientImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshRestOkHttpClientImpl.java
@@ -30,9 +30,10 @@ public class MeshRestOkHttpClientImpl extends MeshRestHttpClientImpl {
 	}
 
 	@Override
-	public <T> MeshRequest<T> prepareRequest(HttpMethod method, String path, Class<? extends T> classOfT, InputStream bodyData, long fileSize,
-		String contentType) {
-		return MeshOkHttpRequestImpl.BinaryRequest(this, client, config, method.name(), getUrl(path), createHeaders(), classOfT, bodyData, fileSize, contentType);
+	public <T> MeshRequest<T> prepareFileuploadRequest(HttpMethod method, String path, Class<? extends T> classOfT,
+			String fileName, String contentType, InputStream fileData, long fileSize, Map<String, String> fields) {
+		return MeshOkHttpRequestImpl.FileUploadRequest(this, client, config, method.name(), getUrl(path),
+				createHeaders(), classOfT, fileName, contentType, fileData, fileSize, fields);
 	}
 
 	@Override


### PR DESCRIPTION
Reimplement file upload to properly send the Content-Length header

## Abstract

When sending http/2 requests to the server, the bodyhandler either expects the transfer-encoding header to be set (which is forbidden in http/2) or the Content-Length header to be set.
With the previous implementation for uploading files, it was impossible to set the Content-Length header, which resulted in the body handler to completely ignore the body.

## Checklist

### General

* [x] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
