### PR TITLE
SUP-15674: Disallow empty or spaced password

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.21]]
+== 1.10.21 (TBD)
+
+icon:check[] Core: Now it is not allowed to set a new password to an empty or invalid (e.g. spaces) string. 
+
 [[v1.10.20]]
 == 1.10.20 (17.11.2023)
 

--- a/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
+++ b/core/src/main/java/com/gentics/mesh/cli/AbstractBootstrapInitializer.java
@@ -262,7 +262,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
 				adminUser.setLastEditedTimestamp();
 
 				String pw = config.getInitialAdminPassword();
-				if (pw != null) {
+				if (StringUtils.isNotBlank(pw)) {
 					StringBuffer sb = new StringBuffer();
 					String hash = passwordEncoder.encode(pw);
 					sb.append("-----------------------\n");

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingUserDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingUserDao.java
@@ -10,7 +10,7 @@ import static com.gentics.mesh.core.rest.error.Errors.conflict;
 import static com.gentics.mesh.core.rest.error.Errors.error;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -513,10 +513,10 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 		if (requestModel == null) {
 			throw error(BAD_REQUEST, "error_parse_request_json_error");
 		}
-		if (isEmpty(requestModel.getPassword())) {
+		if (isBlank(requestModel.getPassword())) {
 			throw error(BAD_REQUEST, "user_missing_password");
 		}
-		if (isEmpty(requestModel.getUsername())) {
+		if (isBlank(requestModel.getUsername())) {
 			throw error(BAD_REQUEST, "user_missing_username");
 		}
 		if (!hasPermission(requestUser, userRoot, CREATE_PERM)) {
@@ -546,7 +546,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 		inheritRolePermissions(requestUser, userRoot, user);
 		ExpandableNode reference = requestModel.getNodeReference();
 
-		if (!isEmpty(groupUuid)) {
+		if (!isBlank(groupUuid)) {
 			HibGroup parentGroup = groupDao.loadObjectByUuid(ac, groupUuid, CREATE_PERM);
 			groupDao.addUser(parentGroup, user);
 			// batch.add(parentGroup.onUpdated());
@@ -558,7 +558,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 			String referencedNodeUuid = basicReference.getUuid();
 			String projectName = basicReference.getProjectName();
 
-			if (isEmpty(projectName) || isEmpty(referencedNodeUuid)) {
+			if (isBlank(projectName) || isBlank(referencedNodeUuid)) {
 				throw error(BAD_REQUEST, "user_incomplete_node_reference");
 			}
 
@@ -600,6 +600,9 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 	// blocking
 	@Override
 	default HibUser setPassword(HibUser user, String password) {
+		if (isBlank(password)) {
+			throw error(BAD_REQUEST, "user_missing_password");
+		}
 		String hashedPassword = Tx.get().passwordEncoder().encode(password);
 		updatePasswordHash(user, hashedPassword);
 		return mergeIntoPersisted(user);
@@ -675,7 +678,7 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 			modified = true;
 		}
 
-		if (!isEmpty(requestModel.getPassword())) {
+		if (!isBlank(requestModel.getPassword())) {
 			if (!dry) {
 				updatePasswordHash(user, Tx.get().passwordEncoder().encode(requestModel.getPassword()));
 			}
@@ -693,14 +696,14 @@ public interface PersistingUserDao extends UserDao, PersistingDaoGlobal<HibUser>
 					throw error(BAD_REQUEST, "user_incomplete_node_reference");
 				}
 				projectName = project.getName();
-				if (isEmpty(projectName)) {
+				if (isBlank(projectName)) {
 					throw error(BAD_REQUEST, "user_incomplete_node_reference");
 				}
 				referencedNodeUuid = response.getUuid();
 			}
 			if (reference instanceof NodeReference) {
 				NodeReference basicReference = ((NodeReference) reference);
-				if (isEmpty(basicReference.getProjectName()) || isEmpty(reference.getUuid())) {
+				if (isBlank(basicReference.getProjectName()) || isBlank(reference.getUuid())) {
 					throw error(BAD_REQUEST, "user_incomplete_node_reference");
 				}
 				referencedNodeUuid = basicReference.getUuid();

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/user/UserEndpointTest.java
@@ -1014,6 +1014,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 			tx.userDao().updatePasswordHash(user(), null);
 			uuid = user().getUuid();
 			oldHash = user().getPasswordHash();
+			tx.success();
 		}
 
 		UserUpdateRequest updateRequest = new UserUpdateRequest();
@@ -1024,7 +1025,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 
 		try (Tx tx = tx()) {
 			HibUser reloadedUser = tx.userDao().findByUuid(uuid);
-			assertNotEquals("The hash should be different and thus the password updated.", oldHash, reloadedUser.getPasswordHash());
+			assertEquals("The hash should not be different and thus the password stays old.", oldHash, reloadedUser.getPasswordHash());
 		}
 	}
 
@@ -1037,6 +1038,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 			tx.userDao().updatePasswordHash(user(), null);
 			uuid = user().getUuid();
 			oldHash = user().getPasswordHash();
+			tx.success();
 		}
 
 		UserUpdateRequest updateRequest = new UserUpdateRequest();
@@ -1061,6 +1063,7 @@ public class UserEndpointTest extends AbstractMeshTest implements BasicRestTestc
 			username = user.getUsername();
 			uuid = user.getUuid();
 			oldHash = user.getPasswordHash();
+			tx.success();
 		}
 		UserUpdateRequest updateRequest = new UserUpdateRequest();
 		updateRequest.setPassword("new_password");


### PR DESCRIPTION
## Abstract

It is possible ATM to set an empty string as password, that should not be the case.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
