### PR TITLE
SUP-15904: Speed up the parents fetch

### DIFF
--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/node/NodeContent.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/node/NodeContent.java
@@ -1,7 +1,9 @@
 package com.gentics.mesh.core.data.node;
 
 import java.util.List;
+import java.util.Optional;
 
+import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.HibNodeFieldContainer;
 import com.gentics.mesh.core.data.dao.ContentDao;
 import com.gentics.mesh.core.db.Tx;
@@ -13,9 +15,10 @@ import com.gentics.mesh.core.rest.common.ContainerType;
 public class NodeContent {
 
 	private HibNode node;
-	private HibNodeFieldContainer container;
-	private List<String> languageFallback;
-	private ContainerType type;
+	private final HibNodeFieldContainer container;
+	private final List<String> languageFallback;
+	private final ContainerType type;
+	private Optional<HibNode> nodeParent;
 
 	/**
 	 * Create a new node content.
@@ -26,10 +29,23 @@ public class NodeContent {
 	 *            Language fallback list which was used to load the content
 	 */
 	public NodeContent(HibNode node, HibNodeFieldContainer container, List<String> languageFallback, ContainerType type) {
+		this(node, container, languageFallback, type, null);
+	}
+
+	/**
+	 * Create a new node content.
+	 * 
+	 * @param node
+	 * @param container
+	 * @param languageFallback
+	 *            Language fallback list which was used to load the content
+	 */
+	public NodeContent(HibNode node, HibNodeFieldContainer container, List<String> languageFallback, ContainerType type, HibNode nodeParent) {
 		this.node = node;
 		this.container = container;
 		this.languageFallback = languageFallback;
 		this.type = type;
+		this.setNodeParent(Optional.ofNullable(nodeParent));
 	}
 
 	/**
@@ -57,4 +73,11 @@ public class NodeContent {
 		return type;
 	}
 
+	public HibNode getNodeParent(InternalActionContext ac) {
+		return nodeParent.orElseGet(() -> getNode().getParentNode(ac.getVersioningParameters().getBranch()));
+	}
+
+	public void setNodeParent(Optional<HibNode> nodeParent) {
+		this.nodeParent = nodeParent;
+	}
 }

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/NodeTypeProvider.java
@@ -127,7 +127,6 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 	 */
 	public CompletableFuture<DataFetcherResult<NodeContent>> parentNodeFetcher(DataFetchingEnvironment env) {
 		Tx tx = Tx.get();
-		NodeDao nodeDao = tx.nodeDao();
 
 		NodeContent content = env.getSource();
 		if (content == null) {
@@ -135,7 +134,7 @@ public class NodeTypeProvider extends AbstractTypeProvider {
 		}
 		GraphQLContext gc = env.getContext();
 		String uuid = tx.getBranch(gc).getUuid();
-		HibNode parentNode = nodeDao.getParentNode(content.getNode(), uuid);
+		HibNode parentNode = content.getNodeParent(gc);
 		// The project root node can have no parent. Lets check this and exit early.
 		if (parentNode == null) {
 			return null;


### PR DESCRIPTION
## Abstract

One can fetch the parent node along with the node and its content, to speed up GraphQL requests

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
