### PR TITLE
SUP-16917: Get back timeout tests

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,12 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+
+[[v1.10.31]]
+== 1.10.31 (TBD)
+
+An Elasticsearch Java Client has been updated to the version 1.1.2, containing the corrections to the connection failure processing mechanism.
+
 [[v1.10.30]]
 == 1.10.30 (13.05.2024)
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -24,7 +24,7 @@
 		<asm.version>3.3.1</asm.version>
 		<spring.security.version>5.5.7</spring.security.version>
 		<ferma.version>${project.version}</ferma.version>
-		<elasticsearch.client.version>1.1.1</elasticsearch.client.version>
+		<elasticsearch.client.version>1.1.2</elasticsearch.client.version>
 		<orientdb.version>3.2.10</orientdb.version>
 		<hazelcast.version>3.12.8</hazelcast.version>
 		<jackson.version>2.13.2</jackson.version>

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/ElasticsearchProcessVerticle.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/ElasticsearchProcessVerticle.java
@@ -223,7 +223,11 @@ public class ElasticsearchProcessVerticle extends AbstractVerticle {
 				// To make sure the subscription stays alive
 				.onErrorResumeNext(Flowable.empty()), 1)
 			// To make sure the subscription stays alive
-			.doOnError(err -> log.info("Error at end of ES process chain", err))
+			.doOnError(err -> {
+				log.info("Error at end of ES process chain", err);
+				idleChecker.reset();
+				startSync();
+			})
 			.retry()
 			.subscribe();
 	}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/IdleChecker.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/verticle/IdleChecker.java
