### PR TITLE
Stop JobWorkerVerticle and wait for currently running jobs before

### DIFF
--- a/common/src/main/java/com/gentics/mesh/verticle/AbstractJobVerticle.java
+++ b/common/src/main/java/com/gentics/mesh/verticle/AbstractJobVerticle.java
@@ -113,6 +113,11 @@ public abstract class AbstractJobVerticle extends AbstractVerticle {
 					if (message != null) {
 						message.reply(new JsonObject().put("status", STATUS_REJECTED));
 					}
+				} else if (stopped) {
+					log.error("Not executing locked action, because processing was stopped");
+					if (message != null) {
+						message.reply(new JsonObject().put("status", STATUS_REJECTED));
+					}
 				} else {
 					Lock lock = rh.result();
 					if (message != null) {

--- a/core/src/main/java/com/gentics/mesh/core/verticle/job/JobWorkerVerticleImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/verticle/job/JobWorkerVerticleImpl.java
@@ -14,7 +14,10 @@ import com.gentics.mesh.verticle.AbstractJobVerticle;
 
 import dagger.Lazy;
 import io.reactivex.Completable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.shareddata.Lock;
 
 /**
  * Dedicated verticle which will process jobs.
@@ -85,6 +88,11 @@ public class JobWorkerVerticleImpl extends AbstractJobVerticle implements JobWor
 	@Override
 	public Completable executeJob(Message<Object> message) {
 		return Completable.defer(() -> jobProcessor.process());
+	}
+
+	@Override
+	public void doWithLock(long timeout, Handler<AsyncResult<Lock>> resultHandler) {
+		vertx.sharedData().getLockWithTimeout(getLockName(), timeout, resultHandler);
 	}
 
 	/**

--- a/mdm/common/src/main/java/com/gentics/mesh/core/verticle/job/JobWorkerVerticle.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/verticle/job/JobWorkerVerticle.java
@@ -1,6 +1,9 @@
 package com.gentics.mesh.core.verticle.job;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
+import io.vertx.core.shareddata.Lock;
 
 /**
  * Worker verticles are used to run job executions.
@@ -21,4 +24,10 @@ public interface JobWorkerVerticle extends Verticle {
 	 */
 	void stop() throws Exception;
 
+	/**
+	 * Wait for the global lock for the given timeout in ms and pass the result to the given handler
+	 * @param timeout timeout in ms
+	 * @param resultHandler result handler
+	 */
+	void doWithLock(long timeout, Handler<AsyncResult<Lock>> resultHandler);
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -495,6 +495,9 @@ public class MeshTestContext implements TestRule {
 		JobWorkerVerticle jobWorkerVerticle = meshDagger.jobWorkerVerticle();
 		jobWorkerVerticle.stop();
 
+		// if any jobs are currently running, they will hold the global lock.
+		// so we will wait until we can acquire the lock, which makes sure that
+		// currently running jobs will have stopped.
 		CountDownLatch jobWait = new CountDownLatch(1);
 		jobWorkerVerticle.doWithLock(1000, rh -> {
 			if (rh.succeeded()) {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -43,6 +43,7 @@ import com.gentics.mesh.cli.MeshImpl;
 import com.gentics.mesh.core.data.search.IndexHandler;
 import com.gentics.mesh.core.db.Database;
 import com.gentics.mesh.core.rest.MeshEvent;
+import com.gentics.mesh.core.verticle.job.JobWorkerVerticle;
 import com.gentics.mesh.crypto.KeyStoreHelper;
 import com.gentics.mesh.dagger.MeshComponent;
 import com.gentics.mesh.etc.config.AuthenticationOptions;
@@ -463,6 +464,8 @@ public class MeshTestContext implements TestRule {
 	 * @throws Exception
 	 */
 	private void resetDatabase(MeshTestSetting settings) throws Exception {
+		stopJobWorker();
+
 		meshDagger.boot().clearReferences();
 		long start = System.currentTimeMillis();
 		if (settings.inMemoryDB() || settings.clusterMode()) {
@@ -474,11 +477,35 @@ public class MeshTestContext implements TestRule {
 			meshTestContextProvider.getInstanceProvider().cleanupPhysicalStorage();
 			meshDagger.database().setupConnectionPool();
 		}
+		meshDagger.jobWorkerVerticle().start();
 		long duration = System.currentTimeMillis() - start;
 		LOG.info("Clearing DB took {" + duration + "} ms.");
 		if (trackingSearchProvider != null) {
 			trackingSearchProvider.reset();
 		}
+	}
+
+	/**
+	 * Stop the JobWorkerVerticle and wait for any jobs, which are still running
+	 * @throws Exception
+	 */
+	private void stopJobWorker() throws Exception {
+		long start = System.currentTimeMillis();
+
+		JobWorkerVerticle jobWorkerVerticle = meshDagger.jobWorkerVerticle();
+		jobWorkerVerticle.stop();
+
+		CountDownLatch jobWait = new CountDownLatch(1);
+		jobWorkerVerticle.doWithLock(1000, rh -> {
+			if (rh.succeeded()) {
+				rh.result().release();
+			} else {
+				LOG.warn("Failed to get job worker verticle lock in");
+			}
+			jobWait.countDown();
+		});
+		jobWait.await(2, TimeUnit.SECONDS);
+		LOG.info(String.format("Stopping JobWorkerVerticle took {%d} ms", System.currentTimeMillis() - start));
 	}
 
 	private void cleanupFolders() throws IOException {


### PR DESCRIPTION
resetting database during test execution

## Abstract

The tested database is reset between test executions. The JobWorkerVerticle (or any of its jobs) should not be running while this is done.

## Checklist

### General

* [x] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
