### PR TITLE
SUP-16448: Get back common filters

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
 		<!-- when updating version, don't forget to update administration-guide.asciidoc -->
 		<graphql.version>20.0</graphql.version>
 		<graphql-dataloader.version>3.1.2</graphql-dataloader.version>
-		<graphql-filter.version>3.0.2</graphql-filter.version>
+		<graphql-filter.version>3.0.3</graphql-filter.version>
 		<pf4j.version>3.1.0</pf4j.version>
 		<asm.version>3.3.1</asm.version>
 		<spring.security.version>5.5.7</spring.security.version>

--- a/changelog/src/changelog/entries/2024/03/7715.SUP-16448.bugfix
+++ b/changelog/src/changelog/entries/2024/03/7715.SUP-16448.bugfix
@@ -1,0 +1,1 @@
+GraphQL: A regression of missing common `and`, `or`, `not` top level filters has been fixed.

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/graphql/GraphQLEndpointTest.java
@@ -161,6 +161,7 @@ public class GraphQLEndpointTest extends AbstractMeshTest {
 				Arrays.asList("node-tag-query", true, false, "draft"),
 				Arrays.asList("nodes-query", true, false, "draft"),
 				Arrays.asList("nodes-query-by-uuids", true, false, "draft"),
+				Arrays.asList("nodes-query-by-uuids-common-filters", true, false, "draft"),
 				Arrays.asList("node-breadcrumb-query", true, false, "draft"),
 				Arrays.asList("node-breadcrumb-query-with-lang", true, false, "draft"),
 				Arrays.asList("node-language-fallback-query", true, false, "draft"),

--- a/tests/tests-core/src/main/resources/graphql/nodes-query-by-uuids-common-filters
+++ b/tests/tests-core/src/main/resources/graphql/nodes-query-by-uuids-common-filters
@@ -1,0 +1,48 @@
+{
+	orNodes: nodes( uuids: [ "43ee8f9ff71e4016ae8f9ff71e10161c", "4b1346a2163a4ff89346a2163a9ff883" ]
+		filter: {uuid: { or: [{equals: "43ee8f9ff71e4016ae8f9ff71e10161c"},{equals: "4b1346a2163a4ff89346a2163a9ff883"}] }}
+	) {
+		# [$.data.orNodes.totalCount=2]
+		totalCount
+
+		elements {
+			# [$.data.orNodes.elements[0].uuid=43ee8f9ff71e4016ae8f9ff71e10161c]
+			# [$.data.orNodes.elements[1].uuid=4b1346a2163a4ff89346a2163a9ff883]
+			uuid
+		}
+	}
+	oneOfNodes: nodes( uuids: [ "43ee8f9ff71e4016ae8f9ff71e10161c", "4b1346a2163a4ff89346a2163a9ff883" ]
+		filter: {uuid: { oneOf: ["43ee8f9ff71e4016ae8f9ff71e10161c", "4b1346a2163a4ff89346a2163a9ff883"] }}
+	) {
+		# [$.data.oneOfNodes.totalCount=2]
+		totalCount
+
+		elements {
+			# [$.data.oneOfNodes.elements[0].uuid=43ee8f9ff71e4016ae8f9ff71e10161c]
+			# [$.data.oneOfNodes.elements[1].uuid=4b1346a2163a4ff89346a2163a9ff883]
+			uuid
+		}
+	}
+	andNodes: nodes( uuids: [ "43ee8f9ff71e4016ae8f9ff71e10161c", "4b1346a2163a4ff89346a2163a9ff883" ]
+		filter: {uuid: { and: [{equals: "43ee8f9ff71e4016ae8f9ff71e10161c"},{equals: "4b1346a2163a4ff89346a2163a9ff883"}] }}
+	) {
+		# [$.data.andNodes.totalCount=0]
+		totalCount
+
+		elements {
+			uuid
+		}
+	}
+	notNodes: nodes( uuids: [ "43ee8f9ff71e4016ae8f9ff71e10161c", "4b1346a2163a4ff89346a2163a9ff883" ]
+		filter: {uuid: { not: {equals: "4b1346a2163a4ff89346a2163a9ff883"}}}
+	) {
+		# [$.data.notNodes.totalCount=1]
+		totalCount
+
+		elements {
+			# [$.data.notNodes.elements[0].uuid=43ee8f9ff71e4016ae8f9ff71e10161c]
+			uuid
+		}
+	}
+}
+# [$.errors=<is-undefined>]


### PR DESCRIPTION
## Abstract

Common GraphQL filters (and, or, not) were missing from the API.

## Checklist

### General

* [ ] Added abstract that describes the change
* [ ] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [ ] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
