### PR TITLE
Fix checks when creating a language variant of the project root node

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,10 +20,12 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.10.27]]
 == 1.10.27 (TBD)
 
-icon:check[] REST client: Improves error handling for WebSocket errors.
+icon:check[] Core: Creating a translation for the root node of a project always failed with a "Bad Request" error, which has been fixed.
 
 [[v1.10.26]]
-== 1.10.26 (TBD)
+== 1.10.26 (07.02.2024)
+
+icon:check[] REST client: Improves error handling for WebSocket errors.
 
 icon:check[] GraphQL: When an inexisting language has been requested for a node, the schema info was not loaded as well. This has been fixed.
 

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingContentDao.java
@@ -683,7 +683,7 @@ public interface PersistingContentDao extends ContentDao {
 			String segmentInfo = composeSegmentInfo(parentNode, segment);
 
 			String currentSegmentInfo = edge.getSegmentInfo();
-			if (StringUtils.equals(segmentInfo, currentSegmentInfo)) {
+			if (StringUtils.equals(segmentInfo, currentSegmentInfo) || (StringUtils.isEmpty(segmentInfo) && StringUtils.isEmpty(currentSegmentInfo))) {
 				return true;
 			}
 

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingNodeDao.java
@@ -1417,7 +1417,7 @@ public interface PersistingNodeDao extends NodeDao, PersistingRootDao<HibProject
 		if (latestDraftVersion == null) {
 			// Check whether the node has a parent node in this branch, if not, the request is supposed to be a create request
 			// and we get the parent node from this create request
-			if (getParentNode(node, branch.getUuid()) == null) {
+			if (!node.isBaseNode() && getParentNode(node, branch.getUuid()) == null) {
 				NodeCreateRequest createRequest = JsonUtil.readValue(ac.getBodyAsString(), NodeCreateRequest.class);
 				if (createRequest.getParentNode() == null || isEmpty(createRequest.getParentNode().getUuid())) {
 					throw error(BAD_REQUEST, "node_missing_parentnode_field");


### PR DESCRIPTION
## Abstract

When creating a new translation of a project's root node, the parent node uuid is not required, because the root node does not have a parent anyways.
Also the check for uniqueness of the segment field value has been fixed to treat empty string and null both as "not set".

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