@@ -78,7 +78,10 @@ public class IdleChecker {
 	 * @return
 	 */
 	public int incrementAndGetTransformations() {
-		return transformations.incrementAndGet();
+		int current = transformations.incrementAndGet();
+		log.trace("Incremented transformations. Remaining requests: {}, remaining transformations: {}",
+				requests.get(), transformations.get());
+		return current;
 	}
 
 	/**
@@ -118,5 +121,17 @@ public class IdleChecker {
 	 */
 	public void resetTransformations() {
 		transformations.set(0);
+		log.trace("Reset transformations. Remaining requests: {}, remaining transformations: {}",
+				requests.get(), transformations.get());
+	}
+
+	/**
+	 * Resets the amount of pending transformations and requests
+	 */
+	public void reset() {
+		transformations.set(0);
+		requests.set(0);
+		log.trace("Reset transformations and requests. Remaining requests: {}, remaining transformations: {}",
+				requests.get(), transformations.get());
 	}
 }

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
@@ -205,7 +205,6 @@ public class MeshOkHttpRequestImpl<T> implements MeshRequest<T> {
 	private Single<Response> getOkResponse() {
 		Single<Response> response =  Single.create(sub -> {
 			Call call = client.newCall(createRequest());
-			sub.setCancellable(call::cancel);
 			call.enqueue(new Callback() {
 				@Override
 				public void onFailure(Call call, IOException e) {

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
@@ -209,7 +209,10 @@ public class MeshOkHttpRequestImpl<T> implements MeshRequest<T> {
 			call.enqueue(new Callback() {
 				@Override
 				public void onFailure(Call call, IOException e) {
-					if (!sub.isDisposed()) {
+					// Don't call the onError twice, but notify about multiple exceptions (should not occur often).
+					if (sub.isDisposed()) {
+						e.printStackTrace();
+					} else {
 						sub.onError(new IOException(String.format("I/O Error in %s %s : %s (%s)",
 								HttpMethod.valueOf(method.toUpperCase()), url, e.getClass().getSimpleName(), e.getLocalizedMessage()), e));
 					}

--- a/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
+++ b/rest-client/src/main/java/com/gentics/mesh/rest/client/impl/MeshOkHttpRequestImpl.java
@@ -205,6 +205,7 @@ public class MeshOkHttpRequestImpl<T> implements MeshRequest<T> {
 	private Single<Response> getOkResponse() {
 		Single<Response> response =  Single.create(sub -> {
 			Call call = client.newCall(createRequest());
+			sub.setCancellable(call::cancel);
 			call.enqueue(new Callback() {
 				@Override
 				public void onFailure(Call call, IOException e) {

--- a/tests/tests-core/pom.xml
+++ b/tests/tests-core/pom.xml
@@ -62,6 +62,11 @@
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
+			<artifactId>vertx-web-client</artifactId>
+			
+		</dependency>
+		<dependency>
+			<groupId>io.vertx</groupId>
 			<artifactId>vertx-core</artifactId>
 			<type>test-jar</type>
 			<scope>compile</scope>

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
@@ -178,12 +178,11 @@ public class ElasticSearchProviderTimeoutTest extends AbstractMeshTest {
 	}
 
 	@Test
-	@Ignore("Too slow for CI")
 	public void testResumeQueriesAfterBeingBlocked() throws IOException, InterruptedException {
 		timeout = false;
 		block = true;
 		String json = getESText("userWildcard.es");
-		IntStream.range(0, 100).forEach(unused -> {
+		IntStream.range(0, 10).forEach(unused -> {
 			call(() -> client().searchUsers(json), INTERNAL_SERVER_ERROR);
 			try {
 				Thread.sleep(100);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
@@ -17,6 +17,7 @@ import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.gentics.mesh.core.db.Tx;
@@ -177,6 +178,7 @@ public class ElasticSearchProviderTimeoutTest extends AbstractMeshTest {
 	}
 
 	@Test
+	@Ignore("Too slow for CI")
 	public void testResumeQueriesAfterBeingBlocked() throws IOException, InterruptedException {
 		timeout = false;
 		block = true;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/ElasticSearchProviderTimeoutTest.java
@@ -4,37 +4,42 @@ import static com.gentics.mesh.test.ClientHelper.call;
 import static com.gentics.mesh.test.ElasticsearchTestMode.CONTAINER_ES6;
 import static com.gentics.mesh.test.MeshCoreOptionChanger.RANDOM_ES_PORT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import com.gentics.mesh.core.db.Tx;
+import com.gentics.mesh.core.rest.user.UserListResponse;
 import com.gentics.mesh.etc.config.search.ElasticSearchOptions;
 import com.gentics.mesh.test.MeshTestSetting;
 import com.gentics.mesh.test.TestSize;
-import com.gentics.mesh.test.category.FailingTests;
 import com.gentics.mesh.test.context.AbstractMeshTest;
 
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.HttpServer;
+import io.vertx.reactivex.ext.web.client.HttpRequest;
+import io.vertx.reactivex.ext.web.client.WebClient;
 
-/**
- * Note: marked as "failing test", because it seems to be stuck.
- */
-@Category(FailingTests.class)
 @MeshTestSetting(elasticsearch = CONTAINER_ES6, testSize = TestSize.PROJECT_AND_NODE, startServer = true, optionChanger = RANDOM_ES_PORT)
 public class ElasticSearchProviderTimeoutTest extends AbstractMeshTest {
 
 	private static final Logger log = LoggerFactory.getLogger(ElasticSearchProviderTimeoutTest.class);
+
+	private static HttpServer server;
+	private static WebClient realClient;
+	private static boolean timeout = false;
 
 	/**
 	 * Use the vert.x server which answers requests after 16s instead.
@@ -47,18 +52,46 @@ public class ElasticSearchProviderTimeoutTest extends AbstractMeshTest {
 		ElasticSearchOptions options = testContext.getOptions().getSearchOptions();
 		String url = options.getUrl();
 		int port = new URL(url).getPort();
+		realClient = WebClient.create(vertx);
 		// Create a dummy server which just blocks on every in-bound request for 1 second
-		HttpServer server = vertx.createHttpServer(new HttpServerOptions().setPort(port));
+		server = vertx.createHttpServer(new HttpServerOptions().setPort(port));
 		server.requestHandler(rh -> {
-			// Don't block validation requests.
-			if (rh.absoluteURI().indexOf("_template/validation") > 0) {
-				rh.response().end(new JsonObject().encodePrettily());
-			} else {
-				log.info("Waiting for 16 second to answer request: " + rh.absoluteURI());
-				vertx.setTimer(Duration.ofSeconds(3).toMillis(), th -> rh.response().end());
+			try {
+				if (timeout) {
+					Thread.sleep(Duration.ofSeconds(16).toMillis());
+				}
+				HttpRequest<Buffer> realRequest = realClient.request(
+						rh.method(), 
+						testContext.elasticsearchContainer().getMappedPort(9200), 
+						testContext.elasticsearchContainer().getHost(), 
+						rh.uri()
+					).putHeaders(rh.headers());
+				realRequest.queryParams().addAll(rh.params());
+				if (HttpMethod.POST == rh.method() || HttpMethod.PUT == rh.method()) {
+					rh.bodyHandler(body -> realRequest.sendBuffer(body, rs -> {
+						log.info(rh.toString() + " body sent");
+						rh.response().end(rs.result().body());
+					}));
+				} else {
+					realRequest.send(rs -> {
+						log.info(rh.toString() + " sent");
+						rh.response().end(rs.result().body());
+					});
+				}
+			} catch (InterruptedException e) {
 			}
 		});
-		server.rxListen().blockingGet();
+		server.rxListen().subscribe();
+	}
+
+	@Before
+	public void set() {
+		timeout = true;
+	}
+
+	@After
+	public void reset() {
+		timeout = false;
 	}
 
 	@Test
@@ -81,5 +114,17 @@ public class ElasticSearchProviderTimeoutTest extends AbstractMeshTest {
 	public void testSearchQuery() throws IOException {
 		String json = getESText("userWildcard.es");
 		call(() -> client().searchUsers(json), INTERNAL_SERVER_ERROR, "search_error_timeout");
+	}
+
+	@Test
+	public void testResumeQueriesAfterBlackout() throws IOException, InterruptedException {
+		// black out!
+		String json = getESText("userWildcard.es");
+		call(() -> client().searchUsers(json), INTERNAL_SERVER_ERROR, "search_error_timeout");
+		// reset
+		timeout = false;
+		Thread.sleep(Duration.ofSeconds(16).toMillis());
+		UserListResponse response = call(() -> client().searchUsers(json));
+		assertThat(response.getData()).isNotNull();
 	}
 }


### PR DESCRIPTION
## Abstract

ES timeout tests were failing. Reimplemented + extended.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
