### PR TITLE
GPU-1625: Elasticsearch 8.x compatibility

### DIFF
--- a/api/src/main/java/com/gentics/mesh/etc/config/search/ComplianceMode.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/search/ComplianceMode.java
@@ -13,5 +13,10 @@ public enum ComplianceMode {
 	/**
 	 * Enables the Elasticsearch 7 compliance mode. This will allow Gentics Mesh to work with ES 7 installations.
 	 */
-	ES_7
+	ES_7,
+
+	/**
+	 * Enables the Elasticsearch 8 compliance mode. This will allow Gentics Mesh to work with ES 8 installations.
+	 */
+	ES_8
 }

--- a/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
@@ -167,7 +167,7 @@ public class ElasticSearchOptions implements Option {
 	private MappingMode mappingMode = DEFAULT_MAPPING_MODE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("This setting controls the compliance mode for Elasticsearch. When set to ES_7 it will support Elasticsearch 7.x - In PRE_ES_7 mode it will support Elasticsearch 6.x - Default: PRE_ES_7")
+	@JsonPropertyDescription("This setting controls the compliance mode for Elasticsearch. Currently supported modes are ES_6, ES_7 and ES_8. Default: ES_6")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_COMPLIANCE_MODE_ENV, description = "Override the search compliance mode.")
 	private ComplianceMode complianceMode = DEFAULT_COMPLIANCE_MODE;
 
@@ -391,6 +391,10 @@ public class ElasticSearchOptions implements Option {
 	}
 
 	public ComplianceMode getComplianceMode() {
+		if (complianceMode == null) {
+			complianceMode = DEFAULT_COMPLIANCE_MODE;
+		}
+
 		return complianceMode;
 	}
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,7 +26,7 @@
 		<asm.version>3.3.1</asm.version>
 		<spring.security.version>5.5.7</spring.security.version>
 		<ferma.version>${project.version}</ferma.version>
-		<elasticsearch.client.version>1.2.0-SNAPSHOT</elasticsearch.client.version>
+		<elasticsearch.client.version>1.1.1</elasticsearch.client.version>
 		<orientdb.version>3.2.10</orientdb.version>
 		<hazelcast.version>3.12.13</hazelcast.version>
 		<jackson.version>2.17.0</jackson.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,7 +26,7 @@
 		<asm.version>3.3.1</asm.version>
 		<spring.security.version>5.5.7</spring.security.version>
 		<ferma.version>${project.version}</ferma.version>
-		<elasticsearch.client.version>1.1.1</elasticsearch.client.version>
+		<elasticsearch.client.version>1.2.0-SNAPSHOT</elasticsearch.client.version>
 		<orientdb.version>3.2.10</orientdb.version>
 		<hazelcast.version>3.12.13</hazelcast.version>
 		<jackson.version>2.17.0</jackson.version>

--- a/changelog/src/changelog/entries/2024/07/7885.GPU-1625.enhancement
+++ b/changelog/src/changelog/entries/2024/07/7885.GPU-1625.enhancement
@@ -1,0 +1,1 @@
+Search: Adds compliance mode ES_8 for Elasticsearch 8.x.

