### PR TITLE
Per-schema/field configuration for Elasticsearch indexing

### DIFF
--- a/changelog/src/changelog/entries/2023/10/7574.GPU-676.enhancement
+++ b/changelog/src/changelog/entries/2023/10/7574.GPU-676.enhancement
@@ -1,0 +1,2 @@
+Search: Several enhancements have been applied to the content, sent to the search engine for the indexing. Each (micro)schema is presented a `noIndex` flag, marking the content of the (micro)schema as excluded from the indexing. Each (micro)schema field is presented a similar `noIndex` flag. 
+By default no flag is set, meaning the content to be indexable. This feature serves security purposes, preventing the sensible information from leaking through the search engine. 

--- a/common/src/main/resources/i18n/translations_de.properties
+++ b/common/src/main/resources/i18n/translations_de.properties
@@ -227,6 +227,7 @@ schema_error_invalid_name=Der Schema Name {0} ist ungültig. Es sind nur Buchsta
 schema_delete_still_in_use=Das Schema mit Uuid {0} wird noch von Nodes verwendet. Bitte löschen Sie zuerst diese Nodes.
 schema_error_allowed_list_empty=Die Liste mit erlaubten Microschemas wurde nicht für das Feld {0} angegeben.
 schema_error_index_validation=Die Validierung der Index Einstellungen ist mit der folgenden Meldung fehlgeschlagen:\n{0}
+schema_error_index_disabled=Die Indexierung des Schemas "{0}" wird ausgeschaltet.
 schema_error_change_field_not_found=Das Schemafeld "{0}" in Schema "{1}" für Änderung "{2}" konnte nicht gefunden werden."
 
 microschema_reference_invalid=Es war nicht möglich das Feld {0} zu aktualisieren. Das entsprechende Microschema konnte nicht mittels name oder uuid gefunden werden.
@@ -236,6 +237,7 @@ microschema_conflicting_name=Microschema name "{0}" bereits belegt.
 microschema_delete_still_in_use=Das Microschema mit Uuid {0} wird noch von Micronodes verwendet. Bitte löschen Sie zuerst die Nodes welche diese Micronodes verwenden.
 microschema_validation_successful=Die Microschema Validierung war erfolgreich.
 microschema_error_index_validation=Die Validierung der Index Einstellungen ist mit der folgenden Meldung fehlgeschlagen:\n{0}
+microschema_error_index_disabled=Die Indexierung des Microschemas "{0}" wird ausgeschaltet.
 
 field_html_error_invalid_type=Der Wert des HTML Feldes {0} ist kein Text Wert. Gefundener Wert {1}.
 field_number_error_invalid_type=Der Wert des Nummern Feldes {0} ist keine Zahl. Gefundener Wert {1}.

--- a/common/src/main/resources/i18n/translations_en.properties
+++ b/common/src/main/resources/i18n/translations_en.properties
@@ -225,6 +225,7 @@ schema_error_microschema_reference_no_perm=The schema references the microschema
 schema_delete_still_in_use=There are nodes which use schema {0}. Delete those nodes first.
 schema_error_allowed_list_empty=No allowed microschemas have been specified for microschemaModel field {0}.
 schema_error_index_validation=The index settings validation failed with the following message:\n{0}
+schema_error_index_disabled=The indexing of the schema "{0}" has been disabled.
 schema_error_change_field_not_found=Could not find schema field "{0}" within schema "{1}" for change "{2}".
 schema_error_schema_not_linked_to_branch=The specified schema "{0}" was not linked to branch "{2}" of project "{3}".
 
@@ -235,6 +236,7 @@ microschema_conflicting_name=Microschema name "{0}" already in use.
 microschema_delete_still_in_use=There are micronodes which use the microschemaModel {0}. Delete the nodes which use the micronodes first.
 microschema_validation_successful=Microschema validation was successful.
 microschema_error_index_validation=The index settings validation failed with the following message:\n{0}
+microschema_error_index_disabled=The indexing of the microschema "{0}" has been disabled.
 
 field_html_error_invalid_type=The HTML field value for field {0} is not a text value. The value was {1}.
 field_number_error_invalid_type=The Number field value for field {0} is not a number value. The value was {1}.

--- a/common/src/main/resources/i18n/translations_zh.properties
+++ b/common/src/main/resources/i18n/translations_zh.properties
@@ -216,6 +216,7 @@ schema_error_microschema_reference_no_perm=数据模型通过缺少读取权限�
 schema_delete_still_in_use=有一些节点使用了数据模型{0}。首先删除那些节点。
 schema_error_allowed_list_empty=没有为字段{0}指定允许的内嵌数据模型。
 schema_error_index_validation=索引设置验证失败，并显示以下消息：\n{0}
+schema_error_index_disabled=架构“{0}”的索引已被禁用。
 schema_error_change_field_not_found=在数据模型“{1}”内找不到更改为“{2}”的数据模型字段“{0}”。
 schema_error_schema_not_linked_to_branch=指定的数据模型“{0}”未链接到项目“{3}”的分支“{2}”。
 
@@ -226,6 +227,7 @@ microschema_conflicting_name=内嵌数据模型名称“{0}”已被使用。
 microschema_delete_still_in_use=存在一些使用内嵌数据模型{0}的内嵌节点。首先删除使用内嵌节点的节点。
 microschema_validation_successful=内嵌数据模型验证成功。
 microschema_error_index_validation=索引设置验证失败，并显示以下消息：\n{0}
+microschema_error_index_disabled=微架构“{0}”的索引已被禁用。
 
 field_html_error_invalid_type=字段{0}的HTML字段值不是文本。该值为{1}。
 field_number_error_invalid_type=字段{0}的“数字”字段值不是数字。该值为{1}。

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/handler/MicroschemaComparatorImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/handler/MicroschemaComparatorImpl.java
@@ -1,5 +1,7 @@
 package com.gentics.mesh.core.data.schema.handler;
 
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.NO_INDEX_KEY;
+
 import java.util.List;
 
 import javax.inject.Inject;
@@ -20,7 +22,12 @@ public class MicroschemaComparatorImpl extends AbstractFieldSchemaContainerCompa
 
 	@Override
 	public List<SchemaChangeModel> diff(MicroschemaModel containerA, MicroschemaModel containerB) {
-		return super.diff(containerA, containerB, MicroschemaModel.class);
+		List<SchemaChangeModel> changes = super.diff(containerA, containerB, MicroschemaModel.class);
+
+		// .noIndex
+		compareAndAddSchemaProperty(changes, NO_INDEX_KEY, containerA.getNoIndex(), containerB.getNoIndex(), MicroschemaModel.class);
+
+		return changes;
 	}
 
 }

--- a/core/src/main/java/com/gentics/mesh/core/data/schema/handler/SchemaComparatorImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/data/schema/handler/SchemaComparatorImpl.java
@@ -4,6 +4,7 @@ import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.AU
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.CONTAINER_FLAG_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.DISPLAY_FIELD_NAME_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.ELASTICSEARCH_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.NO_INDEX_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.SEGMENT_FIELD_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.URLFIELDS_KEY;
 
@@ -44,6 +45,9 @@ public class SchemaComparatorImpl extends AbstractFieldSchemaContainerComparator
 
 		// .autoPurge
 		compareAndAddSchemaProperty(changes, AUTO_PURGE_FLAG_KEY, schemaA.getAutoPurge(), schemaB.getAutoPurge(), SchemaModel.class);
+
+		// .noIndex
+		compareAndAddSchemaProperty(changes, NO_INDEX_KEY, schemaA.getNoIndex(), schemaB.getNoIndex(), SchemaModel.class);
 
 		// .container
 		// Only diff the flag if a value has been set in the schemaB

--- a/doc/src/main/docs/elasticsearch.asciidoc
+++ b/doc/src/main/docs/elasticsearch.asciidoc
@@ -816,3 +816,9 @@ Example:
   ]
 }
 ----
+
+=== Exclude distinct Schemas/Microschemas/Fields from indexing.
+
+By default all the (micro)schemas in Mesh are subject to the indexing. This may be an unwanted behavior in the cases of storing the sensitive data, that should not in any case leave Mesh. For this case every Schema, Microschema and each field definition of those are equipped with the `noIndex` flag, allowing exclusion the target from indexing process, as well as removing the already existing indices. Simply use Mesh REST API or Java client for the management of `noIndex` over schemas, microschemas and fields.
+
+

--- a/doc/src/main/docs/elasticsearch.asciidoc
+++ b/doc/src/main/docs/elasticsearch.asciidoc
@@ -819,6 +819,6 @@ Example:
 
 === Exclude distinct Schemas/Microschemas/Fields from indexing.
 
