### PR TITLE
Fix double-delegation of graphql requests to worker threads.

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.28]]
+== 1.10.28 (TBD)
+
+icon:check[] GraphQL: In cases of long running GraphQL requests, some other GraphQL requests were queued and executed after the long running request, even if enough workers were still
+available. The behaviour has been changed, so that GraphQL requests will only be queued, if all workers are currently busy.
+
 [[v1.10.27]]
 == 1.10.27 (21.02.2024)
 


### PR DESCRIPTION
This also fixes possible unnecessary queueing of graphql requests, since the removed "inner" delegation was done "ordered".

## Abstract

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
