### PR TITLE
SUP-16105: Support for newer Keycloak versions

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,13 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.27]]
+== 1.10.27 (TBD)
+
+icon:check[] A regression regarding OAuth user filtering has been fixed.
+
+icon:check[] Minor improvements in authentication-related utilities Java API, allowing more control over authentication URL management.
+
 [[v1.10.26]]
 == 1.10.26 (07.02.2024)
 

--- a/services/jwt-auth/src/main/java/com/gentics/mesh/auth/util/KeycloakUtils.java
+++ b/services/jwt-auth/src/main/java/com/gentics/mesh/auth/util/KeycloakUtils.java
@@ -27,8 +27,10 @@ public final class KeycloakUtils {
 
 	private static final Logger log = LoggerFactory.getLogger(KeycloakUtils.class);
 
-	// TODO The default format has to be changed to the one applicable for KC 22+ (no /auth segment). This is a breaking change though.
-	public static final String DEFAULT_REALM_URL_FORMAT = "%s://%s:%d/auth/realms/%s";
+	private static final String DEFAULT_REALM_URL_FORMAT = "%s://%s:%d%s/realms/%s";
+
+	// TODO consider updating this to the default of KC 17+: empty string
+	public static final String DEFAULT_REALM_URL_PREFIX = "/auth";
 
 	private KeycloakUtils() {
 	}
@@ -75,14 +77,14 @@ public final class KeycloakUtils {
 	 * @param host
 	 * @param port
 	 * @param realmName
-	 * @param maybeCustomRealmUrlFormat optional realm URL format, suitable for Java formatter with parameters [protocol, host, port, realm name], e.g. '%s://%s:%d/auth/realms/%s'
+	 * @param maybeCustomRealmUrlPrefix optional realm URL prefix
 	 * @return
 	 * @throws IOException
 	 */
-	public static Set<JsonObject> loadJWKs(String protocol, String host, int port, String realmName, Optional<String> maybeCustomRealmUrlFormat) throws IOException {
+	public static Set<JsonObject> loadJWKs(String protocol, String host, int port, String realmName, Optional<String> maybeCustomRealmUrlPrefix) throws IOException {
 		Request request = new Request.Builder()
 			.header("Accept", "application/json")
-			.url(String.format(maybeCustomRealmUrlFormat.orElse(DEFAULT_REALM_URL_FORMAT), protocol, host, port, realmName) + "/protocol/openid-connect/certs")
+			.url(String.format(DEFAULT_REALM_URL_FORMAT, protocol, host, port, maybeCustomRealmUrlPrefix.orElse(DEFAULT_REALM_URL_PREFIX), realmName) + "/protocol/openid-connect/certs")
 			.build();
 
 		try (Response response = httpClient().newCall(request).execute()) {
@@ -123,15 +125,15 @@ public final class KeycloakUtils {
 	 * @param host
 	 * @param port
 	 * @param realmName
-	 * @param maybeCustomRealmUrlFormat optional realm URL format, suitable for Java formatter with parameters [protocol, host, port, realm name], e.g. '%s://%s:%d/auth/realms/%s'
+	 * @param maybeCustomRealmUrlPrefix optional realm URL prefix
 	 * @return Realm information
 	 * @throws IOException
 	 */
-	public static JsonObject fetchPublicRealmInfo(String protocol, String host, int port, String realmName, Optional<String> maybeCustomRealmUrlFormat) throws IOException {
+	public static JsonObject fetchPublicRealmInfo(String protocol, String host, int port, String realmName, Optional<String> maybeCustomRealmUrlPrefix) throws IOException {
 
 		Request request = new Request.Builder()
 			.header("Accept", "application/json")
-			.url(String.format(maybeCustomRealmUrlFormat.orElse(DEFAULT_REALM_URL_FORMAT), protocol, host, port, realmName))
+			.url(String.format(DEFAULT_REALM_URL_FORMAT, protocol, host, port, maybeCustomRealmUrlPrefix.orElse(DEFAULT_REALM_URL_PREFIX), realmName))
 			.build();
 
 		try (Response response = httpClient().newCall(request).execute()) {
@@ -174,23 +176,31 @@ public final class KeycloakUtils {
 	 * @param username
 	 * @param password
 	 * @param secret
-	 * @param maybeCustomRealmUrlFormat optional realm URL format, suitable for Java formatter with parameters [protocol, host, port, realm name], e.g. '%s://%s:%d/auth/realms/%s'
+	 * @param maybeCustomRealmUrlPrefix optional realm URL prefix
 	 * @return
 	 * @throws IOException
 	 */
 	public static JsonObject loginKeycloak(String protocol, String host, int port, String realmName, String clientId, String username,
-		String password, String secret, Optional<String> maybeCustomRealmUrlFormat) throws IOException {
+		String password, String secret, Optional<String> maybeCustomRealmUrlPrefix) throws IOException {
 
 		StringBuilder content = new StringBuilder();
-		content.append("client_id=" + clientId + "&");
-		content.append("username=" + username + "&");
-		content.append("password=" + password + "&");
-		content.append("grant_type=password&");
-		content.append("client_secret=" + secret);
+		content.append("client_id=");
+		content.append(clientId);
+		content.append("&");
+		content.append("username=");
+		content.append(username);
+		content.append("&");
+		content.append("password=");
+		content.append(password);
+		content.append("&");
+		content.append("grant_type=password");
+		content.append("&");
+		content.append("client_secret=");
+		content.append(secret);
 		RequestBody body = RequestBody.create(MediaType.parse("application/x-www-form-urlencoded"), content.toString());
 		Request request = new Request.Builder()
 			.post(body)
-			.url(String.format(maybeCustomRealmUrlFormat.orElse(DEFAULT_REALM_URL_FORMAT), protocol, host, port, realmName) + "/protocol/openid-connect/token")
+			.url(String.format(DEFAULT_REALM_URL_FORMAT, protocol, host, port, maybeCustomRealmUrlPrefix.orElse(DEFAULT_REALM_URL_PREFIX), realmName) + "/protocol/openid-connect/token")
 			.build();
 
 		Response response = httpClient().newCall(request).execute();

--- a/services/jwt-auth/src/main/java/com/gentics/mesh/auth/util/KeycloakUtils.java
+++ b/services/jwt-auth/src/main/java/com/gentics/mesh/auth/util/KeycloakUtils.java
@@ -82,7 +82,7 @@ public final class KeycloakUtils {
 	public static Set<JsonObject> loadJWKs(String protocol, String host, int port, String realmName, Optional<String> maybeCustomRealmUrlFormat) throws IOException {
 		Request request = new Request.Builder()
 			.header("Accept", "application/json")
-			.url(String.format(maybeCustomRealmUrlFormat.orElse(DEFAULT_REALM_URL_FORMAT) + "/protocol/openid-connect/certs", protocol, host, port, realmName))
+			.url(String.format(maybeCustomRealmUrlFormat.orElse(DEFAULT_REALM_URL_FORMAT), protocol, host, port, realmName) + "/protocol/openid-connect/certs")
 			.build();
 
 		try (Response response = httpClient().newCall(request).execute()) {
@@ -190,7 +190,7 @@ public final class KeycloakUtils {
 		RequestBody body = RequestBody.create(MediaType.parse("application/x-www-form-urlencoded"), content.toString());
 		Request request = new Request.Builder()
 			.post(body)
-			.url(String.format(DEFAULT_REALM_URL_FORMAT + "/protocol/openid-connect/token", protocol, host, port, realmName))
+			.url(String.format(maybeCustomRealmUrlFormat.orElse(DEFAULT_REALM_URL_FORMAT), protocol, host, port, realmName) + "/protocol/openid-connect/token")
 			.build();
 
 		Response response = httpClient().newCall(request).execute();

--- a/tests/common/src/main/java/com/gentics/mesh/test/docker/KeycloakContainer.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/docker/KeycloakContainer.java
@@ -66,9 +66,9 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 		setStartupAttempts(1);
 
 		List<String> args = new ArrayList<>();
+		customArgs.stream().forEach(args::add);
 		args.add("-Dkeycloak.migration.usersExportStrategy=SAME_FILE");
 		args.add("-Dkeycloak.migration.strategy=OVERWRITE_EXISTING");
-		customArgs.stream().forEach(args::add);
 
 		if (withConfig) {
 			args.add("-Dkeycloak.import=" + REALM_CONFIG_PATH + (withConfigFolder ? "" : REALM_CONFIG_NAME));
@@ -77,14 +77,13 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 	}
 
 	public static ImageFromDockerfile prepareDockerImage(JsonObject realmConfig, String containerName, String version) {
-		ImageFromDockerfile dockerImage = new ImageFromDockerfile("keycloak-mesh", true);
+		ImageFromDockerfile dockerImage = new ImageFromDockerfile("keycloak-mesh-" + containerName + "-" + version, true);
 		StringBuilder dockerFile = new StringBuilder();
-		dockerFile.append(
-				"FROM " + System.getProperty("mesh.container.image.prefix", "") + containerName + ":" + version + "\n");
+		dockerFile.append("FROM ").append(System.getProperty("mesh.container.image.prefix", "")).append(containerName).append(":").append(version).append("\n");
 
 		if (realmConfig != null) {
-			dockerFile.append("ADD " + REALM_CONFIG_NAME + " " + REALM_CONFIG_PATH + REALM_CONFIG_NAME + "\n");
-			dockerImage.withFileFromString("/realm.json", realmConfig.encodePrettily());
+			dockerFile.append("ADD ").append(REALM_CONFIG_NAME).append(" ").append(REALM_CONFIG_PATH).append(REALM_CONFIG_NAME).append("\n");
+			dockerImage.withFileFromString(REALM_CONFIG_NAME, realmConfig.encodePrettily());
 		}
 		dockerImage.withFileFromString("/Dockerfile", dockerFile.toString());
 		return dockerImage;


### PR DESCRIPTION
## Abstract

An ability to reformat the Keycloak request URL.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
