### PR TITLE
SUP-14117: Admin users should have full access to the data stored in ES

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -24,6 +24,8 @@ icon:check[] Because of a flawed cache invalidation strategy, the project stayed
 
 icon:check[] Core: Creating a translation for the root node of a project always failed with a "Bad Request" error, which has been fixed.
 
+icon:check[] Elasticsearch: A full access to the data backed by ES has been given to the admin users.
+
 [[v1.10.26]]
 == 1.10.26 (07.02.2024)
 


### PR DESCRIPTION
## Abstract

The ES requests currently disobey the ignorance of the permission checks for the admin users.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