--- a/common-api/src/main/java/com/gentics/mesh/core/data/search/request/CreateDocumentRequest.java
+++ b/common-api/src/main/java/com/gentics/mesh/core/data/search/request/CreateDocumentRequest.java
@@ -42,6 +42,7 @@ public class CreateDocumentRequest implements Bulkable {
 
 		switch (mode) {
 		case ES_7:
+		case ES_8:
 			break;
 		case ES_6:
 			settings.put("_type", SearchProvider.DEFAULT_TYPE);

--- a/common-api/src/main/java/com/gentics/mesh/core/data/search/request/DeleteDocumentRequest.java
+++ b/common-api/src/main/java/com/gentics/mesh/core/data/search/request/DeleteDocumentRequest.java
@@ -39,6 +39,7 @@ public class DeleteDocumentRequest implements Bulkable {
 
 		switch (mode) {
 		case ES_7:
+		case ES_8:
 			break;
 		case ES_6:
 			settings.put("_type", SearchProvider.DEFAULT_TYPE);

--- a/common-api/src/main/java/com/gentics/mesh/core/data/search/request/UpdateDocumentRequest.java
+++ b/common-api/src/main/java/com/gentics/mesh/core/data/search/request/UpdateDocumentRequest.java
@@ -32,6 +32,7 @@ public class UpdateDocumentRequest implements Bulkable {
 
 		switch (mode) {
 		case ES_7:
+		case ES_8:
 			break;
 		case ES_6:
 			settings.put("_type", SearchProvider.DEFAULT_TYPE);

--- a/doc/src/main/docs/elasticsearch.asciidoc
+++ b/doc/src/main/docs/elasticsearch.asciidoc
@@ -88,19 +88,7 @@ Settings for Elasticsearch versions, which are needed so Gentics Mesh works corr
 
 ==== Elasticsearch 8.x
 
-The `destructive_requires_name` setting must be set to `false` otherwise Gentics Mesh cannot delete certain indices.
-
-This is a cluster setting which can be set permanently with a PUT request to `/_cluster/settings`:
-
-```
-{
-    "persistent": {
-        "action": {
-           "destructive_requires_name": false
-        }
-    }
-}
-```
+The `action.destructive_requires_name` setting must be set to `false` otherwise Gentics Mesh cannot delete certain indices.
 
 == Security
 

--- a/doc/src/main/docs/elasticsearch.asciidoc
+++ b/doc/src/main/docs/elasticsearch.asciidoc
@@ -78,8 +78,9 @@ The `search.complianceMode` setting or `MESH_ELASTICSEARCH_COMPLIANCE_MODE` envi
 
 Levels:
 
+* `ES_6` - Support Elasticsearch 6.x (*Default*)
 * `ES_7` - Support Elasticsearch 7.x
-* `PRE_ES_7` - Support Elasticsearch 6.x (*Default*)
+* `ES_8` - Support Elasticsearch 8.x
 
 == Security
 
@@ -112,11 +113,25 @@ The settings can be also configured via environment variables:
 * `MESH_ELASTICSEARCH_CA_PATH` - Override the ca path
 * `MESH_ELASTICSEARCH_HOSTNAME_VERIFICATION` - Override the hostname verification
 
+=== Creating certificates
+
+Creating and configuring certificates for Elasticsearch is covered in the Elasticsearch documentation in the sections "link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html#generate-certificates[Set up basic security]" and "link:https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup-https.html#encrypt-http-communication[Encrypt HTTP client communications]".
+
+The following steps are a condensed version of how to create the HTTPS certificate.
+
+. Generate a certificate authority (CA): `bin/elasticsearch-certutil ca`. Choosing the default names, this will create a file called `elastic-stack-ca.p12`.
+. Create the HTTPS certificate: `bin/elasticsearch-certutil http`. Choosing the default names, this will create a file called `http.p12`.
+. Convert the PKCS12 files to PEM: `openssl pkcs12 -in elastic-stack-ca.p12 -out elastic-stack-ca.crt.pem -clcerts -nokeys` and `openssl pkcs12 -in http.p12 -out http.crt.pem -clcerts -nokeys`.
+. Enable HTTPS: Make sure the following entries exist in the `elasticsearch.yml` file:
+.. `xpack.security.http.ssl.enabled: true`
+.. `xpack.security.http.ssl.keystore.path: http.p12`
+. Set certificate paths: In the `mesh.yml` file set `search.certPath` and `search.caPath` to the paths for `http.crt.pem` and `elastic-stack-ca.crt.pem` respectively (or set the environment variables `MESH_ELASTICSEARCH_CERT_PATH` and `MESH_ELASTICSEARCH_CA_PATH` accordingly).
+
 == Basic Authentication
 
 Connections to Elasticsearch can be authenticated using a user. Details on how to configure this in Elasticsearch can be found in the link:https://www.elastic.co/guide/en/elastic-stack-overview/current/built-in-users.html[Elasticsearch documentation].
 
-When `xpack.security.enabled` has been enabled in Elasticsearch you can use the `elasticsearch-setup-passwords`
+When `xpack.security.enabled` has been enabled in Elasticsearch you can use the `elasticsearch-setup-passwords` script to create a password for basic authentication. When passwords have already been created, it can be reset via the `elasticsearch-reset-password` script.
 
 The authentication details can be configured using the `search.username` and `search.password` settings in the `mesh.yml`.
 

--- a/doc/src/main/docs/elasticsearch.asciidoc
+++ b/doc/src/main/docs/elasticsearch.asciidoc
@@ -82,6 +82,26 @@ Levels:
 * `ES_7` - Support Elasticsearch 7.x
 * `ES_8` - Support Elasticsearch 8.x
 
+=== Required settings
+
+Settings for Elasticsearch versions, which are needed so Gentics Mesh works correctly.
+
+==== Elasticsearch 8.x
+
+The `destructive_requires_name` setting must be set to `false` otherwise Gentics Mesh cannot delete certain indices.
+
+This is a cluster setting which can be set permanently with a PUT request to `/_cluster/settings`:
+
+```
+{
+    "persistent": {
+        "action": {
+           "destructive_requires_name": false
+        }
+    }
+}
+```
+
 == Security
 
 Gentics Mesh supports basic authentication and TLS in-transit encrypted connections for Elasticsearch communication.

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
@@ -97,8 +97,7 @@ public class ElasticSearchProvider implements SearchProvider {
 
 	@Override
 	public ElasticSearchProvider init() {
-
-        return this;
+		return this;
 	}
 
 	@Override
@@ -124,11 +123,11 @@ public class ElasticSearchProvider implements SearchProvider {
 
 		JsonObject tokenizer = new JsonObject();
 
-        if (complianceMode == ComplianceMode.ES_8) {
-            tokenizer.put("type", "ngram");
-        } else {
-            tokenizer.put("type", "nGram");
-        }
+		if (complianceMode == ComplianceMode.ES_8) {
+			tokenizer.put("type", "ngram");
+		} else {
+			tokenizer.put("type", "nGram");
+		}
 
 		tokenizer.put("min_gram", "3");
 		tokenizer.put("max_gram", "3");

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
@@ -97,40 +97,6 @@ public class ElasticSearchProvider implements SearchProvider {
 
 	@Override
 	public ElasticSearchProvider init() {
-		JsonObject settings = null;
-
-        try {
-            settings = client.clusterSettings().sync();
-        } catch (HttpErrorException e) {
-			log.error("Could not determine current cluster settings: {}", e.getMessage(), e);
-
-			return this;
-        }
-
-		Optional<Boolean> settingsDestructiveRequiresName = Optional.ofNullable(settings)
-				.map(o -> o.getJsonObject("persistent"))
-				.map(o -> o.getJsonObject("action"))
-				.map(o -> o.getString("destructive_requires_name"))
-				.map(Boolean::valueOf);
-
-		if (settingsDestructiveRequiresName.isEmpty() || settingsDestructiveRequiresName.get()) {
-			log.info("Updating cluster configuration: destructive_requires_name=false");
-
-			JsonObject update = new JsonObject()
-				.put("persistent", new JsonObject()
-					.put("action", new JsonObject()
-						.put("destructive_requires_name", false)));
-
-            try {
-                settings = client.updateClusterSettings(update).sync();
-
-				if (log.isInfoEnabled()) {
-					log.info("Updated cluster configuration:\n{}", settings.encodePrettily());
-				}
-            } catch (HttpErrorException e) {
-				log.error("Could update cluster settings: {}", e.getMessage(), e);
-            }
-        }
 
         return this;
 	}

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
@@ -110,7 +110,8 @@ public class ElasticSearchProvider implements SearchProvider {
 		Optional<Boolean> settingsDestructiveRequiresName = Optional.ofNullable(settings)
 				.map(o -> o.getJsonObject("persistent"))
 				.map(o -> o.getJsonObject("action"))
-				.map(o -> o.getBoolean("destructive_requires_name"));
+				.map(o -> o.getString("destructive_requires_name"))
+				.map(Boolean::valueOf);
 
 		if (settingsDestructiveRequiresName.isEmpty() || settingsDestructiveRequiresName.get()) {
 			log.info("Updating cluster configuration: destructive_requires_name=false");
@@ -123,7 +124,9 @@ public class ElasticSearchProvider implements SearchProvider {
             try {
                 settings = client.updateClusterSettings(update).sync();
 
-				log.info("Updated cluster configuration:\n%s", settings.encodePrettily());
+				if (log.isInfoEnabled()) {
+					log.info("Updated cluster configuration:\n{}", settings.encodePrettily());
+				}
             } catch (HttpErrorException e) {
 				log.error("Could update cluster settings: {}", e.getMessage(), e);
             }

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/impl/ElasticSearchProvider.java
@@ -97,7 +97,39 @@ public class ElasticSearchProvider implements SearchProvider {
 
 	@Override
 	public ElasticSearchProvider init() {
-		return this;
+		JsonObject settings = null;
+
+        try {
+            settings = client.clusterSettings().sync();
+        } catch (HttpErrorException e) {
+			log.error("Could not determine current cluster settings: {}", e.getMessage(), e);
+
+			return this;
+        }
+
+		Optional<Boolean> settingsDestructiveRequiresName = Optional.ofNullable(settings)
+				.map(o -> o.getJsonObject("persistent"))
+				.map(o -> o.getJsonObject("action"))
+				.map(o -> o.getBoolean("destructive_requires_name"));
+
+		if (settingsDestructiveRequiresName.isEmpty() || settingsDestructiveRequiresName.get()) {
+			log.info("Updating cluster configuration: destructive_requires_name=false");
+
+			JsonObject update = new JsonObject()
+				.put("persistent", new JsonObject()
+					.put("action", new JsonObject()
+						.put("destructive_requires_name", false)));
+
+            try {
+                settings = client.updateClusterSettings(update).sync();
+
+				log.info("Updated cluster configuration:\n%s", settings.encodePrettily());
+            } catch (HttpErrorException e) {
+				log.error("Could update cluster settings: {}", e.getMessage(), e);
+            }
+        }
+
+        return this;
 	}
 
 	@Override
@@ -122,7 +154,13 @@ public class ElasticSearchProvider implements SearchProvider {
 	public JsonObject getDefaultIndexSettings() {
 
 		JsonObject tokenizer = new JsonObject();
-		tokenizer.put("type", "nGram");
+
+        if (complianceMode == ComplianceMode.ES_8) {
+            tokenizer.put("type", "ngram");
+        } else {
+            tokenizer.put("type", "nGram");
+        }
+
 		tokenizer.put("min_gram", "3");
 		tokenizer.put("max_gram", "3");
 
@@ -697,6 +735,7 @@ public class ElasticSearchProvider implements SearchProvider {
 		case ES_6:
 			return DEFAULT_TYPE;
 		case ES_7:
+		case ES_8:
 			return null;
 		default:
 			throw new RuntimeException("Unknown compliance mode {" + complianceMode + "}");

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/AbstractMappingProvider.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/AbstractMappingProvider.java
@@ -59,6 +59,7 @@ public abstract class AbstractMappingProvider implements MappingProvider {
 			mapping.put(DEFAULT_TYPE, typeMapping);
 			return mapping;
 		case ES_7:
+		case ES_8:
 			return typeMapping;
 		default:
 			throw new RuntimeException("Unknown mode {" + complianceMode + "}");

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/AbstractSearchHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/AbstractSearchHandler.java
@@ -284,6 +284,7 @@ public abstract class AbstractSearchHandler<T extends HibCoreElement<RM>, RM ext
 							hitsInfo.put("total", total - 1);
 							break;
 						case ES_7:
+						case ES_8:
 							hitsInfo.put("total", new JsonObject().put("value", total - 1));
 							break;
 						default:
@@ -355,6 +356,7 @@ public abstract class AbstractSearchHandler<T extends HibCoreElement<RM>, RM ext
 	protected long extractTotalCount(JsonObject info) {
 		switch (complianceMode) {
 		case ES_7:
+		case ES_8:
 			return info.getJsonObject("total").getLong("value");
 		case ES_6:
 			return info.getLong("total");

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeContainerMappingProviderImpl.java
@@ -163,6 +163,7 @@ public class NodeContainerMappingProviderImpl extends AbstractMappingProvider im
 
 		switch (complianceMode) {
 		case ES_7:
+		case ES_8:
 			return Optional.of(typeMapping);
 		case ES_6:
 			mapping.put(DEFAULT_TYPE, typeMapping);

--- a/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeSearchHandler.java
+++ b/elasticsearch/src/main/java/com/gentics/mesh/search/index/node/NodeSearchHandler.java
@@ -184,6 +184,7 @@ public class NodeSearchHandler extends AbstractSearchHandler<HibNode, NodeRespon
 					hitsInfo.put("total", totalCount.longValue());
 					break;
 				case ES_7:
+				case ES_8:
 					hitsInfo.put("total", new JsonObject().put("value", totalCount.longValue()));
 					break;
 				default:

--- a/tests/common/src/main/java/com/gentics/mesh/test/docker/ElasticsearchContainer.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/docker/ElasticsearchContainer.java
@@ -125,7 +125,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 	 * Create the full image name from the version number.
 	 *
 	 * <p>
-	 *     All versions use the docker.apa-it.at repository.
+	 *     All versions use the docker.gentics.com repository.
 	 * </p>
 	 *
 	 * <p>

--- a/tests/common/src/main/java/com/gentics/mesh/test/docker/ElasticsearchContainer.java
+++ b/tests/common/src/main/java/com/gentics/mesh/test/docker/ElasticsearchContainer.java
@@ -1,19 +1,17 @@
 package com.gentics.mesh.test.docker;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.time.Duration;
-import java.util.Collections;
-
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.FrameConsumerResultCallback;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.ToStringConsumer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.TestEnvironment;
 
-import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Collections;
 
 /**
  * Testcontainer for a non-clustered Elasticsearch instance.
@@ -22,20 +20,30 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
 	private static final Charset UTF8 = Charset.forName("UTF-8");
 
+	public static final String VERSION_ES8 = "8.14.1";
+
 	public static final String VERSION_ES7 = "7.4.0";
 	
 	public static final String VERSION_ES6 = "6.8.1";
+
+	private final int majorVersion;
 
 	public ElasticsearchContainer() {
 		this(VERSION_ES6);
 	}
 
 	public ElasticsearchContainer(String version) {
-		super("docker.gentics.com/elasticsearch/elasticsearch-oss:" + version);
+		super(getImageName(version));
+
+		majorVersion = getMajorVersion(version);
 	}
 
 	@Override
 	protected void configure() {
+		if (majorVersion >= 8) {
+			addEnv("xpack.security.enabled", "false");
+		}
+
 		addEnv("discovery.type", "single-node");
 		withTmpFs(Collections.singletonMap("/usr/share/elasticsearch/data", "rw,size=64m"));
 		// addEnv("xpack.security.enabled", "false");
@@ -113,4 +121,39 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 		}
 	}
 
+	/**
+	 * Create the full image name from the version number.
+	 *
+	 * <p>
+	 *     All versions use the docker.apa-it.at repository.
+	 * </p>
+	 *
+	 * <p>
+	 *     Versions lower than Elasticsearch 8 will use the
+	 *     elasticsearch-oss version of the image (an oss version
+	 *     is no longer available for Elasticsearch 8).
+	 * </p>
+	 *
+	 * @param version The Elasticsearch version to use.
+	 * @return The full image name for the given version.
+	 */
+	private static String getImageName(String version) {
+		int major = getMajorVersion(version);
+
+		if (major >= 8) {
+			return "docker.gentics.com/elasticsearch/elasticsearch:" + version;
+}
+
+		return "docker.gentics.com/elasticsearch/elasticsearch-oss:" + version;
+	}
+
+	/**
+	 * Get the major version from the given version string.
+	 *
+	 * @param version The version string
+	 * @return The major version for the given version string.
+	 */
+	private static int getMajorVersion(String version) {
+		return Integer.parseInt(version.substring(0, version.indexOf(".")));
+	}
 }

--- a/tests/context-api/src/main/java/com/gentics/mesh/test/ElasticsearchTestMode.java
+++ b/tests/context-api/src/main/java/com/gentics/mesh/test/ElasticsearchTestMode.java
@@ -28,6 +28,11 @@ public enum ElasticsearchTestMode {
 	CONTAINER_ES7,
 
 	/**
+	 * Run using an ES 8 docker container
+	 */
+	CONTAINER_ES8,
+
+	/**
 	 * Run using a toxified ES docker container
 	 */
 	CONTAINER_ES6_TOXIC,

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -526,10 +526,8 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		int createIndex = 2;
 		assertThat(trackingSearchProvider()).hasEvents(store, update, delete, dropIndex, createIndex);
 		for (JsonObject mapping : trackingSearchProvider().getCreateIndexEvents().values()) {
-			String basePath = "$.mapping.default";
-			if (complianceMode() == ComplianceMode.ES_7) {
-				basePath = "$.mapping";
-			}
+			String basePath = complianceMode() == ComplianceMode.ES_6 ? "$.mapping.default" : "$.mapping";
+
 			assertThat(mapping).has(basePath + ".properties.fields.properties.teaser.fields.raw.type", "keyword",
 				"The mapping should include a raw field for the teaser field");
 			assertThat(mapping).hasNot(basePath + ".properties.fields.properties.title.fields.raw",

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/AbstractMultiESTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/AbstractMultiESTest.java
@@ -37,6 +37,7 @@ public abstract class AbstractMultiESTest implements TestHttpMethods, TestGraphH
 		return Arrays.asList(new Object[][] {
 			{ ElasticsearchTestMode.CONTAINER_ES6 },
 			{ ElasticsearchTestMode.CONTAINER_ES7 },
+			{ ElasticsearchTestMode.CONTAINER_ES8 },
 		});
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/CustomIndexSettingsTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/CustomIndexSettingsTest.java
@@ -338,10 +338,7 @@ public class CustomIndexSettingsTest extends AbstractNodeSearchEndpointTest {
 	}
 
 	private String typeName() {
-		String name = "default";
-		if (complianceMode() == ComplianceMode.ES_7) {
-			name = "_doc";
-		}
-		return name;
+		// Mapping types have been removed in ES 7 and ES 7+ uses "_doc" as dummy.
+        return complianceMode() == ComplianceMode.ES_6 ? "default" : "_doc";
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/WaitSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/WaitSearchEndpointTest.java
@@ -61,20 +61,20 @@ public class WaitSearchEndpointTest extends AbstractMultiESTest {
 	public void rawSearchWithWaitDisabled() {
 		ObjectNode result = rawSearch(false);
 
-		if (complianceMode() == ComplianceMode.ES_7) {
-			assertThat(result.get("responses").get(0).get("hits").get("total").get("value").asLong()).isEqualTo(0);
-		} else {
+		if (complianceMode() == ComplianceMode.ES_6) {
 			assertThat(result.get("responses").get(0).get("hits").get("total").asLong()).isEqualTo(0);
+		} else {
+			assertThat(result.get("responses").get(0).get("hits").get("total").get("value").asLong()).isEqualTo(0);
 		}
 	}
 
 	@Test
 	public void rawSearchWithWaitEnabled() {
 		ObjectNode result = rawSearch(true);
-		if (complianceMode() == ComplianceMode.ES_7) {
-			assertThat(result.get("responses").get(0).get("hits").get("total").get("value").asLong()).isEqualTo(1);
-		} else {
+		if (complianceMode() == ComplianceMode.ES_6) {
 			assertThat(result.get("responses").get(0).get("hits").get("total").asLong()).isEqualTo(1);
+		} else {
+			assertThat(result.get("responses").get(0).get("hits").get("total").get("value").asLong()).isEqualTo(1);
 		}
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/NodeRawSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/NodeRawSearchEndpointTest.java
@@ -71,10 +71,7 @@ public class NodeRawSearchEndpointTest extends AbstractMeshTest {
 
 		// search in old project
 		JsonObject response = new JsonObject(call(() -> client().searchNodesRaw(getSimpleQuery("fields.content", contentFieldValue))).toString());
-		String path = "responses[0].hits.total";
-		if (complianceMode() == ComplianceMode.ES_7) {
-			path = "responses[0].hits.total.value";
-		}
+		String path = complianceMode() == ComplianceMode.ES_6 ? "responses[0].hits.total" : "responses[0].hits.total.value";
 		assertThat(response).has(path, "2", "Not exactly two item was found.");
 		JsonArray hits = response.getJsonArray("responses").getJsonObject(0).getJsonObject("hits").getJsonArray("hits");
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/project/ProjectNodeRawSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/project/ProjectNodeRawSearchEndpointTest.java
@@ -54,11 +54,7 @@ public class ProjectNodeRawSearchEndpointTest extends AbstractMeshTest {
 			call(() -> client().searchNodesRaw("projectA", getSimpleQuery("fields.content", contentFieldValue))).toString());
 		assertNotNull(response);
 		assertThat(response).has("responses[0].hits.hits[0]._id", nodeA.getUuid() + "-en", "The correct element was not found.");
-		String path = "responses[0].hits.total";
-		if (complianceMode() == ComplianceMode.ES_7) {
-			path = "responses[0].hits.total.value";
-		}
+		String path = complianceMode() == ComplianceMode.ES_6 ? "responses[0].hits.total" : "responses[0].hits.total.value";
 		assertThat(response).has(path, "1", "Not exactly one item was found");
-
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/project/ProjectTagFamilyRawSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/project/ProjectTagFamilyRawSearchEndpointTest.java
@@ -37,10 +37,7 @@ public class ProjectTagFamilyRawSearchEndpointTest extends AbstractMeshTest {
 		assertNotNull(response);
 		assertThat(response).has("responses[0].hits.hits[0]._id", tagFamily2.getUuid(), "The correct element was not found.");
 
-		String path = "responses[0].hits.total";
-		if (complianceMode() == ComplianceMode.ES_7) {
-			path = "responses[0].hits.total.value";
-		}
+		String path = complianceMode() == ComplianceMode.ES_6 ? "responses[0].hits.total" : "responses[0].hits.total.value";
 		assertThat(response).has(path, "1", "Not exactly one item was found");
 	}
 }

--- a/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/project/ProjectTagRawSearchEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/search/raw/project/ProjectTagRawSearchEndpointTest.java
@@ -43,10 +43,7 @@ public class ProjectTagRawSearchEndpointTest extends AbstractMeshTest {
 		JsonObject response = new JsonObject(call(() -> client().searchTagsRaw("projectA", query)).toString());
 		assertNotNull(response);
 		assertThat(response).has("responses[0].hits.hits[0]._id", tagA.getUuid(), "The correct element was not found.");
-		String path = "responses[0].hits.total";
-		if (complianceMode() == ComplianceMode.ES_7) {
-			path = "responses[0].hits.total.value";
-		}
+		String path = complianceMode() == ComplianceMode.ES_6 ? "responses[0].hits.total" : "responses[0].hits.total.value";
 		assertThat(response).has(path, "1", "Not exactly one item was found");
 
 	}

--- a/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/test/context/MeshTestContext.java
@@ -174,6 +174,7 @@ public class MeshTestContext implements TestRule {
 		switch (settings.elasticsearch()) {
 		case CONTAINER_ES6:
 		case CONTAINER_ES7:
+		case CONTAINER_ES8:
 			setupIndexHandlers(true);
 			break;
 		default:
@@ -187,6 +188,7 @@ public class MeshTestContext implements TestRule {
 		switch (settings.elasticsearch()) {
 		case CONTAINER_ES6:
 		case CONTAINER_ES7:
+		case CONTAINER_ES8:
 			setupIndexHandlers(false);
 			break;
 		default:
@@ -285,6 +287,7 @@ public class MeshTestContext implements TestRule {
 		idleConsumer.unregister();
 		switch (settings.elasticsearch()) {
 		case CONTAINER_ES7:
+		case CONTAINER_ES8:
 		case CONTAINER_ES6:
 		case CONTAINER_ES6_TOXIC:
 			meshDagger.searchProvider().clear().blockingAwait();
@@ -641,12 +644,26 @@ public class MeshTestContext implements TestRule {
 		S3Options s3Options = meshOptions.getS3Options();
 		searchOptions.setTimeout(10_000L);
 
-		String version = ElasticsearchContainer.VERSION_ES6;
-		switch (settings.elasticsearch()) {
-		case CONTAINER_ES7:
-			searchOptions.setComplianceMode(ComplianceMode.ES_7);
-			version = ElasticsearchContainer.VERSION_ES7;
+		String version = switch (settings.elasticsearch()) {
+            case CONTAINER_ES7 -> {
+                searchOptions.setComplianceMode(ComplianceMode.ES_7);
+
+                yield ElasticsearchContainer.VERSION_ES7;
+            }
+
+            case CONTAINER_ES8 -> {
+                searchOptions.setComplianceMode(ComplianceMode.ES_8);
+
+                yield ElasticsearchContainer.VERSION_ES8;
+            }
+
+            default -> ElasticsearchContainer.VERSION_ES6;
+        };
+
+        switch (settings.elasticsearch()) {
 		case CONTAINER_ES6:
+		case CONTAINER_ES7:
+		case CONTAINER_ES8:
 		case UNREACHABLE:
 			elasticsearch = new ElasticsearchContainer(version);
 			if (!elasticsearch.isRunning()) {


### PR DESCRIPTION
## Abstract

Make sure Mesh is compatible with Elasticsearch 8.x. New compliance mode ES_8 added. Documentation updated on how to create HTTPS certificates. Mapping and index operations updated to work with ES 8. Added ES 8 version to test container and changed tests to run with ES 6, ES 7 and ES 8.

## Checklist

### General

* [X ] Added abstract that describes the change
* [X] Added changelog entry to `/CHANGELOG.adoc`
* [X] Ensured that the change is covered by tests
* [X] Ensured that the change is documented in the docs

### On API Changes

* [ ] Checked if the changes are breaking or not
* [ ] Added GraphQL API if applicable
* [ ] Added Elasticsearch mapping if applicable
