### PR TITLE
Hotfix 2.0.x SUP-16159 Improve WebSocket error handling

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,16 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.27]]
+== 1.10.27 (TBD)
+
+icon:check[] REST client: Improves error handling for WebSocket errors.
+
+[[v1.10.26]]
+== 1.10.26 (TBD)
+
+icon:check[] Auth: Synchronization of users, groups and roles from AuthServicePlugin implementations (like the keycloak plugin) has been improved for performance and stability.
+
 [[v1.10.25]]
 == 1.10.25 (17.01.2024)
 
@@ -27,7 +37,7 @@ icon:check[] GraphQL: Fetching of micronode fields has been improved to allow ba
 
 icon:check[] REST: The documentation of the generic parameter `fields` has been fixed. Now `fields` works over the Language entities as well, the values are `uuid`,`name`,`languageTag`,`nativeName`.
 
-icon:check[] GraphQL: Some of (micro)schema fields related queries rely on the target (micro)schema having at least one field, crashing in HTTP 500 otherwise. This has now been fixed. 
+icon:check[] GraphQL: Some of (micro)schema fields related queries rely on the target (micro)schema having at least one field, crashing in HTTP 500 otherwise. This has now been fixed.
 
 [[v1.10.23]]
 == 1.10.23 (20.12.2023)
@@ -38,7 +48,7 @@ icon:check[] Auth: The unnecessary logging of outdated/mismatched auth token has
 
 icon:check[] GraphQL: The overall performance of GraphQL requests has been improved by caching the GraphQL schemas.
 
-icon:check[] Core: Now it is not allowed to set a new password to an empty or invalid (e.g. spaces) string. 
+icon:check[] Core: Now it is not allowed to set a new password to an empty or invalid (e.g. spaces) string.
 
 [[v1.10.22]]
 == 1.10.22 (06.12.2023)
@@ -66,7 +76,7 @@ icon:check[] GraphQL: `referencedBy` field fetcher has been refactored for more 
 [[v1.10.19]]
 == 1.10.19 (02.11.2023)
 
-icon:check[] GraphQL: Performance optimizations of the Elasticsearch-based requests. 
+icon:check[] GraphQL: Performance optimizations of the Elasticsearch-based requests.
 
 == 1.10.18 (24.10.2023)
 
@@ -92,7 +102,7 @@ icon:check[] Core: More NPE occurrences during the massive concurrent publishing
 [[v1.10.15]]
 == 1.10.15 (20.09.2023)
 
-icon:check[] Core: When running in the massive concurrent publishing process, it is possible to run into a race condition when some field containers are already processed while being referenced by the edge, 
+icon:check[] Core: When running in the massive concurrent publishing process, it is possible to run into a race condition when some field containers are already processed while being referenced by the edge,
 throwing an NPE. This has now been fixed.
 
 [[v1.10.14]]
@@ -140,7 +150,7 @@ icon:check[] GraphQL: Performance of queries that return large amounts of nodes 
 [[v1.9.14]]
 == 1.9.14 (19.04.2023)
 
-icon:check[] Core: The name of a Mesh user is now forced to be unique on a database level, to prevent creating users with an already existing username. The duplicated username detection mechanism has also been improved. 
+icon:check[] Core: The name of a Mesh user is now forced to be unique on a database level, to prevent creating users with an already existing username. The duplicated username detection mechanism has also been improved.
 
 CAUTION: Duplicate usernames must be removed before the update, otherwise Mesh will fail to start!
 
@@ -187,7 +197,7 @@ icon:check[] Core: Corner case of updating the webroot info might throw a false 
 [[v1.8.21]]
 == 1.8.21 (19.04.2023)
 
-icon:check[] Core: The name of a Mesh user is now forced to be unique on a database level, to prevent creating users with an already existing username. The duplicated username detection mechanism has also been improved. 
+icon:check[] Core: The name of a Mesh user is now forced to be unique on a database level, to prevent creating users with an already existing username. The duplicated username detection mechanism has also been improved.
 
 CAUTION: Duplicate usernames must be removed before the update, otherwise Mesh will fail to start!
 

