### PR TITLE
Branch cache invalidation improved

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.27]]
+== 1.10.27 (TBD)
+
+icon:check[] Because of a flawed cache invalidation strategy, the project stayed on an old 'latest' branch, even if a new one has been assigned, until the caches are invalidated, or a restart is triggered. This has been fixed.
+
 [[v1.10.26]]
 == 1.10.26 (07.02.2024)
 

--- a/core/src/main/java/com/gentics/mesh/cache/ProjectBranchNameCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/ProjectBranchNameCacheImpl.java
@@ -5,6 +5,7 @@ import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_DELETED;
 import static com.gentics.mesh.core.rest.MeshEvent.BRANCH_UPDATED;
 import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_DATABASE_CHANGE_STATUS;
 import static com.gentics.mesh.core.rest.MeshEvent.CLUSTER_NODE_JOINED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_LATEST_BRANCH_UPDATED;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -29,6 +30,7 @@ public class ProjectBranchNameCacheImpl extends AbstractNameCache<HibBranch> imp
 				BRANCH_DELETED,
 				CLUSTER_NODE_JOINED,
 				CLUSTER_DATABASE_CHANGE_STATUS,
+				PROJECT_LATEST_BRANCH_UPDATED
 			});
 	}
 }

--- a/core/src/main/java/com/gentics/mesh/cache/WebrootPathCacheImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cache/WebrootPathCacheImpl.java
@@ -11,6 +11,7 @@ import static com.gentics.mesh.core.rest.MeshEvent.NODE_MOVED;
 import static com.gentics.mesh.core.rest.MeshEvent.NODE_PUBLISHED;
 import static com.gentics.mesh.core.rest.MeshEvent.NODE_UNPUBLISHED;
 import static com.gentics.mesh.core.rest.MeshEvent.NODE_UPDATED;
+import static com.gentics.mesh.core.rest.MeshEvent.PROJECT_LATEST_BRANCH_UPDATED;
 import static com.gentics.mesh.core.rest.MeshEvent.SCHEMA_MIGRATION_FINISHED;
 
 import javax.inject.Inject;
@@ -48,7 +49,9 @@ public class WebrootPathCacheImpl extends AbstractMeshCache<String, Path> implem
 		CLUSTER_NODE_JOINED,
 		CLUSTER_DATABASE_CHANGE_STATUS,
 		SCHEMA_MIGRATION_FINISHED,
-		BRANCH_UPDATED};
+		BRANCH_UPDATED,
+		PROJECT_LATEST_BRANCH_UPDATED
+	};
 
 	@Inject
 	public WebrootPathCacheImpl(EventAwareCacheFactory factory, CacheRegistry registry, MeshOptions options) {


### PR DESCRIPTION
## Abstract

A latest-assignment event has been missing in the branch name cache invalidation strategy.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