-By default all the (micro)schemas in Mesh are subject to the indexing. This may be an unwanted behavior in the cases of storing the sensitive data, that should not in any case leave Mesh. For this case every Schema, Microschema and each field definition of those are equipped with the `noIndex` flag, allowing exclusion the target from indexing process, as well as removing the already existing indices. Simply use Mesh REST API or Java client for the management of `noIndex` over schemas, microschemas and fields.
+By default all the (micro)schemas in Mesh are subject to the indexing. This may be an unwanted behavior in the cases of storing the sensitive data, that should not in any case leave Mesh. For this case every Schema, Microschema and each field definition of those are equipped with the `noIndex` flag, allowing the exclusion of the target from the indexing process, as well as removing the already existing indices. Simply use Mesh REST API or Java client for the management of `noIndex` over schemas, microschemas and fields.
 
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/group/GroupIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/group/GroupIndexHandlerImpl.java
@@ -72,10 +72,10 @@ public class GroupIndexHandlerImpl extends AbstractIndexHandler<HibGroup> implem
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		String indexName = HibGroup.composeIndexName();
 		IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "group");
-		return Collections.singletonMap(indexName, info);
+		return Collections.singletonMap(indexName, Optional.of(info));
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/microschema/MicroschemaContainerIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/microschema/MicroschemaContainerIndexHandlerImpl.java
@@ -101,10 +101,10 @@ public class MicroschemaContainerIndexHandlerImpl extends AbstractIndexHandler<H
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		String indexName = HibMicroschema.composeIndexName();
 		IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "microschema");
-		return Collections.singletonMap(indexName, info);
+		return Collections.singletonMap(indexName, Optional.of(info));
 	}
 
 }

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
@@ -67,12 +67,17 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 	}
 
 	@Override