--- a/changelog/src/changelog/entries/2024/02/7673.SUP-16159.bugfix
+++ b/changelog/src/changelog/entries/2024/02/7673.SUP-16159.bugfix
@@ -1,0 +1,1 @@
+REST client: Improves error handling for WebSocket errors.

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/EventbusEvent.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/EventbusEvent.java
@@ -15,13 +15,20 @@ public class EventbusEvent {
 
 	/**
 	 * Parses a websocket text frame.
-	 * @param rawText
+	 * @param rawText The text frame to process.
 	 * @throws IOException
 	 */
 	public EventbusEvent(String rawText) throws IOException {
-		ObjectNode parsed = (ObjectNode) JsonUtil.getMapper().readTree(rawText);
-		address = parsed.get("address").textValue();
-		body = parsed.get("body");
+		this((ObjectNode) JsonUtil.getMapper().readTree(rawText));
+	}
+
+	/**
+	 * Extract address and body from an already parsed text frame.
+	 * @param parsedMessage The parsed text frame.
+	 */
+	public EventbusEvent(ObjectNode parsedMessage) {
+		address = parsedMessage.get("address").textValue();
+		body = parsedMessage.get("body");
 	}
 
 	/**

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/OkHttpWebsocket.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/OkHttpWebsocket.java
@@ -1,5 +1,8 @@
 package com.gentics.mesh.rest.client.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.rest.client.EventbusEvent;
 import com.gentics.mesh.rest.client.MeshRestClientConfig;
 import com.gentics.mesh.rest.client.MeshWebsocket;
@@ -20,8 +23,10 @@ import okio.ByteString;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,7 +35,7 @@ import java.util.stream.Stream;
 import static com.gentics.mesh.rest.client.impl.Util.eventbusMessage;
 
 /**
- * Websocket client implementation for {@link OkHttpClient}. 
+ * Websocket client implementation for {@link OkHttpClient}.
  */
 public class OkHttpWebsocket implements MeshWebsocket {
 
@@ -59,6 +64,36 @@ public class OkHttpWebsocket implements MeshWebsocket {
 		errors.subscribe(err -> log.error("Error in Websocket", err));
 	}
 
+	/**
+	 * Create an {@link EventbusEvent} from the given WebSocket message text.
+	 *
+	 * @param text The WebSocket message.
+	 * @return An {@code Optional} with the created {@code EventbusEvent} if
+	 * 		successful or an empty {@code Optional} when {@code text} does not
+	 * 		contain the expected fields.
+	 * @throws IOException
+	 */
+	private Optional<EventbusEvent> createEvent(String text) throws IOException {
+		ObjectNode parsed = (ObjectNode) JsonUtil.getMapper().readTree(text);
+		JsonNode type = parsed.get("type");
+
+		if (type != null && type.isTextual() && "err".equals(type.asText())) {
+			log.warn("WebSocket error: {}", parsed.get("body"));
+
+			return Optional.empty();
+		}
+
+		JsonNode address = parsed.get("address");
+
+		if (address == null || !address.isTextual()) {
+			log.warn("Unexpected WebSocket message: {}", text);
+
+			return Optional.empty();
+		}
+
+		return Optional.of(new EventbusEvent(parsed));
+	}
+
 	private void connect() {
 		Request request = new Request.Builder()
 			.url(config.getBaseUrl() + "/eventbus/websocket")
@@ -74,7 +109,7 @@ public class OkHttpWebsocket implements MeshWebsocket {
 			@Override
 			public void onOpen(WebSocket webSocket, Response response) {
 				connected.set(true);
-				sendRegisterEvents();
+				sendRegisterEvents(registeredEventAddresses);
 				log.debug("Connection established, sending connection event");
 				connections.onNext(connectionDummy);
 			}
@@ -84,7 +119,7 @@ public class OkHttpWebsocket implements MeshWebsocket {
 				log.trace("Received message: {}", text);
 
 				try {
-					events.onNext(new EventbusEvent(text));
+					createEvent(text).ifPresent(events::onNext);
 				} catch (IOException e) {
 					errors.onNext(new Exception("Could not parse message from mesh", e));
 				}
@@ -149,8 +184,9 @@ public class OkHttpWebsocket implements MeshWebsocket {
 
 	@Override
 	public void registerEvents(String... eventNames) {
-		registeredEventAddresses.addAll(Arrays.asList(eventNames));
-		sendRegisterEvents();
+		Set<String> newAddresses = addEventAddresses(eventNames);
+
+		sendRegisterEvents(newAddresses);
 	}
 
 	@Override
@@ -158,8 +194,26 @@ public class OkHttpWebsocket implements MeshWebsocket {
 		Stream.of(eventNames).forEach(registeredEventAddresses::remove);
 	}
 
-	private void sendRegisterEvents() {
-		registeredEventAddresses.forEach(address -> send(eventbusMessage(EventbusMessageType.REGISTER, address)));
+	/**
+	 * Adds all given event addresses to {@link #registeredEventAddresses} and
+	 * returns a {@code Set} containing only new addresses.
+	 *
+	 * @param eventAddresses The event addresses to add.
+	 * @return A {@code Set} containing all input addresses that were not
+	 * 		already registered.
+	 */
+	private synchronized Set<String> addEventAddresses(String[] eventAddresses) {
+		Set<String> newEventAddresses = new HashSet<>(eventAddresses.length);
+
+		Collections.addAll(newEventAddresses, eventAddresses);
+		newEventAddresses.removeAll(registeredEventAddresses);
+		registeredEventAddresses.addAll(newEventAddresses);
+
+		return newEventAddresses;
+	}
+
+	private void sendRegisterEvents(Collection<String> eventAddresses) {
+		eventAddresses.forEach(address -> send(eventbusMessage(EventbusMessageType.REGISTER, address)));
 	}
 
 	private void send(String text) {


### PR DESCRIPTION
## Abstract

Errors from Vert.x when creating an eventbus WebSocket where not handled which caused a NullPointerException during event creation. Typical errors like invalid event addresses are now handled, and multiple registrations of the same address no longer lead to errors.
## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
