### PR TITLE
Implement cache for GraphQlSchema instances

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -22,6 +22,8 @@ All fixes and changes in LTS releases will be released the next minor release. C
 
 icon:check[] Auth: The unnecessary logging of outdated/mismatched auth token has been removed.
 
+icon:check[] GraphQL: The overall performance of GraphQL requests has been improved by caching the GraphQL schemas.
+
 [[v1.10.22]]
 == 1.10.22 (06.12.2023)
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
@@ -15,9 +15,13 @@ public class GraphQLOptions implements Option {
 
 	public static final long DEFAULT_ASYNC_WAIT_TIMEOUT = 120_000L;
 
+	public static final long DEFAULT_SCHEMA_CACHE_SIZE = 1000L;
+
 	public static final String MESH_GRAPHQL_SLOW_THRESHOLD_ENV = "MESH_GRAPHQL_SLOW_THRESHOLD";
 
 	public static final String MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV = "MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT";
+
+	public static final String MESH_GRAPHQL_SCHEMA_CACHE_SIZE_ENV = "MESH_GRAPHQL_SCHEMA_CACHE_SIZE";
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Threshold for logging slow graphql queries. Default: " + DEFAULT_SLOW_THRESHOLD + "ms")
@@ -28,6 +32,11 @@ public class GraphQLOptions implements Option {
 	@JsonPropertyDescription("Threshold for waiting for asynchronous graphql queries. Default: " + DEFAULT_ASYNC_WAIT_TIMEOUT + "ms")
 	@EnvironmentVariable(name = MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV, description = "Override the configured graphQl async wait timeout.")
 	private Long asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Cache size for graphQl Schema instances. Setting this to 0 will disable the cache. Default: " + DEFAULT_SCHEMA_CACHE_SIZE)
+	@EnvironmentVariable(name = MESH_GRAPHQL_SCHEMA_CACHE_SIZE_ENV, description = "Override the configured graphQl schema cache size.")
+	private long schemaCacheSize = DEFAULT_SCHEMA_CACHE_SIZE;
 
 	/**
 	 * Get the threshold for logging slow graphQl queries (in milliseconds)
@@ -66,6 +75,24 @@ public class GraphQLOptions implements Option {
 		if (this.asyncWaitTimeout == null) {
 			this.asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
 		}
+		return this;
+	}
+
+	/**
+	 * Get the schema cache size
+	 * @return schema cache size
+	 */
+	public long getSchemaCacheSize() {
+		return schemaCacheSize;
+	}
+
+	/**
+	 * Set the schema cache size
+	 * @param schemaCacheSize schema cache size
+	 * @return fluent API
+	 */
+	public GraphQLOptions setSchemaCacheSize(long schemaCacheSize) {
+		this.schemaCacheSize = schemaCacheSize;
 		return this;
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLSchemaCacheTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLSchemaCacheTest.java
@@ -1,0 +1,491 @@
+package com.gentics.mesh.core.graphql;
+
+import static com.gentics.mesh.test.ClientHelper.call;
+import static com.gentics.mesh.test.TestDataProvider.PROJECT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.gentics.mesh.FieldUtil;
+import com.gentics.mesh.cache.GraphQLSchemaCache;
+import com.gentics.mesh.core.rest.branch.BranchCreateRequest;
+import com.gentics.mesh.core.rest.branch.BranchResponse;
+import com.gentics.mesh.core.rest.graphql.GraphQLError;
+import com.gentics.mesh.core.rest.graphql.GraphQLResponse;
+import com.gentics.mesh.core.rest.job.JobStatus;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaCreateRequest;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaResponse;
+import com.gentics.mesh.core.rest.microschema.impl.MicroschemaUpdateRequest;
+import com.gentics.mesh.core.rest.project.ProjectCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaCreateRequest;
+import com.gentics.mesh.core.rest.schema.impl.SchemaReferenceImpl;
+import com.gentics.mesh.core.rest.schema.impl.SchemaResponse;
+import com.gentics.mesh.core.rest.schema.impl.SchemaUpdateRequest;
+import com.gentics.mesh.parameter.client.SchemaUpdateParametersImpl;
+import com.gentics.mesh.parameter.client.VersioningParametersImpl;
+import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.test.TestSize;
+import com.gentics.mesh.test.context.AbstractMeshTest;
+import com.jayway.jsonpath.JsonPath;
+
+/**
+ * Test cases for cache invalidation of {@link GraphQLSchemaCache}.
+ */
+@MeshTestSetting(testSize = TestSize.FULL, startServer = true)
+public class GraphQLSchemaCacheTest extends AbstractMeshTest {
+	/**
+	 * Get error messages from response
+	 * @param response response
+	 * @return error messages
+	 */
+	protected static List<String> errorMessages(GraphQLResponse response) {
+		List<GraphQLError> errors = response.getErrors();
+
+		if (CollectionUtils.isEmpty(errors)) {
+			return Collections.emptyList();
+		} else {
+			return errors.stream().map(GraphQLError::getMessage).collect(Collectors.toList());
+		}
+	}
+
+	/**
+	 * Consumer that asserts that the response contains no errors
+	 */
+	protected final static Consumer<GraphQLResponse> noErrors = response -> {
+		assertThat(errorMessages(response)).as("Response errors").isNullOrEmpty();
+	};
+
+	/**
+	 * Consumer that asserts that the response contains a ValidationError
+	 */
+	protected final static Consumer<GraphQLResponse> validationError = response -> {
+		assertThat(response.getErrors()).usingElementComparatorOnFields("type").contains(new GraphQLError().setType("ValidationError"));
+	};
+
+	/**
+	 * Test adding a field to a schema
+	 */
+	@Test
+	public void testSchemaChange() {
+		String jsonPathToUuid = "$.schema.uuid";
+
+		// get a node with its fields via graphQl
+		String responseData = executeQuery(getNodesQuery("folder", "slug", "name"), noErrors);
+		String schemaUuid = JsonPath.read(responseData, jsonPathToUuid);
+
+		SchemaResponse schema = call(() -> client().findSchemaByUuid(schemaUuid));
+
+		// add field to schema
+		SchemaUpdateRequest update = new SchemaUpdateRequest();
+		update.setName("folder");
+		update.setFields(schema.getFields());
+		update.addField(FieldUtil.createStringFieldSchema("newfield"));
+
+		waitForJobs(() -> {
+			call(() -> client().updateSchema(schemaUuid, update));
+		}, JobStatus.COMPLETED, 1);
+
+		// get a node again
+		responseData = executeQuery(getNodesQuery("folder", "slug", "name", "newfield"), noErrors);
+	}
+
+	/**
+	 * Test assigning a schema to a project
+	 */
+	@Test
+	public void testSchemaAssign() {
+		// create a new schema
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("newschema");
+		create.addField(FieldUtil.createStringFieldSchema("newfield"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// get a node of schema "folder" with its fields via graphQl
+		executeQuery(getNodesQuery("folder", "slug", "name"), noErrors);
+
+		// getting the nodes of the new schema should produce a ValidationError
+		executeQuery(getNodesQuery("newschema", "newfield"), null, validationError);
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// try to get nodes of new schema
+		executeQuery(getNodesQuery("newschema", "newfield"), noErrors);
+	}
+
+	/**
+	 * Test unassigning a schema from a project
+	 */
+	@Test
+	public void testSchemaUnassign() {
+		// create a new schema
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("newschema");
+		create.addField(FieldUtil.createStringFieldSchema("newfield"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// try to get nodes of new schema
+		executeQuery(getNodesQuery("newschema", "newfield"), noErrors);
+
+		// unassign schema from project
+		call(() -> client().unassignSchemaFromProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// getting the nodes of the new schema should produce a ValidationError
+		executeQuery(getNodesQuery("newschema", "newfield"), null, validationError);
+	}
+
+	/**
+	 * Test deleting a schema
+	 */
+	@Test
+	public void testSchemaDelete() {
+		// create a new schema
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("newschema");
+		create.addField(FieldUtil.createStringFieldSchema("newfield"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// try to get nodes of new schema
+		executeQuery(getNodesQuery("newschema", "newfield"), noErrors);
+
+		// delete the schema
+		call(() -> client().deleteSchema(newSchema.getUuid()));
+
+		// try to get nodes of new schema
+		executeQuery(getNodesQuery("newschema", "newfield"), validationError);
+	}
+
+	/**
+	 * Test adding a field to a microschema
+	 */
+	@Test
+	public void testMicroschemaChange() {
+		// create a new schema with micronode field
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("withmicronode");
+		create.addField(FieldUtil.createMicronodeFieldSchema("micronode"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// create a new microschema
+		MicroschemaCreateRequest createMicro = new MicroschemaCreateRequest();
+		createMicro.setName("microschema");
+		createMicro.addField(FieldUtil.createStringFieldSchema("string"));
+		MicroschemaResponse microschema = call(() -> client().createMicroschema(createMicro));
+
+		// assign microschema to project
+		call(() -> client().assignMicroschemaToProject(PROJECT_NAME, microschema.getUuid()));
+
+		// get nodes with micronodes
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), noErrors);
+
+		// add field to microschema
+		waitForJobs(() -> {
+			call(() -> {
+				MicroschemaUpdateRequest update = new MicroschemaUpdateRequest();
+				update.setName(microschema.getName());
+				update.setFields(microschema.getFields());
+				update.addField(FieldUtil.createStringFieldSchema("newfield"));
+				return client().updateMicroschema(microschema.getUuid(), update);
+			});
+		}, JobStatus.COMPLETED, 1);
+
+		// get nodes with micronodes containing new fields
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string", "newfield"), noErrors);
+	}
+
+	/**
+	 * Test assigning a microschema to a project
+	 */
+	@Test
+	public void testMicroschemaAssign() {
+		// create a new schema with micronode field
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("withmicronode");
+		create.addField(FieldUtil.createMicronodeFieldSchema("micronode"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// create a new microschema
+		MicroschemaCreateRequest createMicro = new MicroschemaCreateRequest();
+		createMicro.setName("microschema");
+		createMicro.addField(FieldUtil.createStringFieldSchema("string"));
+		MicroschemaResponse microschema = call(() -> client().createMicroschema(createMicro));
+
+		// try to get nodes with microschema
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), validationError);
+
+		// assign microschema
+		call(() -> client().assignMicroschemaToProject(PROJECT_NAME, microschema.getUuid()));
+
+		// try to get nodes with microschema
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), noErrors);
+	}
+
+	/**
+	 * Test unassigning a microschema from a project
+	 */
+	@Test
+	public void testMicroschemaUnassign() {
+		// create a new schema with micronode field
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("withmicronode");
+		create.addField(FieldUtil.createMicronodeFieldSchema("micronode"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// create a new microschema
+		MicroschemaCreateRequest createMicro = new MicroschemaCreateRequest();
+		createMicro.setName("microschema");
+		createMicro.addField(FieldUtil.createStringFieldSchema("string"));
+		MicroschemaResponse microschema = call(() -> client().createMicroschema(createMicro));
+
+		// assign microschema
+		call(() -> client().assignMicroschemaToProject(PROJECT_NAME, microschema.getUuid()));
+
+		// try to get nodes with microschema
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), noErrors);
+
+		// unassign microschema
+		call(() -> client().unassignMicroschemaFromProject(PROJECT_NAME, microschema.getUuid()));
+
+		// try to get nodes with microschema
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), validationError);
+	}
+
+	/**
+	 * Test deleting a microschema
+	 */
+	@Test
+	public void testMicroschemaDelete() {
+		// create a new schema with micronode field
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("withmicronode");
+		create.addField(FieldUtil.createMicronodeFieldSchema("micronode"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// create a new microschema
+		MicroschemaCreateRequest createMicro = new MicroschemaCreateRequest();
+		createMicro.setName("microschema");
+		createMicro.addField(FieldUtil.createStringFieldSchema("string"));
+		MicroschemaResponse microschema = call(() -> client().createMicroschema(createMicro));
+
+		// assign microschema
+		call(() -> client().assignMicroschemaToProject(PROJECT_NAME, microschema.getUuid()));
+
+		// try to get nodes with microschema
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), noErrors);
+
+		// delete microschema
+		call(() -> client().deleteMicroschema(microschema.getUuid()));
+
+		// try to get nodes with microschema
+		executeQuery(getMicronodesQuery("withmicronode", "micronode", "microschema", "string"), validationError);
+	}
+
+	/**
+	 * Test that the cache separates instances by project
+	 */
+	@Test
+	public void testProjectSeparation() {
+		call(() -> {
+			ProjectCreateRequest create = new ProjectCreateRequest();
+			create.setName("newproject");
+			create.setSchemaRef("folder");
+
+			return client().createProject(create);
+		});
+
+		// test query for the test project
+		executeQuery(PROJECT_NAME, 2, getNodesQuery("content", "slug"), null, noErrors);
+
+		// test query for the new project
+		executeQuery("newproject", 2, getNodesQuery("content", "slug"), null, validationError);
+	}
+
+	/**
+	 * Test that the cache separates instances by branch
+	 */
+	@Test
+	@Ignore("This test currently fails, because the GraphQLSchema will always use the latest version of the schema, not the version, which is assigned to the branch")
+	public void testBranchSeparation() {
+		// create a new schema
+		SchemaCreateRequest create = new SchemaCreateRequest();
+		create.setName("newschema");
+		create.addField(FieldUtil.createStringFieldSchema("newfield"));
+		SchemaResponse newSchema = call(() -> client().createSchema(create));
+
+		// assign new schema to project
+		call(() -> client().assignSchemaToProject(PROJECT_NAME, newSchema.getUuid()));
+
+		// create branch in project
+		waitForJobs(() -> {
+			BranchCreateRequest createBranch = new BranchCreateRequest();
+			createBranch.setName("newbranch");
+			createBranch.setLatest(false);
+			call(() -> client().createBranch(PROJECT_NAME, createBranch));
+		}, JobStatus.COMPLETED, 1);
+
+		AtomicReference<String> initialBranchUuid = new AtomicReference<>();
+		AtomicReference<String> newBranchUuid = new AtomicReference<>();
+
+		for (BranchResponse branch : call(() -> client().findBranches(PROJECT_NAME)).getData()) {
+			if (StringUtils.equals(branch.getName(), PROJECT_NAME)) {
+				initialBranchUuid.set(branch.getUuid());
+			} else if (StringUtils.equals(branch.getName(), "newbranch")) {
+				newBranchUuid.set(branch.getUuid());
+			}
+		}
+
+		// update schema and assign to initial branch
+		call(() -> {
+			SchemaUpdateRequest update = new SchemaUpdateRequest();
+			update.setName("newschema");
+			update.setFields(newSchema.getFields());
+			update.addField(FieldUtil.createStringFieldSchema("field_in_initialbranch"));
+			return client().updateSchema(newSchema.getUuid(), update,
+					new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false));
+		});
+
+		String initialBranchVersion = call(() -> client().findSchemaByUuid(newSchema.getUuid())).getVersion();
+
+		waitForJobs(() -> {
+			call(() -> client().assignBranchSchemaVersions(PROJECT_NAME, initialBranchUuid.get(),
+					new SchemaReferenceImpl().setName("newschema").setVersion(initialBranchVersion)));
+		}, JobStatus.COMPLETED, 1);
+
+		// update schema again and assign to new branch
+		call(() -> {
+			SchemaUpdateRequest update = new SchemaUpdateRequest();
+			update.setName("newschema");
+			update.setFields(newSchema.getFields());
+			update.removeField("field_in_initialbranch");
+			update.addField(FieldUtil.createStringFieldSchema("field_in_newbranch"));
+			return client().updateSchema(newSchema.getUuid(), update,
+					new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false));
+		});
+
+		String newBranchVersion = call(() -> client().findSchemaByUuid(newSchema.getUuid())).getVersion();
+
+		waitForJobs(() -> {
+			call(() -> client().assignBranchSchemaVersions(PROJECT_NAME, newBranchUuid.get(),
+					new SchemaReferenceImpl().setName("newschema").setVersion(newBranchVersion)));
+		}, JobStatus.COMPLETED, 1);
+
+		// get nodes for initial branch
+		executeQuery(getNodesQuery("newschema", "newfield", "field_in_initialbranch"), PROJECT_NAME, noErrors);
+
+		// get nodes for new branch
+		executeQuery(getNodesQuery("newschema", "newfield", "field_in_newbranch"), "newbranch", noErrors);
+	}
+
+	/**
+	 * Test that the cache separates instances by API Version
+	 */
+	@Test
+	public void testAPIVersionSeparation() {
+		// executing the query with API v2 succeeds
+		executeQuery(PROJECT_NAME, 2, getNodesQuery("folder", "slug", "name"), null, noErrors);
+
+		// executing the same query with API v1 fails
+		executeQuery(PROJECT_NAME, 1, getNodesQuery("folder", "slug", "name"), null, validationError);
+	}
+
+	/**
+	 * Get the graphQl Query to fetch nodes with fields for a schema
+	 * @param schemaName schema name
+	 * @param fields fields to fetch for the schema
+	 * @return query
+	 */
+	protected String getNodesQuery(String schemaName, String...fields) {
+		return String.format("{ schema(name: \"%s\") { uuid nodes { elements { ... on %s { fields { %s } } } } } }", schemaName, schemaName, StringUtils.join(fields, " "));
+	}
+
+	/**
+	 * Get the graphQL query to fetch nodes with a micronode field
+	 * @param schemaName schema name
+	 * @param micronodeFieldName micronode field name
+	 * @param microschemaName microschema name
+	 * @param fields microschema field names
+	 * @return query
+	 */
+	protected String getMicronodesQuery(String schemaName, String micronodeFieldName, String microschemaName,
+			String... fields) {
+		return String.format(
+				"{ schema(name: \"%s\") { nodes { elements { ... on %s { fields { %s { ... on %s { fields { %s } } } } } } } } }",
+				schemaName, schemaName, micronodeFieldName, microschemaName, StringUtils.join(fields, " "));
+	}
+
+	/**
+	 * Execute the query with API v2 for the default branch, pass the response to the asserter and return the data as json string
+	 * @param query query to perform
+	 * @param asserter consumer to check the response
+	 * @return data as json string
+	 */
+	protected String executeQuery(String query, Consumer<GraphQLResponse> asserter) {
+		return executeQuery(query, null, asserter);
+	}
+
+	/**
+	 * Execute the query with API v2 for the given branch (default branch if no branchName is given), pass the response to the asserter and return the data as json string
+	 * @param query query to perform
+	 * @param branchName branch name (null for default branch)
+	 * @param asserter consumer to check the response
+	 * @return data as json string
+	 */
+	protected String executeQuery(String query, String branchName, Consumer<GraphQLResponse> asserter) {
+		return executeQuery(PROJECT_NAME, 2, query, branchName, asserter);
+	}
+
+	/**
+	 * Execute the query with given API version for the given branch (default branch if no branchName is given), pass the response to the asserter and return the data as json string
+	 * @param projectName project Name
+	 * @param apiVersion api Version
+	 * @param query query to perform
+	 * @param branchName branch name (null for default branch)
+	 * @param asserter consumer to check the response
+	 * @return data as json string
+	 */
+	protected String executeQuery(String projectName, int apiVersion, String query, String branchName, Consumer<GraphQLResponse> asserter) {
+		GraphQLResponse response = null;
+
+		if (StringUtils.isEmpty(branchName)) {
+			response = call(() -> client(String.format("v%d", apiVersion)).graphqlQuery(projectName, query));
+		} else {
+			response = call(() -> client(String.format("v%d", apiVersion)).graphqlQuery(projectName, query, new VersioningParametersImpl().setBranch(branchName)));
+		}
+		if (asserter != null) {
+			asserter.accept(response);
+		}
+		if (response.getData() != null) {
+			return response.getData().toString();
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/verticles/graphql/src/main/java/com/gentics/mesh/cache/GraphQLSchemaCache.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/cache/GraphQLSchemaCache.java
@@ -1,0 +1,84 @@
+package com.gentics.mesh.cache;
+
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_DELETED;
+import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.MICROSCHEMA_BRANCH_ASSIGN;
+import static com.gentics.mesh.core.rest.MeshEvent.MICROSCHEMA_BRANCH_UNASSIGN;
+import static com.gentics.mesh.core.rest.MeshEvent.MICROSCHEMA_DELETED;
+import static com.gentics.mesh.core.rest.MeshEvent.MICROSCHEMA_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_DELETED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_MICROSCHEMA_ASSIGNED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_MICROSCHEMA_UNASSIGNED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_SCHEMA_ASSIGNED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_SCHEMA_UNASSIGNED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_BRANCH_ASSIGN;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_BRANCH_UNASSIGN;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_DELETED;
+import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_UPDATED;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.gentics.mesh.cache.impl.EventAwareCacheFactory;
+import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.etc.config.MeshOptions;
+
+import graphql.schema.GraphQLSchema;
+
+/**
+ * Cache for instances of {@link GraphQLSchema}, which are used to handle GraphQL requests
+ */
+@Singleton
+public class GraphQLSchemaCache extends AbstractMeshCache<String, GraphQLSchema> {
+	/**
+	 * Events, which will trigger invalidation of the cache.
+	 * The {@link GraphQLSchema} instances in the cache depend on a project, a branch and the schemas/microschemas, which
+	 * are assigned to the project/branch.
+	 */
+	private static final MeshEvent EVENTS[] = {
+		PROJECT_DELETED,
+		PROJECT_UPDATED,
+		PROJECT_SCHEMA_ASSIGNED,
+		PROJECT_SCHEMA_UNASSIGNED,
+		PROJECT_MICROSCHEMA_ASSIGNED,
+		PROJECT_MICROSCHEMA_UNASSIGNED,
+		BRANCH_DELETED,
+		BRANCH_UPDATED,
+		SCHEMA_BRANCH_ASSIGN,
+		SCHEMA_BRANCH_UNASSIGN,
+		MICROSCHEMA_BRANCH_ASSIGN,
+		MICROSCHEMA_BRANCH_UNASSIGN,
+		SCHEMA_DELETED,
+		SCHEMA_UPDATED,
+		MICROSCHEMA_DELETED,
+		MICROSCHEMA_UPDATED
+	};
+
+	/**
+	 * Create the instance
+	 * @param factory cache factory
+	 * @param registry cache registry
+	 * @param options mesh options
+	 */
+	@Inject
+	public GraphQLSchemaCache(EventAwareCacheFactory factory, CacheRegistry registry, MeshOptions options) {
+		super(createCache(factory, options.getGraphQLOptions().getSchemaCacheSize()), registry, options.getGraphQLOptions().getSchemaCacheSize());
+	}
+
+	/**
+	 * Create the cache instance
+	 * @param factory cache factory
+	 * @return cache instance
+	 */
+	private static EventAwareCache<String, GraphQLSchema> createCache(EventAwareCacheFactory factory, long cacheSize) {
+		return factory.<String, GraphQLSchema>builder()
+			.events(EVENTS)
+			.action((event, cache) -> {
+				cache.invalidate();
+			})
+			.name("graphql_schema")
+			.maxSize(cacheSize)
+			.build();
+	}
+}

--- a/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/QueryTypeProvider.java
+++ b/verticles/graphql/src/main/java/com/gentics/mesh/graphql/type/QueryTypeProvider.java
@@ -49,6 +49,7 @@ import graphql.GraphQLError;
 import graphql.execution.DataFetcherResult;
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.gentics.mesh.cache.GraphQLSchemaCache;
 import com.gentics.mesh.cli.BootstrapInitializer;
 import com.gentics.mesh.core.action.DAOActionsCollection;
 import com.gentics.mesh.core.data.HibNodeFieldContainer;
@@ -160,6 +161,8 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 
 	protected final DAOActionsCollection actions;
 
+	protected final GraphQLSchemaCache cache;
+
 	@Inject
 	public QueryTypeProvider(MeshOptions options, MeshTypeProvider meshTypeProvider,
 			InterfaceTypeProvider interfaceTypeProvider, MicronodeFieldTypeProvider micronodeFieldTypeProvider,
@@ -173,7 +176,7 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 			RoleSearchHandler roleSearchHandler, GroupSearchHandler groupSearchHandler,
 			ProjectSearchHandler projectSearchHandler, TagFamilySearchHandler tagFamilySearchHandler,
 			TagSearchHandler tagSearchHandler, PluginTypeProvider pluginProvider,
-			PluginApiTypeProvider pluginApiProvider, DAOActionsCollection actions) {
+			PluginApiTypeProvider pluginApiProvider, DAOActionsCollection actions, GraphQLSchemaCache cache) {
 		super(options);
 		this.meshTypeProvider = meshTypeProvider;
 		this.interfaceTypeProvider = interfaceTypeProvider;
@@ -202,6 +205,7 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 		this.pluginProvider = pluginProvider;
 		this.pluginApiProvider = pluginApiProvider;
 		this.actions = actions;
+		this.cache = cache;
 	}
 
 	/**
@@ -599,68 +603,89 @@ public class QueryTypeProvider extends AbstractTypeProvider {
 	 * @return
 	 */
 	public GraphQLSchema getRootSchema(GraphQLContext context) {
-		HibProject project = Tx.get().getProject(context);
-		graphql.schema.GraphQLSchema.Builder builder = GraphQLSchema.newSchema();
+		String cacheKey = getCacheKey(context);
 
-		Set<GraphQLType> additionalTypes = new HashSet<>();
+		return cache.get(cacheKey, key -> {
+			HibProject project = Tx.get().getProject(context);
+			graphql.schema.GraphQLSchema.Builder builder = GraphQLSchema.newSchema();
 
-		additionalTypes.add(schemaTypeProvider.createType(context));
-		additionalTypes.add(newPageType(SCHEMA_PAGE_TYPE_NAME, SCHEMA_TYPE_NAME));
+			Set<GraphQLType> additionalTypes = new HashSet<>();
 
-		additionalTypes.add(microschemaTypeProvider.createType());
-		additionalTypes.add(newPageType(MICROSCHEMA_PAGE_TYPE_NAME, MICROSCHEMA_TYPE_NAME));
+			additionalTypes.add(schemaTypeProvider.createType(context));
+			additionalTypes.add(newPageType(SCHEMA_PAGE_TYPE_NAME, SCHEMA_TYPE_NAME));
 
-		additionalTypes.add(nodeTypeProvider.createVersionInfoType());
-		additionalTypes.add(nodeTypeProvider.createType(context).forVersion(context));
-		additionalTypes.add(newPageType(NODE_PAGE_TYPE_NAME, NODE_TYPE_NAME));
+			additionalTypes.add(microschemaTypeProvider.createType());
+			additionalTypes.add(newPageType(MICROSCHEMA_PAGE_TYPE_NAME, MICROSCHEMA_TYPE_NAME));
 
-		additionalTypes.add(nodeReferenceTypeProvider.createType());
-		additionalTypes.add(newPageType(NODE_REFERENCE_PAGE_TYPE_NAME, NODE_REFERENCE_TYPE_NAME));
+			additionalTypes.add(nodeTypeProvider.createVersionInfoType());
+			additionalTypes.add(nodeTypeProvider.createType(context).forVersion(context));
+			additionalTypes.add(newPageType(NODE_PAGE_TYPE_NAME, NODE_TYPE_NAME));
 
-		additionalTypes.add(micronodeFieldTypeProvider.createType(context).forVersion(context));
+			additionalTypes.add(nodeReferenceTypeProvider.createType());
+			additionalTypes.add(newPageType(NODE_REFERENCE_PAGE_TYPE_NAME, NODE_REFERENCE_TYPE_NAME));
 
-		additionalTypes.add(projectTypeProvider.createType(project));
-		additionalTypes.add(newPageType(PROJECT_PAGE_TYPE_NAME, PROJECT_TYPE_NAME));
+			additionalTypes.add(micronodeFieldTypeProvider.createType(context).forVersion(context));
 
-		additionalTypes.add(projectReferenceTypeProvider.createType());
-		additionalTypes.add(newPageType(PROJECT_REFERENCE_PAGE_TYPE_NAME, PROJECT_REFERENCE_TYPE_NAME));
+			additionalTypes.add(projectTypeProvider.createType(project));
+			additionalTypes.add(newPageType(PROJECT_PAGE_TYPE_NAME, PROJECT_TYPE_NAME));
 
-		additionalTypes.add(tagTypeProvider.createType());
-		additionalTypes.add(newPageType(TAG_PAGE_TYPE_NAME, TAG_TYPE_NAME));
+			additionalTypes.add(projectReferenceTypeProvider.createType());
+			additionalTypes.add(newPageType(PROJECT_REFERENCE_PAGE_TYPE_NAME, PROJECT_REFERENCE_TYPE_NAME));
 
-		additionalTypes.add(tagFamilyTypeProvider.createType());
-		additionalTypes.add(newPageType(TAG_FAMILY_PAGE_TYPE_NAME, TAG_FAMILY_TYPE_NAME));
+			additionalTypes.add(tagTypeProvider.createType());
+			additionalTypes.add(newPageType(TAG_PAGE_TYPE_NAME, TAG_TYPE_NAME));
 
-		additionalTypes.add(userTypeProvider.createType());
-		additionalTypes.add(newPageType(USER_PAGE_TYPE_NAME, USER_TYPE_NAME));
+			additionalTypes.add(tagFamilyTypeProvider.createType());
+			additionalTypes.add(newPageType(TAG_FAMILY_PAGE_TYPE_NAME, TAG_FAMILY_TYPE_NAME));
 
-		additionalTypes.add(groupTypeProvider.createType());
-		additionalTypes.add(newPageType(GROUP_PAGE_TYPE_NAME, GROUP_TYPE_NAME));
+			additionalTypes.add(userTypeProvider.createType());
+			additionalTypes.add(newPageType(USER_PAGE_TYPE_NAME, USER_TYPE_NAME));
 
-		additionalTypes.add(roleTypeProvider.createType());
-		additionalTypes.add(newPageType(ROLE_PAGE_TYPE_NAME, ROLE_TYPE_NAME));
+			additionalTypes.add(groupTypeProvider.createType());
+			additionalTypes.add(newPageType(GROUP_PAGE_TYPE_NAME, GROUP_TYPE_NAME));
 
-		additionalTypes.add(branchTypeProvider.createType());
+			additionalTypes.add(roleTypeProvider.createType());
+			additionalTypes.add(newPageType(ROLE_PAGE_TYPE_NAME, ROLE_TYPE_NAME));
 
-		additionalTypes.add(pluginProvider.createType());
-		additionalTypes.add(newPageType(PLUGIN_PAGE_TYPE_NAME, PLUGIN_TYPE_NAME));
+			additionalTypes.add(branchTypeProvider.createType());
 
-		additionalTypes.add(meshTypeProvider.createType());
-		additionalTypes.add(interfaceTypeProvider.createPermInfoType());
-		additionalTypes.add(fieldDefProvider.createBinaryFieldType());
-		additionalTypes.add(fieldDefProvider.createS3BinaryFieldType());
+			additionalTypes.add(pluginProvider.createType());
+			additionalTypes.add(newPageType(PLUGIN_PAGE_TYPE_NAME, PLUGIN_TYPE_NAME));
 
-		// Shared argument types
-		additionalTypes.add(createLinkEnumType());
-		additionalTypes.add(createNodeEnumType());
+			additionalTypes.add(meshTypeProvider.createType());
+			additionalTypes.add(interfaceTypeProvider.createPermInfoType());
+			additionalTypes.add(fieldDefProvider.createBinaryFieldType());
+			additionalTypes.add(fieldDefProvider.createS3BinaryFieldType());
 
-		Versioned.doSince(2, context, () -> {
-			additionalTypes.addAll(nodeTypeProvider.generateSchemaFieldTypes(context).forVersion(context));
-			additionalTypes.addAll(micronodeFieldTypeProvider.generateMicroschemaFieldTypes(context).forVersion(context));
+			// Shared argument types
+			additionalTypes.add(createLinkEnumType());
+			additionalTypes.add(createNodeEnumType());
+
+			Versioned.doSince(2, context, () -> {
+				additionalTypes.addAll(nodeTypeProvider.generateSchemaFieldTypes(context).forVersion(context));
+				additionalTypes.addAll(micronodeFieldTypeProvider.generateMicroschemaFieldTypes(context).forVersion(context));
+			});
+
+			GraphQLSchema schema = builder.query(getRootType(context)).additionalTypes(additionalTypes).build();
+			return schema;
 		});
-
-		GraphQLSchema schema = builder.query(getRootType(context)).additionalTypes(additionalTypes).build();
-		return schema;
 	}
 
+	/**
+	 * Get the cache key for the context.
+	 * The cache key consists of
+	 * <ol>
+	 * <li>Project UUID</li>
+	 * <li>Branch UUID</li>
+	 * <li>API Version</li>
+	 * </ol>
+	 * @param context graphql context
+	 * @return cache key
+	 */
+	protected String getCacheKey(GraphQLContext context) {
+		HibProject project = Tx.get().getProject(context);
+		HibBranch branch = Tx.get().getBranch(context);
+
+		return String.format("%s-%s-%d", project.getUuid(), branch.getUuid(), context.getApiVersion());
+	}
 }


### PR DESCRIPTION
## Abstract

Without caching, the GraphQlSchema instances were created on every request. Creating the instances could be slow, if hundreds (or thousands) of schemas are assigned to the project.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
