### PR TITLE
Hotfix sup 15750

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.15]]
+== 1.10.15 (TBD)
+
+icon:check[] Core: When running in the massive concurrent publishing process, it is possible to run into a race condition when some field containers are already processed while being referenced by the edge, 
+throwing an NPE. This has now been fixed.
+
 [[v1.10.14]]
 == 1.10.14 (04.09.2023)
 

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
@@ -1950,11 +1950,15 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 		HibNodeFieldContainerEdge edge = contentDao.getEdge(node, languageTag, branchUuid, PUBLISHED);
 		if (edge != null) {
 			HibNodeFieldContainer oldPublishedContainer = contentDao.getFieldContainerOfEdge(edge);
-			oldUrlFieldValues = contentDao.getUrlFieldValues(oldPublishedContainer).collect(Collectors.toSet());
-			contentDao.removeEdge(edge);
-			contentDao.updateWebrootPathInfo(oldPublishedContainer, branchUuid, "node_conflicting_segmentfield_publish", true);
-			if (ac.isPurgeAllowed() && isAutoPurgeEnabled && contentDao.isPurgeable(oldPublishedContainer)) {
-				contentDao.purge(oldPublishedContainer);
+			if (oldPublishedContainer != null) {
+				oldUrlFieldValues = contentDao.getUrlFieldValues(oldPublishedContainer).collect(Collectors.toSet());
+				contentDao.removeEdge(edge);
+				contentDao.updateWebrootPathInfo(oldPublishedContainer, branchUuid, "node_conflicting_segmentfield_publish", true);
+				if (ac.isPurgeAllowed() && isAutoPurgeEnabled && contentDao.isPurgeable(oldPublishedContainer)) {
+					contentDao.purge(oldPublishedContainer);
+				}
+			} else {
+				contentDao.removeEdge(edge);
 			}
 		}
 		if (ac.isPurgeAllowed()) {


### PR DESCRIPTION
## Abstract

When running in the massive concurrent publishing process, it is possible to run into a race condition when some field containers are already processed while being referenced by the edge, 
throwing an NPE.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
