### PR TITLE
SUP-16283: Make bulk request loader follow the limits in the edge cases

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,8 +17,8 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
-[[v1.10.25]]
-== 1.10.25 (17.01.2024)
+[[v1.10.26]]
+== 1.10.26 (TBD)
 
 icon:check[] Elasticsearch: A possibility of DDoSing the ES with a bulk request of too many items has been eliminated.
 

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,6 +20,11 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.10.25]]
 == 1.10.25 (17.01.2024)
 
+icon:check[] Elasticsearch: A possibility of DDoSing the ES with a bulk request of too many items has been eliminated.
+
+[[v1.10.25]]
+== 1.10.25 (17.01.2024)
+
 icon:check[] GraphQL: Fetching of micronode fields has been improved to allow batch loading.
 
 [[v1.10.24]]

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/bulk/BulkOperator.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/bulk/BulkOperator.java
@@ -90,7 +90,7 @@ public class BulkOperator implements FlowableOperator<SearchRequest, SearchReque
 				skipIfMultipleThreads(lock, () -> {
 					if (!canceled.get() && requested.get() > 0 && !bulkableRequests.isEmpty() && flushActive.get() && flushing.compareAndSet(true, false)) {
 						timer.stop();
-						log.error("Emitting bulk of size {} to subscriber", bulkableRequests.size());
+						log.debug("Emitting bulk of size {} to subscriber", bulkableRequests.size());
 						do {
 							AtomicLong bulkLength = new AtomicLong(0);
 							List<Bulkable> requests = IntStream.range(0, requestLimit)

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/bulk/BulkOperator.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/bulk/BulkOperator.java
@@ -49,6 +49,9 @@ public class BulkOperator implements FlowableOperator<SearchRequest, SearchReque
 	private final long lengthLimit;
 	private ActualBulkOperator<SearchRequest> operator;
 
+	/**
+ 	 * This package-protected switch is for testing purposes only. Avoid using it during runtime.
+    	 */
 	final AtomicBoolean flushActive = new AtomicBoolean(true);
 
 	public BulkOperator(Vertx vertx, Duration bulkTime, int requestLimit, long lengthLimit) {

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/bulk/BulkQueue.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/bulk/BulkQueue.java
@@ -2,6 +2,7 @@ package com.gentics.mesh.search.verticle.bulk;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -39,5 +40,12 @@ class BulkQueue {
 
 	public List<Bulkable> asList() {
 		return new ArrayList<>(bulkableRequests);
+	}
+
+	public Optional<Bulkable> poll() {
+		return Optional.ofNullable(bulkableRequests.poll()).map(polled -> {
+			bulkLength -= polled.bulkLength();
+			return polled;
+		});
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
@@ -59,7 +59,14 @@ public class ElasticSearchProviderTimeoutTest extends AbstractMeshTest {
 			}
 		});
 		server.rxListen().blockingGet();
+	}
 
+	@Test
+	public void testHugeBatch() throws IOException {
+		String username = "testuser";
+		for (int i = 0; i < 1200; i++) {
+			createUser(username + i);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Abstract

There exists a possibility of DDoSing the Elasticsearch server, if a network glitch makes Mesh collecting unlimited ES requests, which are then pushed for the processing all at once.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
