### PR TITLE
SUP-15608: TX API for (re)attaching entities. DB-aware cache.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,7 +20,9 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.10.27]]
 == 1.10.27 (TBD)
 
-icon:check[] Because of a flawed cache invalidation strategy, the project stayed on an old 'latest' branch, even if a new one has been assigned, until the caches are invalidated, or a restart is triggered. This has been fixed.
+icon:check[] Cache: A mechanism of reattaching the cached entity to the persistence context has been introduced, allowing implementations of smarter cache policies.
+
+icon:check[] Cache: Because of a flawed cache invalidation strategy, the project stayed on an old 'latest' branch, even if a new one has been assigned, until the caches are invalidated, or a restart is triggered. This has been fixed.
 
 icon:check[] Core: Creating a translation for the root node of a project always failed with a "Bad Request" error, which has been fixed.
 

--- a/common/src/main/java/com/gentics/mesh/cache/impl/EventAwareCacheImpl.java
+++ b/common/src/main/java/com/gentics/mesh/cache/impl/EventAwareCacheImpl.java
@@ -12,6 +12,8 @@ import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.gentics.mesh.cache.EventAwareCache;
+import com.gentics.mesh.core.db.CommonTx;
+import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.MeshEvent;
 import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.event.EventBusStore;
@@ -188,13 +190,13 @@ public class EventAwareCacheImpl<K, V> implements EventAwareCache<K, V> {
 			} else {
 				hitCounter.increment();
 			}
-			return value.orElse(null);
+			return value.map(this::attachToPersistedState).orElse(null);
 		} else {
 			@Nullable Optional<V> value = cache.getIfPresent(key);
 			if (value == null) {
 				return null;
 			}
-			return value.orElse(null);
+			return value.map(this::attachToPersistedState).orElse(null);
 		}
 	}
 
@@ -218,7 +220,7 @@ public class EventAwareCacheImpl<K, V> implements EventAwareCache<K, V> {
 			} else {
 				missCounter.increment();
 			}
-			return value.orElse(null);
+			return value.map(this::attachToPersistedState).orElse(null);
 		} else {
 			@Nullable Optional<V> value = cache.getIfPresent(key);
 			if (value == null) {
@@ -227,8 +229,18 @@ public class EventAwareCacheImpl<K, V> implements EventAwareCache<K, V> {
 					cache.put(key, value);
 				}
 			}
-			return value.orElse(null);
+			return value.map(this::attachToPersistedState).orElse(null);
 		}
+	}
+
+	/**
+	 * Try to attach the cached entity to the persistence provider, if available and supported.
+	 * 
+	 * @param element
+	 * @return
+	 */
+	protected V attachToPersistedState(V element) {
+		return Tx.maybeGet().map(Tx::<CommonTx>unwrap).map(ctx -> ctx.attach(element, false)).orElse(element);
 	}
 
 	/**

--- a/core/src/main/java/com/gentics/mesh/cache/AbstractNameCache.java
+++ b/core/src/main/java/com/gentics/mesh/cache/AbstractNameCache.java
@@ -1,6 +1,7 @@
 package com.gentics.mesh.cache;
 
 import com.gentics.mesh.cache.impl.EventAwareCacheFactory;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibNamedElement;
 import com.gentics.mesh.core.rest.MeshEvent;
 
@@ -11,7 +12,7 @@ import com.gentics.mesh.core.rest.MeshEvent;
  *
  * @param <V>
  */
