### PR TITLE
SUP-15795: More potential NPEs at the node reference fields healed

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.16]]
+== 1.10.16 (04.10.2023)
+
+icon:check[] Core: More NPE occurrences during the massive concurrent publishing process have been fixes.
+
 [[v1.10.15]]
 == 1.10.15 (20.09.2023)
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerTransformer.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerTransformer.java
@@ -266,7 +266,10 @@ public class NodeContainerTransformer extends AbstractTransformer<HibNodeFieldCo
 						if (graphNodeList != null) {
 							List<String> nodeItems = new ArrayList<>();
 							for (HibNodeField listItem : graphNodeList.getList()) {
-								nodeItems.add(listItem.getNode().getUuid());
+								HibNode node = listItem.getNode();
+								if (node != null) {
+									nodeItems.add(node.getUuid());
+								}
 							}
 							fieldsMap.put(fieldSchema.getName(), nodeItems);
 						}

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
@@ -580,7 +580,7 @@ public interface HibFieldContainer extends HibBasicFieldContainer {
 				.map(listField -> listField.getList().stream())
 				.orElseGet(Stream::empty)
 				.map(HibNodeField::getNode)
-				.filter(n -> n != null);
+				.filter(Objects::nonNull);
 		} else if (type.equals(FieldTypes.MICRONODE.toString())) {
 			return Optional.ofNullable(getMicronodeList(list.getName()))
 				.map(listField -> listField.getList().stream())

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/node/field/RestUpdaters.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/node/field/RestUpdaters.java
@@ -627,7 +627,12 @@ public class RestUpdaters {
 			if (log.isDebugEnabled()) {
 				log.debug("Adding item {" + item.getUuid() + "} at position {" + pos + "}");
 			}
-			graphNodeFieldList.addItem(graphNodeFieldList.createNode(pos, node));
+			HibNodeField nodeItem = graphNodeFieldList.createNode(pos, node);
+			if (nodeItem != null) {
+				graphNodeFieldList.addItem(nodeItem);
+			} else {
+				log.warn("The referenced node {" + item.getUuid() + "} does not exist for the field {" + fieldKey + "} of schema {" + schema.getName() + "}");
+			}
 		}
 
 	};


### PR DESCRIPTION
## Abstract

Massive parallel publishing causes NPEs at the node reference fields.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
