### PR TITLE
Hotfix 2.0.x sup 15895

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -687,7 +687,7 @@
 			<dependency>
 				<groupId>com.gentics.graphqlfilter</groupId>
 				<artifactId>graphql-java-filter</artifactId>
-				<version>3.0.1</version>
+				<version>3.0.2-SNAPSHOT</version>
 			</dependency>
 
 		</dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,6 +20,7 @@
 		<!-- when updating version, don't forget to update administration-guide.asciidoc -->
 		<graphql.version>20.0</graphql.version>
 		<graphql-dataloader.version>3.1.2</graphql-dataloader.version>
+		<graphql-filter.version>3.0.2</graphql-filter.version>
 		<pf4j.version>3.1.0</pf4j.version>
 		<asm.version>3.3.1</asm.version>
 		<spring.security.version>5.5.7</spring.security.version>
@@ -687,7 +688,7 @@
 			<dependency>
 				<groupId>com.gentics.graphqlfilter</groupId>
 				<artifactId>graphql-java-filter</artifactId>
-				<version>3.0.2-SNAPSHOT</version>
+				<version>${graphql-filter.version}</version>
 			</dependency>
 
 		</dependencies>

--- a/changelog/src/changelog/entries/2023/10/7577.SUP-15895.bugfix
+++ b/changelog/src/changelog/entries/2023/10/7577.SUP-15895.bugfix
@@ -1,0 +1,2 @@
+GraphQL: When the very first GraphQL Queries (after starting the Mesh instance) were executed in parallel, it could happen that
+GraphQL execution failed with some internal errors. This has been fixed.

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/filter/ListFilter.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/filter/ListFilter.java
@@ -2,6 +2,7 @@ package com.gentics.mesh.graphql.filter;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class ListFilter<T, Q> extends MainFilter<Collection<T>> {
 	private static ListFilter<HibMicronode, ?> micronodeListFilterInstance;
 	private static ListFilter<HibBinaryField, ?> binaryListFilterInstance;
 	private static ListFilter<S3HibBinaryField, ?> s3binaryListFilterInstance;
-	private static Map<Byte, ListFilter<NodeReferenceIn, ?>> nodeReferenceListFilterInstances = new HashMap<>();
+	private static Map<Byte, ListFilter<NodeReferenceIn, ?>> nodeReferenceListFilterInstances = Collections.synchronizedMap(new HashMap<>());
 
 	private final Filter<T, Q> itemFilter;
 	private final boolean referenceItem;


### PR DESCRIPTION
## Abstract

The used graphql-filter library was not thread-safe, which caused some internal errors (like You have redefined the type 'StringFilter' from being a 'GraphQLInputObjectType' to a 'GraphQLInputObjectType') when executing GraphQL requests.
The issue has been fixed in the graphql-filter library.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