-	public JsonObject getMapping(SchemaModel schema) {
+	public Optional<JsonObject> getMapping(SchemaModel schema) {
 		return getMapping(schema, null, null);
 	}
 
 	@Override
-	public JsonObject getMapping(SchemaModel schema, HibBranch branch, String language) {
+	public Optional<JsonObject> getMapping(SchemaModel schema, HibBranch branch, String language) {
+		// 0. 'no index' schema flag check
+		if (schema.getNoIndex() != null && schema.getNoIndex()) {
+			return Optional.empty();
+		}
+
 		// 1. Get the common type specific mapping
 		JsonObject mapping = getMapping();
 
@@ -158,10 +163,10 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 
 		switch (complianceMode) {
 		case ES_7:
-			return typeMapping;
+			return Optional.of(typeMapping);
 		case ES_6:
 			mapping.put(DEFAULT_TYPE, typeMapping);
-			return mapping;
+			return Optional.of(mapping);
 		default:
 			throw new RuntimeException("Unknown compliance mode {" + complianceMode + "}");
 		}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
@@ -483,7 +483,7 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 
 				// Check if the microschema is contained in the whitelist
 				// and ignore it if it isn't
-				if (!whitelist.contains(microschemaName)) {
+				if (!whitelist.contains(microschemaName) || (microschema.getNoIndex() != null && microschema.getNoIndex())) {
 					continue;
 				}
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeIndexHandlerImpl.java
@@ -126,9 +126,9 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		return db.tx(tx -> {
-			Map<String, IndexInfo> indexInfo = new HashMap<>();
+			Map<String, Optional<IndexInfo>> indexInfo = new HashMap<>();
 
 			// Iterate over all projects and construct the index names
 			for (HibProject project : tx.projectDao().findAll()) {
@@ -149,9 +149,9 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	 * @param branch
 	 * @return
 	 */
-	public Transactional<Map<String, IndexInfo>> getIndices(HibProject project, HibBranch branch) {
+	public Transactional<Map<String, Optional<IndexInfo>>> getIndices(HibProject project, HibBranch branch) {
 		return db.transactional(tx -> {
-			Map<String, IndexInfo> indexInfo = new HashMap<>();
+			Map<String, Optional<IndexInfo>> indexInfo = new HashMap<>();
 			// Each branch specific index has also document type specific mappings
 			for (HibSchemaVersion containerVersion : branch.findActiveSchemaVersions()) {
 				indexInfo.putAll(getIndices(project, branch, containerVersion).runInExistingTx(tx));
@@ -168,7 +168,7 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	 * @param containerVersion
 	 * @return
 	 */
-	public Transactional<Map<String, IndexInfo>> getIndices(HibProject project, HibBranch branch, HibSchemaVersion containerVersion) {
+	public Transactional<Map<String, Optional<IndexInfo>>> getIndices(HibProject project, HibBranch branch, HibSchemaVersion containerVersion) {
 		return getIndices(project, branch, containerVersion, Collections.emptyMap());
 	}
 
@@ -182,9 +182,9 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	 * @param replacementMap map of microschema names to microschema version uuids (may be empty, but not null)
 	 * @return transactional
 	 */
-	public Transactional<Map<String, IndexInfo>> getIndices(HibProject project, HibBranch branch, HibSchemaVersion containerVersion, Map<String, String> replacementMap) {
+	public Transactional<Map<String, Optional<IndexInfo>>> getIndices(HibProject project, HibBranch branch, HibSchemaVersion containerVersion, Map<String, String> replacementMap) {
 		return db.transactional(tx -> {
-			Map<String, IndexInfo> indexInfos = new HashMap<>();
+			Map<String, Optional<IndexInfo>> indexInfos = new HashMap<>();
 			SchemaVersionModel schema = containerVersion.getSchema();
 
 			// Add all language specific indices (might be none)
@@ -192,7 +192,7 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 				String indexName = ContentDao.composeIndexName(project.getUuid(), branch.getUuid(), containerVersion
 					.getUuid(), version, language, containerVersion.getMicroschemaVersionHash(branch, replacementMap));
 				log.debug("Adding index to map of known indices {" + indexName + "}");
-				// Load the index mapping information for the index
+				// Load the index mapping information for the index, if applicable
 				indexInfos.put(indexName, createIndexInfo(branch, schema, language, indexName, schema.getName() + "@" + schema.getVersion()));
 			}));
 
@@ -201,7 +201,7 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 				String indexName = ContentDao.composeIndexName(project.getUuid(), branch.getUuid(), containerVersion
 					.getUuid(), version, null, containerVersion.getMicroschemaVersionHash(branch, replacementMap));
 				log.debug("Adding index to map of known indices {" + indexName + "}");
-				// Load the index mapping information for the index
+				// Load the index mapping information for the index, if applicable
 				indexInfos.put(indexName, createIndexInfo(branch, schema, null, indexName, schema.getName() + "@" + schema.getVersion()));
 			});
 			return indexInfos;
@@ -278,12 +278,14 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	 *            Human readable name of the source of the index settings (often used for debug information)
 	 * @return
 	 */
-	public IndexInfo createIndexInfo(HibBranch branch, SchemaModel schema, String language, String indexName, String sourceInfo) {
-		JsonObject mapping = getMappingProvider().getMapping(schema, branch, language);
-		JsonObject settings = language == null
-			? getDefaultSetting(schema.getElasticsearch())
-			: getLanguageOverride(schema.getElasticsearch(), language);
-		return new IndexInfo(indexName, settings, mapping, sourceInfo);
+	public Optional<IndexInfo> createIndexInfo(HibBranch branch, SchemaModel schema, String language, String indexName, String sourceInfo) {
+		Optional<JsonObject> maybeMapping = getMappingProvider().getMapping(schema, branch, language);
+		return maybeMapping.map(mapping -> {
+			JsonObject settings = language == null
+					? getDefaultSetting(schema.getElasticsearch())
+					: getLanguageOverride(schema.getElasticsearch(), language);
+			return new IndexInfo(indexName, settings, mapping, sourceInfo);
+		});
 	}
 
 	@Override
@@ -571,7 +573,7 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 			return Flowable.fromIterable(schema.findOverriddenSearchLanguages()::iterator);
 		}).map(language -> createDummyIndexInfo(schema, language))
 			.startWith(createDummyIndexInfo(schema, null))
-			.flatMapCompletable(searchProvider::validateCreateViaTemplate);
+			.flatMapCompletable(ii -> ii.map(searchProvider::validateCreateViaTemplate).orElse(Completable.complete()));
 	}
 
 	/**
@@ -580,7 +582,7 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	 * @param schema
 	 * @return
 	 */
-	public JsonObject createIndexSettings(SchemaModel schema) {
+	public Optional<JsonObject> createIndexSettings(SchemaModel schema) {
 		return createIndexSettings(schema, null);
 	}
 
@@ -590,11 +592,11 @@ public class NodeIndexHandlerImpl extends AbstractIndexHandler<HibNode> implemen
 	 * @param schema
 	 * @return
 	 */
-	public JsonObject createIndexSettings(SchemaModel schema, String language) {
-		return searchProvider.createIndexSettings(createDummyIndexInfo(schema, language));
+	public Optional<JsonObject> createIndexSettings(SchemaModel schema, String language) {
+		return createDummyIndexInfo(schema, language).map(searchProvider::createIndexSettings);
 	}
 
-	private IndexInfo createDummyIndexInfo(SchemaModel schema, String language) {
+	private Optional<IndexInfo> createDummyIndexInfo(SchemaModel schema, String language) {
 		String indexName = language != null
 			? "validationDummy-" + language
 			: "validationDummy";

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/project/ProjectIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/project/ProjectIndexHandlerImpl.java
@@ -101,10 +101,10 @@ public class ProjectIndexHandlerImpl extends AbstractIndexHandler<HibProject> im
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		String indexName = HibProject.composeIndexName();
 		IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "project");
-		return Collections.singletonMap(indexName, info);
+		return Collections.singletonMap(indexName, Optional.of(info));
 	}
 
 }

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/role/RoleIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/role/RoleIndexHandlerImpl.java
@@ -73,10 +73,10 @@ public class RoleIndexHandlerImpl extends AbstractIndexHandler<HibRole>  impleme
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		String indexName = HibRole.composeIndexName();
 		IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "role");
-		return Collections.singletonMap(indexName, info);
+		return Collections.singletonMap(indexName, Optional.of(info));
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/schema/SchemaContainerIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/schema/SchemaContainerIndexHandlerImpl.java
@@ -88,10 +88,10 @@ public class SchemaContainerIndexHandlerImpl extends AbstractIndexHandler<HibSch
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		String indexName = HibSchema.composeIndexName();
 		IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "schema");
-		return Collections.singletonMap(indexName, info);
+		return Collections.singletonMap(indexName, Optional.of(info));
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/tag/TagIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/tag/TagIndexHandlerImpl.java
@@ -82,12 +82,12 @@ public class TagIndexHandlerImpl extends AbstractIndexHandler<HibTag> implements
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		return db.tx(tx -> {
-			Map<String, IndexInfo> indexInfo = new HashMap<>();
+			Map<String, Optional<IndexInfo>> indexInfo = new HashMap<>();
 			for (HibProject project : tx.projectDao().findAll()) {
 				IndexInfo info = getIndex(project.getUuid());
-				indexInfo.put(info.getIndexName(), info);
+				indexInfo.put(info.getIndexName(), Optional.of(info));
 			}
 			return indexInfo;
 		});

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/tagfamily/TagFamilyIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/tagfamily/TagFamilyIndexHandlerImpl.java
@@ -77,13 +77,13 @@ public class TagFamilyIndexHandlerImpl extends AbstractIndexHandler<HibTagFamily
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		return db.tx(tx -> {
-			Map<String, IndexInfo> indexInfo = new HashMap<>();
+			Map<String, Optional<IndexInfo>> indexInfo = new HashMap<>();
 			for (HibProject project : tx.projectDao().findAll()) {
 				String indexName = HibTagFamily.composeIndexName(project.getUuid());
 				IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "tagFamily");
-				indexInfo.put(indexName, info);
+				indexInfo.put(indexName, Optional.of(info));
 			}
 			return indexInfo;
 		});

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/user/UserIndexHandlerImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/user/UserIndexHandlerImpl.java
@@ -100,9 +100,9 @@ public class UserIndexHandlerImpl extends AbstractIndexHandler<HibUser> implemen
 	}
 
 	@Override
-	public Map<String, IndexInfo> getIndices() {
+	public Map<String, Optional<IndexInfo>> getIndices() {
 		String indexName = HibUser.composeIndexName();
 		IndexInfo info = new IndexInfo(indexName, null, getMappingProvider().getMapping(), "user");
-		return Collections.singletonMap(indexName, info);
+		return Collections.singletonMap(indexName, Optional.of(info));
 	}
 }

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/BranchEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/BranchEventHandler.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.search.verticle.eventhandler.Util.toRequests;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -50,7 +51,7 @@ public class BranchEventHandler implements EventHandler {
 				//TODO Implement the drop of the node indices. We need to drop all indices of the branch.
 				return Flowable.empty();
 			} else {
-				Map<String, IndexInfo> map = helper.getDb().transactional(tx -> {
+				Map<String, Optional<IndexInfo>> map = helper.getDb().transactional(tx -> {
 					HibProject project = tx.projectDao().findByUuid(model.getProject().getUuid());
 					HibBranch branch = tx.branchDao().findByUuid(project, model.getUuid());
 					return nodeIndexHandler.getIndices(project, branch).runInExistingTx(tx);

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/MicroschemaMigrationEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/MicroschemaMigrationEventHandler.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -96,11 +97,11 @@ public class MicroschemaMigrationEventHandler implements EventHandler {
 	 */
 	private Flowable<? extends SearchRequest> migrationStart(BranchMicroschemaAssignModel model) {
 		// get all schemas "using" the microschema (in the project/branch) and create schema create requests
-		Pair<Map<String, IndexInfo>, List<Triple<String, String, JsonObject>>> info = helper.getDb().transactional(tx -> {
+		Pair<Map<String, Optional<IndexInfo>>, List<Triple<String, String, JsonObject>>> info = helper.getDb().transactional(tx -> {
 			HibProject project = tx.projectDao().findByUuid(model.getProject().getUuid());
 			HibBranch branch = tx.branchDao().findByUuid(project, model.getBranch().getUuid());
 			HibMicroschema microschema = tx.microschemaDao().findByUuid(model.getSchema().getUuid());
-			Map<String, IndexInfo> indexMap = branch.findAllSchemaVersions().stream().filter(version -> version.usesMicroschema(microschema))
+			Map<String, Optional<IndexInfo>> indexMap = branch.findAllSchemaVersions().stream().filter(version -> version.usesMicroschema(microschema))
 					.map(version -> nodeIndexHandler.getIndices(project, branch, version).runInExistingTx(tx))
 					.collect(HashMap::new, HashMap::putAll, HashMap::putAll);
 

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/SchemaMigrationEventHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/SchemaMigrationEventHandler.java
@@ -9,6 +9,7 @@ import static com.gentics.mesh.search.verticle.eventhandler.Util.toRequests;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -90,7 +91,7 @@ public class SchemaMigrationEventHandler implements EventHandler {
 	 * @return
 	 */
 	public Flowable<SearchRequest> migrationStart(BranchSchemaAssignEventModel model) {
-		Map<String, IndexInfo> map = helper.getDb().transactional(tx -> {
+		Map<String, Optional<IndexInfo>> map = helper.getDb().transactional(tx -> {
 			HibProject project = tx.projectDao().findByUuid(model.getProject().getUuid());
 			HibBranch branch = tx.branchDao().findByUuid(project, model.getBranch().getUuid());
 			HibSchemaVersion schema = getNewSchemaVersion(model).runInExistingTx(tx);

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/Util.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/eventhandler/Util.java
@@ -1,13 +1,5 @@
 package com.gentics.mesh.search.verticle.eventhandler;
 
-import com.gentics.mesh.core.data.search.index.IndexInfo;
-import com.gentics.mesh.core.data.search.request.CreateIndexRequest;
-import com.gentics.mesh.core.data.search.request.SearchRequest;
-import com.gentics.mesh.core.rest.common.ContainerType;
-import io.reactivex.Flowable;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-
 import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -20,6 +12,16 @@ import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.gentics.mesh.core.data.search.index.IndexInfo;
+import com.gentics.mesh.core.data.search.request.CreateIndexRequest;
+import com.gentics.mesh.core.data.search.request.DropIndexRequest;
+import com.gentics.mesh.core.data.search.request.SearchRequest;
+import com.gentics.mesh.core.rest.common.ContainerType;
+
+import io.reactivex.Flowable;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Various static utility functions
@@ -126,9 +128,11 @@ public final class Util {
 	 * @param map
 	 * @return
 	 */
-	public static Flowable<SearchRequest> toRequests(Map<String, IndexInfo> map) {
-		return Flowable.fromIterable(map.values())
-			.map(CreateIndexRequest::new);
+	public static Flowable<SearchRequest> toRequests(Map<String, Optional<IndexInfo>> map) {
+		return Flowable.fromIterable(map.entrySet())
+			.map(entry -> entry.getValue().map(CreateIndexRequest::new)
+					.map(SearchRequest.class::cast)
+					.orElseGet(() -> new DropIndexRequest(entry.getKey())));
 	}
 
 	/**

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibAddFieldChange.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibAddFieldChange.java
@@ -1,10 +1,7 @@
 package com.gentics.mesh.core.data.schema;
 
 import static com.gentics.mesh.core.rest.error.Errors.error;
-import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.ADD_FIELD_AFTER_KEY;
-import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.ALLOW_KEY;
-import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.LIST_TYPE_KEY;
-import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.TYPE_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import java.util.Collections;
@@ -145,6 +142,15 @@ public interface HibAddFieldChange extends HibSchemaFieldChange {
 	 */
 	default Boolean getRequired() {
 		return getRestProperty(SchemaChangeModel.REQUIRED_KEY);
+	}
+
+	/**
+	 * Get the 'exclude from indexing' flag
+	 * 
+	 * @return flag
+	 */
+	default Boolean getNoIndex() {
+		return getRestProperty(SchemaChangeModel.NO_INDEX_KEY);
 	}
 
 	@Override

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibAddFieldChange.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibAddFieldChange.java
@@ -237,6 +237,10 @@ public interface HibAddFieldChange extends HibSchemaFieldChange {
 		if (required != null) {
 			field.setRequired(required);
 		}
+		Boolean noIndex = getNoIndex();
+		if (noIndex != null) {
+			field.setNoIndex(noIndex);
+		}
 		JsonObject elasticSearch = getIndexOptions();
 		if (elasticSearch != null) {
 			field.setElasticsearch(elasticSearch);

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaContainerUpdateChange.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaContainerUpdateChange.java
@@ -59,6 +59,20 @@ public interface HibFieldSchemaContainerUpdateChange<T extends FieldSchemaContai
 	 */
 	void setName(String name);
 
+	/**
+	 * Return the 'exclude from indexing' flag.
+	 * 
+	 * @return
+	 */
+	Boolean getNoIndex();
+
+	/**
+	 * Set the 'exclude from indexing' flag.
+	 * 
+	 * @param name
+	 */
+	void setNoIndexing(Boolean noIndex);
+
 	@Override
 	default <R extends FieldSchemaContainer> R apply(R container) {
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaContainerUpdateChange.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaContainerUpdateChange.java
@@ -71,7 +71,7 @@ public interface HibFieldSchemaContainerUpdateChange<T extends FieldSchemaContai
 	 * 
 	 * @param name
 	 */
-	void setNoIndexing(Boolean noIndex);
+	void setNoIndex(Boolean noIndex);
 
 	@Override
 	default <R extends FieldSchemaContainer> R apply(R container) {
@@ -92,6 +92,12 @@ public interface HibFieldSchemaContainerUpdateChange<T extends FieldSchemaContai
 		JsonObject options = getIndexOptions();
 		if (options != null) {
 			container.setElasticsearch(options);
+		}
+
+		// .noIndex
+		Boolean noIndex = getNoIndex();
+		if (noIndex != null) {
+			container.setNoIndex(noIndex);
 		}
 
 		// Update the fields if the order changes

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaVersionElement.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaVersionElement.java
@@ -65,6 +65,20 @@ public interface HibFieldSchemaVersionElement<
 	void setJson(String json);
 
 	/**
+	 * Return the 'exclude from indexing' flag, or null.
+	 * 
+	 * @return
+	 */
+	Boolean getNoIndex();
+
+	/**
+	 * Set the 'exclude from indexing' flag.
+	 * 
+	 * @param noIndex
+	 */
+	void setNoIndex(Boolean noIndex);
+
+	/**
 	 * Return the schema version.
 	 * 
 	 * @return
@@ -131,8 +145,18 @@ public interface HibFieldSchemaVersionElement<
 	 */
 	void setNextChange(HibSchemaChange<?> change);
 
+	/**
+	 * Get the version prior to this one, or null.
+	 * 
+	 * @return
+	 */
 	SCV getPreviousVersion();
 
+	/**
+	 * Get the version following this one, or null.
+	 * 
+	 * @return
+	 */
 	SCV getNextVersion();
 
 	/**

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldTypeChange.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldTypeChange.java
@@ -154,6 +154,7 @@ public interface HibFieldTypeChange extends HibSchemaFieldChange {
 					throw error(BAD_REQUEST, "Unknown type {" + newType + "} for change " + getUuid());
 			}
 			field.setRequired(fieldSchema.isRequired());
+			field.setNoIndex(fieldSchema.isNoIndex());
 			field.setLabel(fieldSchema.getLabel());
 			field.setName(fieldSchema.getName());
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/search/IndexHandler.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/search/IndexHandler.java
@@ -82,11 +82,11 @@ public interface IndexHandler<T extends HibBaseElement> {
 	Set<String> filterUnknownIndices(Set<String> indices);
 
 	/**
-	 * Load a map which contains the applicable indices. The key of the map is the index name.
+	 * Load a map which contains the applicable indices. The key of the map is the index name. If the value is empty, the indexing is disabled and has to be removed, if exists.
 	 * 
 	 * @return Map with index information
 	 */
-	Map<String, IndexInfo> getIndices();
+	Map<String, Optional<IndexInfo>> getIndices();
 
 	/**
 	 * Get the names of all indices for searching purposes. The action context will be examined to determine the project scope and the branch scope. If possible

--- a/mdm/api/src/main/java/com/gentics/mesh/core/search/index/node/NodeContainerMappingProvider.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/search/index/node/NodeContainerMappingProvider.java
@@ -1,5 +1,7 @@
 package com.gentics.mesh.core.search.index.node;
 
+import java.util.Optional;
+
 import com.gentics.mesh.core.data.branch.HibBranch;
 import com.gentics.mesh.core.rest.schema.SchemaModel;
 import com.gentics.mesh.search.index.MappingProvider;
@@ -22,7 +24,7 @@ public interface NodeContainerMappingProvider extends MappingProvider {
 	 *            The language override to use
 	 * @return An ES-Mapping for the given Schema in the branch
 	 */
-	JsonObject getMapping(SchemaModel schema, HibBranch branch, String language);
+	Optional<JsonObject> getMapping(SchemaModel schema, HibBranch branch, String language);
 
 	/**
 	 * Return the type specific mapping which is constructed using the provided schema.
@@ -31,6 +33,5 @@ public interface NodeContainerMappingProvider extends MappingProvider {
 	 *            Schema from which the mapping should be constructed
 	 * @return An ES-Mapping for the given Schema
 	 */
-	JsonObject getMapping(SchemaModel schema);
-
+	Optional<JsonObject> getMapping(SchemaModel schema);
 }

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContainerDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContainerDao.java
@@ -120,6 +120,7 @@ public interface PersistingContainerDao<
 			}
 			v.setSchemaContainer(version.getSchemaContainer());
 			v.setName(resultingSchema.getName());
+			v.setNoIndex(resultingSchema.getNoIndex());
 		});
 		
 		version.getSchemaContainer().setName(resultingSchema.getName());

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/schema/handler/AbstractFieldSchemaContainerComparator.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/schema/handler/AbstractFieldSchemaContainerComparator.java
@@ -114,6 +114,7 @@ public abstract class AbstractFieldSchemaContainerComparator<FC extends FieldSch
 				}
 
 				change.setProperty(SchemaChangeModel.REQUIRED_KEY, fieldInB.isRequired());
+				change.setProperty(SchemaChangeModel.NO_INDEX_KEY, fieldInB.isNoIndex());
 
 				if (i - 1 >= 0) {
 					FieldSchema fieldBefore = containerB.getFields().get(i - 1);

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractFieldSchemaContainerUpdateChange.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractFieldSchemaContainerUpdateChange.java
@@ -35,7 +35,7 @@ public abstract class AbstractFieldSchemaContainerUpdateChange<T extends FieldSc
 	}
 
 	@Override
-	public void setNoIndexing(Boolean noIndex) {
+	public void setNoIndex(Boolean noIndex) {
 		setRestProperty(SchemaChangeModel.NO_INDEX_KEY, noIndex);
 	}
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractFieldSchemaContainerUpdateChange.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractFieldSchemaContainerUpdateChange.java
@@ -30,6 +30,16 @@ public abstract class AbstractFieldSchemaContainerUpdateChange<T extends FieldSc
 	}
 
 	@Override
+	public Boolean getNoIndex() {
+		return getRestProperty(SchemaChangeModel.NO_INDEX_KEY);
+	}
+
+	@Override
+	public void setNoIndexing(Boolean noIndex) {
+		setRestProperty(SchemaChangeModel.NO_INDEX_KEY, noIndex);
+	}
+
+	@Override
 	public String getDescription() {
 		return getRestProperty(SchemaChangeModel.DESCRIPTION_KEY);
 	}
@@ -61,6 +71,12 @@ public abstract class AbstractFieldSchemaContainerUpdateChange<T extends FieldSc
 		String name = getName();
 		if (name != null) {
 			container.setName(name);
+		}
+
+		// no index
+		Boolean noIndex = getNoIndex();
+		if (noIndex != null) {
+			container.setNoIndex(noIndex);
 		}
 
 		// .description

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractGraphFieldSchemaContainerVersion.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/schema/impl/AbstractGraphFieldSchemaContainerVersion.java
@@ -101,6 +101,20 @@ public abstract class AbstractGraphFieldSchemaContainerVersion<
 	}
 
 	@Override
+	public Boolean getNoIndex() {
+		return property("noindex");
+	}
+
+	@Override
+	public void setNoIndex(Boolean noIndex) {
+		if (noIndex != null && noIndex) {
+			property("noindex", noIndex);
+		} else {
+			removeProperty("noindex");
+		}
+	}
+
+	@Override
 	public String getJson() {
 		return property("json");
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<projectRoot>${project.basedir}</projectRoot>
 		<mesh.admin-ui.version>0.9.2</mesh.admin-ui.version>
-		<mesh.admin-ui2.version>1.3.6</mesh.admin-ui2.version>
+		<mesh.admin-ui2.version>1.3.7</mesh.admin-ui2.version>
 
 		<dagger.version>2.24</dagger.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<projectRoot>${project.basedir}</projectRoot>
 		<mesh.admin-ui.version>0.9.2</mesh.admin-ui.version>
-		<mesh.admin-ui2.version>1.3.7</mesh.admin-ui2.version>
+		<mesh.admin-ui2.version>1.3.6</mesh.admin-ui2.version>
 
 		<dagger.version>2.24</dagger.version>
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaCreateRequest.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.MicroschemaModel;
 
 import io.vertx.core.json.JsonObject;
@@ -28,6 +29,10 @@ public class MicroschemaCreateRequest implements MicroschemaModel {
 	@JsonPropertyDescription("Additional elasticsearch index configuration. This can be used to setup custom analyzers and filters.")
 	private JsonObject elasticsearch;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' flag.")
+	private Boolean noIndex;
+
 	@JsonPropertyDescription("List of microschema fields")
 	private List<FieldSchema> fields = new ArrayList<>();
 
@@ -39,6 +44,17 @@ public class MicroschemaCreateRequest implements MicroschemaModel {
 	@Override
 	public MicroschemaCreateRequest setDescription(String description) {
 		this.description = description;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaCreateRequest.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.MicroschemaModel;
 
 import io.vertx.core.json.JsonObject;
@@ -53,7 +52,7 @@ public class MicroschemaCreateRequest implements MicroschemaModel {
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public MicroschemaCreateRequest setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaModelImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaModelImpl.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.microschema.MicroschemaVersionModel;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 
 import io.vertx.core.json.JsonObject;
 
@@ -69,7 +68,7 @@ public class MicroschemaModelImpl implements MicroschemaVersionModel {
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public MicroschemaVersionModel setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaModelImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaModelImpl.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.microschema.MicroschemaVersionModel;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 
 import io.vertx.core.json.JsonObject;
 
@@ -36,6 +37,10 @@ public class MicroschemaModelImpl implements MicroschemaVersionModel {
 	@JsonPropertyDescription("List of microschema fields")
 	private List<FieldSchema> fields = new ArrayList<>();
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' flag.")
+	private Boolean noIndex;
+
 	@Override
 	public String getVersion() {
 		return version;
@@ -55,6 +60,17 @@ public class MicroschemaModelImpl implements MicroschemaVersionModel {
 	@Override
 	public MicroschemaVersionModel setDescription(String description) {
 		this.description = description;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaResponse.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.common.AbstractGenericRestResponse;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.MicroschemaModel;
 import com.gentics.mesh.core.rest.schema.MicroschemaReference;
 import com.gentics.mesh.core.rest.schema.impl.MicroschemaReferenceImpl;
@@ -82,7 +81,7 @@ public class MicroschemaResponse extends AbstractGenericRestResponse implements 
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public MicroschemaResponse setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.common.AbstractGenericRestResponse;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.MicroschemaModel;
 import com.gentics.mesh.core.rest.schema.MicroschemaReference;
 import com.gentics.mesh.core.rest.schema.impl.MicroschemaReferenceImpl;
@@ -35,6 +36,10 @@ public class MicroschemaResponse extends AbstractGenericRestResponse implements 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Additional search index configuration. This can be used to setup custom analyzers and filters.")
 	private JsonObject elasticsearch;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' flag.")
+	private Boolean noIndex;
 
 	@JsonProperty(required = true)
 	@JsonPropertyDescription("List of microschema fields")
@@ -68,6 +73,17 @@ public class MicroschemaResponse extends AbstractGenericRestResponse implements 
 	@Override
 	public MicroschemaResponse setDescription(String description) {
 		this.description = description;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaUpdateRequest.java
@@ -57,7 +57,7 @@ public class MicroschemaUpdateRequest implements MicroschemaVersionModel {
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public MicroschemaUpdateRequest setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/microschema/impl/MicroschemaUpdateRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.microschema.MicroschemaVersionModel;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 
 import io.vertx.core.json.JsonObject;
 
@@ -32,6 +33,10 @@ public class MicroschemaUpdateRequest implements MicroschemaVersionModel {
 	@JsonPropertyDescription("Additional elasticsearch index configuration. This can be used to setup custom analyzers and filters.")
 	private JsonObject elasticsearch;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' flag.")
+	private Boolean noIndex;
+
 	@JsonPropertyDescription("List of microschema fields")
 	private List<FieldSchema> fields = new ArrayList<>();
 
@@ -43,6 +48,17 @@ public class MicroschemaUpdateRequest implements MicroschemaVersionModel {
 	@Override
 	public MicroschemaUpdateRequest setVersion(String version) {
 		this.version = version;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchema.java
@@ -79,6 +79,21 @@ public interface FieldSchema {
 	FieldSchema setRequired(boolean isRequired);
 
 	/**
+	 * Return the 'excluded from indexing' flag of the field schema.
+	 * 
+	 * @return
+	 */
+	boolean isNoIndex();
+
+	/**
+	 * Set the 'excluded from indexing' flag.
+	 * 
+	 * @param isNoIndex
+	 * @return Fluent API
+	 */
+	FieldSchema setNoIndex(boolean isNoIndex);
+
+	/**
 	 * Compare the field schema with the given field schema.
 	 * 
 	 * @param fieldSchema
@@ -141,6 +156,9 @@ public interface FieldSchema {
 	 */
 	@JsonIgnore
 	default boolean isMappingRequired(ElasticSearchOptions options) {
+		if (isNoIndex()) {
+			return false;
+		}
 		MappingMode mode = options.getMappingMode();
 		return mode == MappingMode.DYNAMIC || mode == MappingMode.STRICT && getElasticsearch() != null;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchemaContainer.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/FieldSchemaContainer.java
@@ -58,6 +58,21 @@ public interface FieldSchemaContainer extends RestModel {
 	FieldSchemaContainer setDescription(String description);
 
 	/**
+	 * Return the 'exclude from indexing' flag.
+	 * 
+	 * @return flag
+	 */
+	Boolean getNoIndex();
+
+	/**
+	 * Set the 'exclude from indexing' flag.
+	 * 
+	 * @param flag
+	 * @return self
+	 */
+	FieldSchemaContainer setNoIndex(Boolean noIndex);
+
+	/**
 	 * Return the field with the given name.
 	 * 
 	 * @param fieldName

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/change/impl/SchemaChangeModel.java
@@ -25,6 +25,8 @@ public class SchemaChangeModel implements RestModel {
 
 	public static final String REQUIRED_KEY = "required";
 
+	public static final String NO_INDEX_KEY = "noIndex";
+
 	public static final String ELASTICSEARCH_KEY = "elasticsearch";
 
 	public static final String SEGMENT_FIELD_KEY = "segmentFieldname";

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
@@ -119,7 +119,7 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 			setRequired(Boolean.valueOf(String.valueOf(fieldProperties.get(REQUIRED_KEY))));
 		}
 		if (fieldProperties.get(SchemaChangeModel.NO_INDEX_KEY) != null) {
-			setRequired(Boolean.valueOf(String.valueOf(fieldProperties.get(NO_INDEX_KEY))));
+			setNoIndex(Boolean.valueOf(String.valueOf(fieldProperties.get(NO_INDEX_KEY))));
 		}
 		if (fieldProperties.get(SchemaChangeModel.ELASTICSEARCH_KEY) != null) {
 			Object value = fieldProperties.get(ELASTICSEARCH_KEY);

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/AbstractFieldSchema.java
@@ -5,6 +5,7 @@ import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.EL
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.LABEL_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.LIST_TYPE_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.NAME_KEY;
+import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.NO_INDEX_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.REQUIRED_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeModel.TYPE_KEY;
 import static com.gentics.mesh.core.rest.schema.change.impl.SchemaChangeOperation.CHANGEFIELDTYPE;
@@ -50,6 +51,10 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 	private boolean required = false;
 
 	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag which indicates whether the field is excluded from indexing or not.")
+	private boolean noIndex = false;
+
+	@JsonProperty(required = false)
 	@JsonPropertyDescription("Additional elasticsearch index field configuration. This can be used to add custom fields with custom analyzers to the search index.")
 	private JsonObject elasticsearch;
 
@@ -87,6 +92,17 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 	}
 
 	@Override
+	public boolean isNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchema setNoIndex(boolean isNoIndex) {
+		this.noIndex = isNoIndex;
+		return this;
+	}
+
+	@Override
 	public JsonObject getElasticsearch() {
 		return elasticsearch;
 	}
@@ -101,6 +117,9 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 	public void apply(Map<String, Object> fieldProperties) {
 		if (fieldProperties.get(SchemaChangeModel.REQUIRED_KEY) != null) {
 			setRequired(Boolean.valueOf(String.valueOf(fieldProperties.get(REQUIRED_KEY))));
+		}
+		if (fieldProperties.get(SchemaChangeModel.NO_INDEX_KEY) != null) {
+			setRequired(Boolean.valueOf(String.valueOf(fieldProperties.get(NO_INDEX_KEY))));
 		}
 		if (fieldProperties.get(SchemaChangeModel.ELASTICSEARCH_KEY) != null) {
 			Object value = fieldProperties.get(ELASTICSEARCH_KEY);
@@ -179,6 +198,7 @@ public abstract class AbstractFieldSchema implements FieldSchema {
 		Map<String, Object> map = new HashMap<>();
 		map.put(LABEL_KEY, getLabel());
 		map.put(REQUIRED_KEY, isRequired());
+		map.put(NO_INDEX_KEY, isNoIndex());
 		// empty object and null/missing should be treated the same
 		map.put(ELASTICSEARCH_KEY, getElasticsearch() == null || getElasticsearch().size() == 0 ? new JsonObject() : getElasticsearch());
 		return map;

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaCreateRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaModel;
 
 import io.vertx.core.json.JsonObject;
@@ -51,6 +52,10 @@ public class SchemaCreateRequest implements SchemaModel {
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should create new versions.")
 	private Boolean autoPurge;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' flag.")
+	private Boolean noIndex;
+
 	@Override
 	public String getDescription() {
 		return description;
@@ -59,6 +64,17 @@ public class SchemaCreateRequest implements SchemaModel {
 	@Override
 	public SchemaCreateRequest setDescription(String description) {
 		this.description = description;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaCreateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaCreateRequest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaModel;
 
 import io.vertx.core.json.JsonObject;
@@ -73,7 +72,7 @@ public class SchemaCreateRequest implements SchemaModel {
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public SchemaCreateRequest setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaModelImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaModelImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaModel;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 
@@ -37,18 +38,6 @@ public class SchemaModelImpl implements SchemaVersionModel {
 	@JsonPropertyDescription("Names of the fields which provide a compete url to the node. This property can be used to define custom urls for certain nodes. The webroot API will try to locate the node via it's segment field and via the specified url fields.")
 	private List<String> urlFields;
 
-	/**
-	 * Create a new schema with the given name.
-	 * 
-	 * @param name
-	 */
-	public SchemaModelImpl(String name) {
-		setName(name);
-	}
-
-	public SchemaModelImpl() {
-	}
-
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Version of the schema")
 	private String version;
@@ -69,6 +58,22 @@ public class SchemaModelImpl implements SchemaVersionModel {
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should create new versions.")
 	private Boolean autoPurge;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' flag.")
+	private Boolean noIndex;
+
+	/**
+	 * Create a new schema with the given name.
+	 * 
+	 * @param name
+	 */
+	public SchemaModelImpl(String name) {
+		setName(name);
+	}
+
+	public SchemaModelImpl() {
+	}
+
 	@Override
 	public String getVersion() {
 		return version;
@@ -88,6 +93,17 @@ public class SchemaModelImpl implements SchemaVersionModel {
 	@Override
 	public SchemaModelImpl setDescription(String description) {
 		this.description = description;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaModelImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaModelImpl.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaModel;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 
@@ -102,7 +101,7 @@ public class SchemaModelImpl implements SchemaVersionModel {
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public SchemaModelImpl setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaResponse.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.common.AbstractGenericRestResponse;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 
 import io.vertx.core.json.JsonObject;
@@ -79,7 +78,7 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public SchemaResponse setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaResponse.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.common.AbstractGenericRestResponse;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 
 import io.vertx.core.json.JsonObject;
@@ -57,6 +58,10 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should be automatically purged on update.")
 	private Boolean autoPurge;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Flag which indicates whether nodes which use this schema should be excluded from the indexing.")
+	private Boolean noIndex;
+
 	@Override
 	public String getName() {
 		return name;
@@ -65,6 +70,17 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 	@Override
 	public SchemaResponse setName(String name) {
 		this.name = name;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 
@@ -174,6 +190,7 @@ public class SchemaResponse extends AbstractGenericRestResponse implements Schem
 		updateRequest.setDescription(getDescription());
 		updateRequest.setElasticsearch(getElasticsearch());
 		updateRequest.setUrlFields(getUrlFields());
+		updateRequest.setNoIndex(getNoIndex());
 		return updateRequest;
 	}
 

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaUpdateRequest.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 
 import io.vertx.core.json.JsonObject;
@@ -78,7 +77,7 @@ public class SchemaUpdateRequest implements SchemaVersionModel {
 	}
 
 	@Override
-	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+	public SchemaUpdateRequest setNoIndex(Boolean noIndex) {
 		this.noIndex = noIndex;
 		return this;
 	}

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaUpdateRequest.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/schema/impl/SchemaUpdateRequest.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.SchemaVersionModel;
 
 import io.vertx.core.json.JsonObject;
@@ -56,6 +57,10 @@ public class SchemaUpdateRequest implements SchemaVersionModel {
 	@JsonPropertyDescription("Auto purge flag of the schema. Controls whether contents of this schema should create new versions.")
 	private Boolean autoPurge;
 
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("'Exclude from indexing' schema flag.")
+	private Boolean noIndex;
+
 	@Override
 	public String getName() {
 		return name;
@@ -64,6 +69,17 @@ public class SchemaUpdateRequest implements SchemaVersionModel {
 	@Override
 	public SchemaUpdateRequest setName(String name) {
 		this.name = name;
+		return this;
+	}
+
+	@Override
+	public Boolean getNoIndex() {
+		return noIndex;
+	}
+
+	@Override
+	public FieldSchemaContainer setNoIndex(Boolean noIndex) {
+		this.noIndex = noIndex;
 		return this;
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/AddFieldChangeTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/change/AddFieldChangeTest.java
@@ -241,6 +241,59 @@ public class AddFieldChangeTest extends AbstractChangeTest {
 	}
 
 	@Test
+	public void testApplyNoIndexTrue() {
+		try (Tx tx = tx()) {
+			HibSchemaVersion version = createVersion(schemaDao(tx));
+			SchemaModelImpl schema = new SchemaModelImpl();
+			HibAddFieldChange change = createChange(schemaDao(tx), version, ADDFIELD);
+			
+			change.setFieldName("noIndexField");
+			change.setType("string");
+			change.setRestProperty(SchemaChangeModel.NO_INDEX_KEY, true);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("noIndexField");
+			assertThat(updatedSchema.getField("noIndexField").isNoIndex()).as("No Index flag").isTrue();
+		}
+	}
+
+	@Test
+	public void testApplyNoIndexFalse() {
+		try (Tx tx = tx()) {
+			HibSchemaVersion version = createVersion(schemaDao(tx));
+			SchemaModelImpl schema = new SchemaModelImpl();
+			HibAddFieldChange change = createChange(schemaDao(tx), version, ADDFIELD);
+			
+			change.setFieldName("indexedField");
+			change.setType("string");
+			change.setRestProperty(SchemaChangeModel.NO_INDEX_KEY, false);
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("indexedField");
+			assertThat(updatedSchema.getField("indexedField").isNoIndex()).as("No Index flag").isFalse();
+		}
+	}
+
+	@Test
+	public void testApplyNoIndexNull() {
+		try (Tx tx = tx()) {
+			HibSchemaVersion version = createVersion(schemaDao(tx));
+			SchemaModelImpl schema = new SchemaModelImpl();
+			HibAddFieldChange change = createChange(schemaDao(tx), version, ADDFIELD);
+			
+			change.setFieldName("defaultIndexedField");
+			change.setType("string");
+			version.setSchema(schema);
+			version.setNextChange(change);
+			FieldSchemaContainer updatedSchema = mutator.apply(version);
+			assertThat(updatedSchema).hasField("defaultIndexedField");
+			assertThat(updatedSchema.getField("defaultIndexedField").isRequired()).as("No Index flag").isFalse();
+		}
+	}
+
+	@Test
 	public void testApplyRequiredTrue() {
 		try (Tx tx = tx()) {
 			HibSchemaVersion version = createVersion(schemaDao(tx));

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/AbstractMultiESTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/AbstractMultiESTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractMultiESTest implements TestHttpMethods, TestGraphH
 	private static ElasticsearchTestMode currentMode = null;
 
 	@Parameters(name = "{index}: ({0})")
-	public static Collection esVersions() {
+	public static Collection<Object[]> esVersions() {
 		return Arrays.asList(new Object[][] {
 			{ ElasticsearchTestMode.CONTAINER_ES6 },
 			{ ElasticsearchTestMode.CONTAINER_ES7 },

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/MicroschemaMappingTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/MicroschemaMappingTest.java
@@ -6,9 +6,11 @@ import static com.gentics.mesh.test.ElasticsearchTestMode.CONTAINER_ES6;
 import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Before;
@@ -56,96 +58,116 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 	@Parameters
 	public static Collection<Object[]> paramData() {
 		// @formatter:off
-		return Arrays.asList(new Object[][] {
-			{
-				FieldUtil.createStringFieldSchema(DYNAMIC_FIELD_NAME),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "keyword")
-						.put("index", true)),
-				FieldUtil.createStringField("aaa-aaa"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("term", new JsonObject()
-						.put(path + ".test", "aaa-aaa")))
-			},
-			{
-				FieldUtil.createStringFieldSchema(DYNAMIC_FIELD_NAME),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "text")
-						.put("index", true)),
-				FieldUtil.createStringField("a very cool test string"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("match", new JsonObject()
-						.put(path + ".test", "cool")))
-			},
-			{
-				FieldUtil.createHtmlFieldSchema(DYNAMIC_FIELD_NAME),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "keyword")
-						.put("index", true)),
-				FieldUtil.createHtmlField("aaa-aaa"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("term", new JsonObject()
-						.put(path + ".test", "aaa-aaa")))
-			},
-			{
-				FieldUtil.createHtmlFieldSchema(DYNAMIC_FIELD_NAME),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "text")
-						.put("index", true)),
-				FieldUtil.createHtmlField("a very cool test string"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("match", new JsonObject()
-						.put(path + ".test", "cool")))
-			},
-			{
-				FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "string"),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "keyword")
-						.put("index", true)),
-				FieldUtil.createStringListField("aaa-aaa"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("term", new JsonObject()
-						.put(path + ".test", "aaa-aaa")))
-			},
-			{
-				FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "string"),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "text")
-						.put("index", true)),
-				FieldUtil.createStringListField("a very cool test string"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("match", new JsonObject()
-						.put(path + ".test", "cool")))
-			},
-			{
-				FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "html"),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "keyword")
-						.put("index", true)),
-				FieldUtil.createHtmlListField("aaa-aaa"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("term", new JsonObject()
-						.put(path + ".test", "aaa-aaa")))
-			},
-			{
-				FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "html"),
-				new JsonObject()
-					.put("test", new JsonObject()
-						.put("type", "text")
-						.put("index", true)),
-				FieldUtil.createHtmlListField("a very cool test string"),
-				(Function<String, JsonObject>) ((path) -> new JsonObject()
-					.put("match", new JsonObject()
-						.put(path + ".test", "cool")))
-			},
-		});
+		List<Object[]> params = new ArrayList<>(4 * 8);
+		for (Boolean noSchemaIndex : new Boolean[] {false, true}) {
+			for (Boolean noFieldIndex : new Boolean[] {false, true}) {
+				params.add(new Object[] {
+					FieldUtil.createStringFieldSchema(DYNAMIC_FIELD_NAME),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "keyword")
+							.put("index", true)),
+					FieldUtil.createStringField("aaa-aaa"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("term", new JsonObject()
+							.put(path + ".test", "aaa-aaa"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createStringFieldSchema(DYNAMIC_FIELD_NAME),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "text")
+							.put("index", true)),
+					FieldUtil.createStringField("a very cool test string"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("match", new JsonObject()
+							.put(path + ".test", "cool"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createHtmlFieldSchema(DYNAMIC_FIELD_NAME),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "keyword")
+							.put("index", true)),
+					FieldUtil.createHtmlField("aaa-aaa"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("term", new JsonObject()
+							.put(path + ".test", "aaa-aaa"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createHtmlFieldSchema(DYNAMIC_FIELD_NAME),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "text")
+							.put("index", true)),
+					FieldUtil.createHtmlField("a very cool test string"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("match", new JsonObject()
+							.put(path + ".test", "cool"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "string"),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "keyword")
+							.put("index", true)),
+					FieldUtil.createStringListField("aaa-aaa"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("term", new JsonObject()
+							.put(path + ".test", "aaa-aaa"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "string"),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "text")
+							.put("index", true)),
+					FieldUtil.createStringListField("a very cool test string"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("match", new JsonObject()
+							.put(path + ".test", "cool"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "html"),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "keyword")
+							.put("index", true)),
+					FieldUtil.createHtmlListField("aaa-aaa"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("term", new JsonObject()
+							.put(path + ".test", "aaa-aaa"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+				params.add(new Object[] {
+					FieldUtil.createListFieldSchema(DYNAMIC_FIELD_NAME, "html"),
+					new JsonObject()
+						.put("test", new JsonObject()
+							.put("type", "text")
+							.put("index", true)),
+					FieldUtil.createHtmlListField("a very cool test string"),
+					(Function<String, JsonObject>) ((path) -> new JsonObject()
+						.put("match", new JsonObject()
+							.put(path + ".test", "cool"))),
+					noSchemaIndex,
+					noFieldIndex
+				});
+			}
+		}
+		return params;
 		// @formatter:on
 	}
 
@@ -161,6 +183,12 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 	@Parameter(3)
 	public Function<String, JsonObject> searchQuery;
 
+	@Parameter(4)
+	public Boolean noSchemaIndex;
+
+	@Parameter(5)
+	public Boolean noFieldIndex;
+
 	/**
 	 * The created dummy schema in the preparations. Used to get the ES-Mapping of it.
 	 */
@@ -171,7 +199,8 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 		// Create and assign a dummy microschema
 		MicroschemaCreateRequest createMicroschema = new MicroschemaCreateRequest();
 		createMicroschema.setName(MICROSCHEMA_NAME);
-		createMicroschema.addField(this.schemaField.setElasticsearch(this.fieldMapping));
+		createMicroschema.addField(this.schemaField.setElasticsearch(this.fieldMapping).setNoIndex(noFieldIndex));
+		createMicroschema.setNoIndex(noSchemaIndex);
 		MicroschemaResponse microschema = call(() -> client().createMicroschema(createMicroschema));
 		call(() -> client().assignMicroschemaToProject(PROJECT_NAME, microschema.getUuid()));
 
@@ -210,10 +239,18 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 				.getJsonObject(MICRONODE_FIELD_NAME)
 				.getJsonObject("properties")
 				.getJsonObject("fields-" + MICROSCHEMA_NAME);
-			assertNotNull(microschemaMapping);
-			JsonObject fieldMapping = microschemaMapping.getJsonObject("properties").getJsonObject(DYNAMIC_FIELD_NAME);
+			if (noSchemaIndex) {
+				assertNull(microschemaMapping);
+			} else {
+				assertNotNull(microschemaMapping);
+				JsonObject fieldMapping = microschemaMapping.getJsonObject("properties").getJsonObject(DYNAMIC_FIELD_NAME);
 
-			assertEquals(this.fieldMapping, fieldMapping.getJsonObject("fields"));
+				if (noFieldIndex) {
+					assertNull(fieldMapping);
+				} else {
+					assertEquals(this.fieldMapping, fieldMapping.getJsonObject("fields"));
+				}
+			}
 		});
 	}
 
@@ -237,13 +274,18 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 			NodeListResponse response = call(() -> client().searchNodes(project().getName(),
 				new JsonObject().put("query", this.searchQuery.apply(searchPath)).encode()));
 
-			// Expect the search to return a single element
-			assertEquals(response.getMetainfo().getTotalCount(), 1);
+			if (noFieldIndex || noSchemaIndex) {
+				// Expect the search to return a single element
+				assertEquals(0, response.getMetainfo().getTotalCount());
+			} else {
+				// Expect the search to return a single element
+				assertEquals(1, response.getMetainfo().getTotalCount());
 
-			// Check if the node is the one we expected
-			NodeResponse responseNode = response.getData().get(0);
-			assertEquals(SCHEMA_NAME, responseNode.getSchema().getName());
-			assertEquals(node.getUuid(), responseNode.getUuid());
+				// Check if the node is the one we expected
+				NodeResponse responseNode = response.getData().get(0);
+				assertEquals(SCHEMA_NAME, responseNode.getSchema().getName());
+				assertEquals(node.getUuid(), responseNode.getUuid());
+			}
 		});
 	}
 
@@ -273,14 +315,18 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 			waitForSearchIdleEvent();
 			// Search for the node
 			NodeListResponse response = call(() -> client().searchNodes(project().getName(), query.encode()));
+			if (noFieldIndex || noSchemaIndex) {
+				// Expect no result
+				assertEquals(0, response.getMetainfo().getTotalCount());
+			} else {
+				// Expect the search to return a single element
+				assertEquals(1, response.getMetainfo().getTotalCount());
 
-			// Expect the search to return a single element
-			assertEquals(response.getMetainfo().getTotalCount(), 1);
-
-			// Check if the node is the one we expected
-			NodeResponse responseNode = response.getData().get(0);
-			assertEquals(SCHEMA_NAME, responseNode.getSchema().getName());
-			assertEquals(node.getUuid(), responseNode.getUuid());
+				// Check if the node is the one we expected
+				NodeResponse responseNode = response.getData().get(0);
+				assertEquals(SCHEMA_NAME, responseNode.getSchema().getName());
+				assertEquals(node.getUuid(), responseNode.getUuid());
+			}
 		});
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/MicroschemaMappingTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/MicroschemaMappingTest.java
@@ -196,7 +196,7 @@ public class MicroschemaMappingTest extends AbstractMeshTest {
 
 		tx(() -> {
 			HibBranch branch = latestBranch();
-			JsonObject schemaMapping = provider.getMapping(this.schema, branch, null);
+			JsonObject schemaMapping = provider.getMapping(this.schema, branch, null).get();
 			if (mode == ComplianceMode.ES_6) {
 				schemaMapping = schemaMapping.getJsonObject(DEFAULT_TYPE);
 			}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/NoIndexTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/NoIndexTest.java
@@ -1,0 +1,95 @@
+package com.gentics.mesh.search;
+
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static com.gentics.mesh.test.TestSize.FULL;
+import static com.gentics.mesh.test.context.MeshTestHelper.getSimpleQuery;
+import static com.gentics.mesh.test.context.MeshTestHelper.getUuidQuery;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.gentics.mesh.core.data.node.HibNode;
+import com.gentics.mesh.core.rest.node.NodeListResponse;
+import com.gentics.mesh.core.rest.node.NodeResponse;
+import com.gentics.mesh.core.rest.schema.SchemaModel;
+import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
+import com.gentics.mesh.test.ElasticsearchTestMode;
+import com.gentics.mesh.test.MeshTestSetting;
+
+@RunWith(Parameterized.class)
+@MeshTestSetting(testSize = FULL, startServer = true)
+public class NoIndexTest extends AbstractNodeSearchEndpointTest {
+
+	public NoIndexTest(ElasticsearchTestMode elasticsearch) throws Exception {
+		super(elasticsearch);
+	}
+
+	protected void setNoFieldIndexing(String fieldName, boolean disable) {
+		tx(() -> {
+			HibNode nodeTmp = content("concorde");
+			SchemaModel schema = nodeTmp.getSchemaContainer().getLatestVersion().getSchema();
+			schema.getField(fieldName).setNoIndex(disable);
+			actions().updateSchemaVersion(nodeTmp.getSchemaContainer().getLatestVersion());
+			return nodeTmp;
+		});
+	}
+
+	protected void setNoSchemaIndexing(boolean disable) {
+		tx(() -> {
+			HibNode nodeTmp = content("concorde");
+			SchemaModel schema = nodeTmp.getSchemaContainer().getLatestVersion().getSchema();
+			schema.setNoIndex(disable);
+			actions().updateSchemaVersion(nodeTmp.getSchemaContainer().getLatestVersion());
+			return nodeTmp;
+		});
+	}
+
+	@Test
+	public void testNoFieldIndex() throws Exception {
+		String uuid = db().tx(() -> content("concorde").getUuid());
+		NodeResponse concorde = call(() -> client().findNodeByUuid(PROJECT_NAME, uuid, new VersioningParametersImpl().draft()));
+
+		// Concorde exists in the index
+		recreateIndices();
+		String oldContent = "supersonic";
+		NodeListResponse response = call(() -> client().searchNodes(PROJECT_NAME, getSimpleQuery("fields.content", oldContent)));
+		assertThat(response.getData()).as("Search result").usingElementComparatorOnFields("uuid").containsOnly(concorde);
+
+		setNoFieldIndexing("content", true);
+
+		// No more Concorde available
+		recreateIndices();
+		response = call(() -> client().searchNodes(PROJECT_NAME, getSimpleQuery("fields.content", oldContent)));
+		assertThat(response.getData()).as("Search result").isEmpty();
+
+		// Control case - the node itself is found by its UUID
+		response = call(() -> client().searchNodes(PROJECT_NAME, getUuidQuery(uuid)));
+		assertThat(response.getData()).as("Search result").usingElementComparatorOnFields("uuid").containsOnly(concorde);
+	}
+
+	@Test
+	public void testNoSchemaIndex() throws Exception {
+		String uuid = db().tx(() -> content("concorde").getUuid());
+		NodeResponse concorde = call(() -> client().findNodeByUuid(PROJECT_NAME, uuid, new VersioningParametersImpl().draft()));
+
+		// Concorde exists in the field index
+		recreateIndices();
+		String oldContent = "supersonic";
+		NodeListResponse response = call(() -> client().searchNodes(PROJECT_NAME, getSimpleQuery("fields.content", oldContent)));
+		assertThat(response.getData()).as("Search result").usingElementComparatorOnFields("uuid").containsOnly(concorde);
+
+		setNoSchemaIndexing(true);
+
+		// No more Concorde available through the field
+		recreateIndices();
+		response = call(() -> client().searchNodes(PROJECT_NAME, getSimpleQuery("fields.content", oldContent)));
+		assertThat(response.getData()).as("Search result").isEmpty();
+
+		// Control case - the node itself is not found by its UUID
+		response = call(() -> client().searchNodes(PROJECT_NAME, getUuidQuery(uuid)));
+		assertThat(response.getData()).as("Search result").isEmpty();
+	}
+}

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/filter/SchemaElementFilter.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/filter/SchemaElementFilter.java
@@ -9,7 +9,9 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.gentics.graphqlfilter.filter.BooleanFilter;
 import com.gentics.graphqlfilter.filter.FilterField;
+import com.gentics.graphqlfilter.filter.MappedFilter;
 import com.gentics.graphqlfilter.filter.operation.Comparison;
 import com.gentics.graphqlfilter.filter.operation.FieldOperand;
 import com.gentics.mesh.ElementType;
@@ -90,6 +92,7 @@ public abstract class SchemaElementFilter<
 		filters.add(CommonFields.hibNameFilter(owner));
 		filters.add(CommonFields.hibUuidFilter(owner));
 		filters.addAll(CommonFields.hibUserTrackingFilter(owner));
+		filters.add(new MappedFilter<>(owner, "noIndex", "Filters by schema 'excluded from index' flag", BooleanFilter.filter(), schema -> getLatestVersion(schema).getNoIndex()));
 		return filters;
 	}
 

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/AbstractTypeProvider.java
@@ -834,6 +834,16 @@ public abstract class AbstractTypeProvider {
 			@Override
 			public void apply(Map<String, Object> fieldProperties) {
 			}
+
+			@Override
+			public boolean isNoIndex() {
+				return false;
+			}
+
+			@Override
+			public FieldSchema setNoIndex(boolean isNoIndex) {
+				return null;
+			}
 		};
 	}
 }


### PR DESCRIPTION
## Abstract

At the moment Mesh gives all the content to the indexing engine, which is a security issue, since not all the indexed data is insensible enough. This feature enables a `No Index` flag, attached to the selected (micro)schemas and fields, banning the corresponding content from being indexed.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