-public abstract class AbstractNameCache<V extends HibNamedElement> extends AbstractMeshCache<String, V> implements NameCache<V> {
+public abstract class AbstractNameCache<V extends HibNamedBaseElement> extends AbstractMeshCache<String, V> implements NameCache<V> {
 
 	public static final long CACHE_SIZE = 100;
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibLanguage.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibLanguage.java
@@ -9,7 +9,7 @@ import static com.gentics.mesh.ElementType.LANGUAGE;
 /**
  * Domain model for languages.
  */
-public interface HibLanguage extends HibCoreElement<LanguageResponse>, HibNamedElement {
+public interface HibLanguage extends HibCoreElement<LanguageResponse>, HibNamedBaseElement {
 
 	TypeInfo TYPE_INFO = new TypeInfo(LANGUAGE, null, null, null);
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/branch/HibBranch.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/branch/HibBranch.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.TypeInfo;
 import com.gentics.mesh.core.data.HibCoreElement;
-import com.gentics.mesh.core.data.HibNamedElement;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibNodeFieldContainer;
 import com.gentics.mesh.core.data.HibProjectElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
@@ -57,7 +57,7 @@ import com.gentics.mesh.parameter.PagingParameters;
  * Domain model for branch.
  */
 public interface HibBranch extends HibCoreElement<BranchResponse>, HibReferenceableElement<BranchReference>, 
-		HibUserTracking, HibProjectElement, HibNamedElement, Taggable {
+		HibUserTracking, HibProjectElement, HibNamedBaseElement, Taggable {
 
 	TypeInfo TYPE_INFO = new TypeInfo(BRANCH, BRANCH_CREATED, BRANCH_UPDATED, BRANCH_DELETED);
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/group/HibGroup.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/group/HibGroup.java
@@ -14,7 +14,6 @@ import com.gentics.mesh.core.TypeInfo;
 import com.gentics.mesh.core.data.HibBucketableElement;
 import com.gentics.mesh.core.data.HibCoreElement;
 import com.gentics.mesh.core.data.HibNamedBaseElement;
-import com.gentics.mesh.core.data.HibNamedElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
 import com.gentics.mesh.core.data.dao.GroupDao;
 import com.gentics.mesh.core.data.dao.UserDao;
@@ -32,7 +31,7 @@ import com.gentics.mesh.handler.VersionUtils;
 /**
  * Domain model for group.
  */
-public interface HibGroup extends HibCoreElement<GroupResponse>, HibReferenceableElement<GroupReference>, HibUserTracking, HibBucketableElement, HibNamedElement, HibNamedBaseElement {
+public interface HibGroup extends HibCoreElement<GroupResponse>, HibReferenceableElement<GroupReference>, HibUserTracking, HibBucketableElement, HibNamedBaseElement {
 
 	TypeInfo TYPE_INFO = new TypeInfo(ElementType.GROUP, GROUP_CREATED, GROUP_UPDATED, GROUP_DELETED);
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/project/HibProject.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/project/HibProject.java
@@ -14,7 +14,7 @@ import com.gentics.mesh.core.data.HibBaseElement;
 import com.gentics.mesh.core.data.HibBucketableElement;
 import com.gentics.mesh.core.data.HibCoreElement;
 import com.gentics.mesh.core.data.HibLanguage;
-import com.gentics.mesh.core.data.HibNamedElement;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
 import com.gentics.mesh.core.data.branch.HibBranch;
 import com.gentics.mesh.core.data.dao.ProjectDao;
@@ -35,7 +35,7 @@ import com.gentics.mesh.handler.VersionUtils;
 /**
  * Domain model for project.
  */
-public interface HibProject extends HibCoreElement<ProjectResponse>, HibReferenceableElement<ProjectReference>, HibUserTracking, HibBucketableElement, HibNamedElement {
+public interface HibProject extends HibCoreElement<ProjectResponse>, HibReferenceableElement<ProjectReference>, HibUserTracking, HibBucketableElement, HibNamedBaseElement {
 
 	TypeInfo TYPE_INFO = new TypeInfo(ElementType.PROJECT, PROJECT_CREATED, PROJECT_UPDATED, PROJECT_DELETED);
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaElement.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/schema/HibFieldSchemaElement.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.data.HibCoreElement;
-import com.gentics.mesh.core.data.HibNamedElement;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
 import com.gentics.mesh.core.data.branch.HibBranch;
 import com.gentics.mesh.core.data.user.HibUserTracking;
@@ -21,7 +21,7 @@ public interface HibFieldSchemaElement<
 			RE extends NameUuidReference<RE>, 
 			SC extends HibFieldSchemaElement<R, RM, RE, SC, SCV>, 
 			SCV extends HibFieldSchemaVersionElement<R, RM, RE, SC, SCV>
-	> extends HibCoreElement<R>, HibReferenceableElement<RE>, HibUserTracking, HibNamedElement {
+	> extends HibCoreElement<R>, HibReferenceableElement<RE>, HibUserTracking, HibNamedBaseElement {
 
 	/**
 	 * Return the latest container version.

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/tag/HibTag.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/tag/HibTag.java
@@ -12,7 +12,7 @@ import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.TypeInfo;
 import com.gentics.mesh.core.data.HibBucketableElement;
 import com.gentics.mesh.core.data.HibCoreElement;
-import com.gentics.mesh.core.data.HibNamedElement;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibProjectElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
 import com.gentics.mesh.core.data.project.HibProject;
@@ -32,7 +32,7 @@ import com.gentics.mesh.handler.VersionUtils;
  * Domain model for tags.
  */
 public interface HibTag extends HibCoreElement<TagResponse>, HibReferenceableElement<TagReference>, HibUserTracking, 
-		HibProjectElement, HibBucketableElement, HibNamedElement {
+		HibProjectElement, HibBucketableElement, HibNamedBaseElement {
 
 	TypeInfo TYPE_INFO = new TypeInfo(ElementType.TAG, TAG_CREATED, TAG_UPDATED, TAG_DELETED);
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/tagfamily/HibTagFamily.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/tagfamily/HibTagFamily.java
@@ -14,7 +14,7 @@ import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.TypeInfo;
 import com.gentics.mesh.core.data.HibBucketableElement;
 import com.gentics.mesh.core.data.HibCoreElement;
-import com.gentics.mesh.core.data.HibNamedElement;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibProjectElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
 import com.gentics.mesh.core.data.dao.UserDao;
@@ -39,7 +39,7 @@ import com.gentics.mesh.handler.VersionUtils;
  * Domain model for tag families.
  */
 public interface HibTagFamily extends HibCoreElement<TagFamilyResponse>, HibReferenceableElement<TagFamilyReference>, 
-		HibProjectElement, HibUserTracking, HibBucketableElement, HibNamedElement {
+		HibProjectElement, HibUserTracking, HibBucketableElement, HibNamedBaseElement {
 
 	TypeInfo TYPE_INFO = new TypeInfo(ElementType.TAGFAMILY, TAG_FAMILY_CREATED, TAG_FAMILY_UPDATED, TAG_FAMILY_DELETED);
 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/user/HibUser.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/user/HibUser.java
@@ -11,7 +11,7 @@ import com.gentics.mesh.context.InternalActionContext;
 import com.gentics.mesh.core.TypeInfo;
 import com.gentics.mesh.core.data.HibBucketableElement;
 import com.gentics.mesh.core.data.HibCoreElement;
-import com.gentics.mesh.core.data.HibNamedElement;
+import com.gentics.mesh.core.data.HibNamedBaseElement;
 import com.gentics.mesh.core.data.HibReferenceableElement;
 import com.gentics.mesh.core.data.dao.UserDao;
 import com.gentics.mesh.core.data.node.HibNode;
@@ -27,7 +27,7 @@ import io.vertx.ext.auth.User;
 /**
  * Domain model for user.
  */
-public interface HibUser extends HibCoreElement<UserResponse>, HibReferenceableElement<UserReference>, HibUserTracking, HibBucketableElement, HibNamedElement {
+public interface HibUser extends HibCoreElement<UserResponse>, HibReferenceableElement<UserReference>, HibUserTracking, HibBucketableElement, HibNamedBaseElement {
 
 	TypeInfo TYPE_INFO = new TypeInfo(ElementType.USER, USER_CREATED, USER_UPDATED, USER_DELETED);
 

--- a/mdm/common/src/main/java/com/gentics/mesh/core/db/TxEntityPersistenceManager.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/db/TxEntityPersistenceManager.java
@@ -93,4 +93,25 @@ public interface TxEntityPersistenceManager {
 	default <T extends HibElement> T create(Class<? extends T> classOfT) {
 		return create(null, classOfT);
 	}
+
+	/**
+	 * Attach the POJO element into the database-driven persistence state, if possible. The default implementation does nothing, not telling apart both states.
+	 * 
+	 * @param element
+	 * @param pushIntoDb if true, the DB data is considered stale and is to be overwritten by the element data, otherwise vice versa. 
+	 * @return
+	 */
+	default <T> T attach(T element, boolean pushIntoDb) {
+		return element;
+	}
+
+	/**
+	 * Make a POJO from possibly database driven persistent element. The default implementation does nothing, not telling apart both states.
+	 * 
+	 * @param element
+	 * @return
+	 */
+	default <T> T detach(T element) {
+		return element;
+	}
 }


### PR DESCRIPTION
## Abstract

An update to cache API, allowing attaching/detaching/reattaching actions on an cacheable entity.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
