### PR TITLE
SUP-15263: Remove unnecessary token logging

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.21]]
+== 1.10.21 (TBD)
+
+icon:check[] Auth: The unnecessary logging of outdated/mismatched auth token has been removed.
+
 [[v1.10.20]]
 == 1.10.20 (17.11.2023)
 

--- a/common/src/main/java/com/gentics/mesh/auth/provider/MeshJWTAuthProvider.java
+++ b/common/src/main/java/com/gentics/mesh/auth/provider/MeshJWTAuthProvider.java
@@ -100,8 +100,6 @@ public class MeshJWTAuthProvider implements AuthenticationProvider, JWTAuth {
 			if (rh.failed()) {
 				if (log.isDebugEnabled()) {
 					log.debug("Could not authenticate token.", rh.cause());
-				} else {
-					log.warn("Could not authenticate token.");
 				}
 				resultHandler.handle(Future.failedFuture("Invalid Token"));
 			} else {


### PR DESCRIPTION
## Abstract

No need to log the failed auth with WARN level.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
