### PR TITLE
SUP-17264: Don't jump over several schema versions during migration

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -20,7 +20,7 @@ All fixes and changes in LTS releases will be released the next minor release. C
 [[v1.10.33]]
 == 1.10.33 (TBD)
 
-icon:check[] Core: It is not anymore possible to trigger the (micro)node migration over the non-adjacent schema versions. If the chain of versions between the requested ones can be built, a distinct migration job per each version pair in the chain is triggered.
+icon:check[] Core: A crash has been fixed on an attempt of (micro)node migration over non-adjacent (micro)schema versions.
 
 [[v1.10.32]]
 == 1.10.32 (07.08.2024)

--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.33]]
+== 1.10.33 (TBD)
+
+icon:check[] Core: It is not anymore possible to trigger the (micro)node migration over the non-adjacent schema versions. If the chain of versions between the requested ones can be built, a distinct migration job per each version pair in the chain is triggered.
+
 [[v1.10.32]]
 == 1.10.32 (07.08.2024)
 

--- a/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
@@ -116,7 +116,7 @@ public abstract class AbstractMigrationHandler extends AbstractHandler implement
 		do {
 			versionChain.add(fromVersion);
 			fromVersion = fromVersion.getNextVersion();
-		} while (!newContainer.getSchemaContainerVersion().equals(fromVersion) && fromVersion != null);
+		} while (fromVersion != null && !newContainer.getSchemaContainerVersion().getVersion().equals(fromVersion.getVersion()));
 
 		versionChain.stream()
 			.flatMap(version -> version.getChanges().map(change -> Pair.of(change, version)))

--- a/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/AbstractMigrationHandler.java
@@ -129,7 +129,7 @@ public abstract class AbstractMigrationHandler extends AbstractHandler implement
 				// If a migration has been started over non-adjacent from/to versions, the intermediate changes need no actual storage, but a validation..
 				FieldSchemaContainerVersion schema = pair.getKey().getNextVersion().getSchema();
 				if (schema instanceof FieldSchemaContainerVersion && !((FieldSchemaContainerVersion)schema).getVersion().equals(newContainer.getSchemaContainerVersion().getVersion())) {
-					log.info("Update skipped for container [{}] of schema version [{}] from the intermediate version [{}]", newContainer.getUuid(), newContainer.getSchemaContainerVersion().getVersion(), ((FieldSchemaContainerVersion)schema).getVersion());
+					log.info("Update skipped for container [{}] of schema [{}] version [{}] from the intermediate version [{}]", newContainer.getUuid(), newContainer.getSchemaContainerVersion().getSchema().getName(), newContainer.getSchemaContainerVersion().getVersion(), ((FieldSchemaContainerVersion)schema).getVersion());
 					schema.assertForUnhandledFields(fm);
 				} else {
 					newContainer.updateFieldsFromRest(ac, fm);

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/MicronodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/MicronodeMigrationImpl.java
@@ -47,6 +47,7 @@ import com.gentics.mesh.etc.config.MeshOptions;
 import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.metric.MetricsService;
 import com.gentics.mesh.util.VersionNumber;
+
 import io.reactivex.Completable;
 import io.reactivex.exceptions.CompositeException;
 import io.vertx.core.logging.Logger;
@@ -85,7 +86,11 @@ public class MicronodeMigrationImpl extends AbstractMigrationHandler implements 
 			Set<String> touchedFields = new HashSet<>();
 			try {
 				db.tx(() -> {
-					prepareMigration(reloadVersion(fromVersion), touchedFields);
+					HibMicroschemaVersion currentVersion = fromVersion;
+					do {
+						prepareMigration(reloadVersion(currentVersion), touchedFields);
+						currentVersion = currentVersion.getNextVersion();
+					} while (currentVersion != toVersion && currentVersion != null);
 					ac.setProject(branch.getProject());
 					ac.setBranch(branch);
 

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/MicronodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/MicronodeMigrationImpl.java
@@ -80,17 +80,18 @@ public class MicronodeMigrationImpl extends AbstractMigrationHandler implements 
 			HibMicroschemaVersion toVersion = context.getToVersion();
 			MigrationStatusHandler status = context.getStatus();
 			MicroschemaMigrationCause cause = context.getCause();
+			String toUuid = db.tx(() -> toVersion.getUuid());
 
 			// Collect the migration scripts
 			NodeMigrationActionContextImpl ac = new NodeMigrationActionContextImpl();
 			Set<String> touchedFields = new HashSet<>();
 			try {
 				db.tx(() -> {
-					HibMicroschemaVersion currentVersion = fromVersion;
+					HibMicroschemaVersion currentVersion = reloadVersion(fromVersion);
 					do {
-						prepareMigration(reloadVersion(currentVersion), touchedFields);
+						prepareMigration(currentVersion, touchedFields);
 						currentVersion = currentVersion.getNextVersion();
-					} while (currentVersion != toVersion && currentVersion != null);
+					} while (currentVersion != null && !currentVersion.getUuid().equals(toUuid));
 					ac.setProject(branch.getProject());
 					ac.setBranch(branch);
 

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
@@ -172,7 +172,8 @@ public class NodeMigrationImpl extends AbstractMigrationHandler implements NodeM
 					do {
 						prepareMigration(reloadVersion(currentVersion), touchedFields);
 						currentVersion = currentVersion.getNextVersion();
-					} while (currentVersion != toVersion || currentVersion == null);
+					} while (currentVersion != toVersion && currentVersion != null);
+
 					if (status != null) {
 						status.setStatus(RUNNING);
 						status.commit();

--- a/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
+++ b/core/src/main/java/com/gentics/mesh/core/migration/impl/NodeMigrationImpl.java
@@ -168,11 +168,11 @@ public class NodeMigrationImpl extends AbstractMigrationHandler implements NodeM
 			Set<String> touchedFields = new HashSet<>();
 			try {
 				db.tx(() -> {
-					HibSchemaVersion currentVersion = fromVersion;
+					HibSchemaVersion currentVersion = reloadVersion(fromVersion);
 					do {
-						prepareMigration(reloadVersion(currentVersion), touchedFields);
+						prepareMigration(currentVersion, touchedFields);
 						currentVersion = currentVersion.getNextVersion();
-					} while (currentVersion != toVersion && currentVersion != null);
+					} while (currentVersion != null && !currentVersion.getUuid().equals(toUuid));
 
 					if (status != null) {
 						status.setStatus(RUNNING);

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
@@ -47,7 +47,6 @@ import com.gentics.mesh.core.rest.schema.FieldSchema;
 import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.rest.schema.FieldSchemaContainerVersion;
 import com.gentics.mesh.core.rest.schema.ListFieldSchema;
-import com.gentics.mesh.core.rest.schema.SchemaModel;
 
 public interface HibFieldContainer extends HibBasicFieldContainer {
 
@@ -222,7 +221,18 @@ public interface HibFieldContainer extends HibBasicFieldContainer {
 	 * @param ac
 	 * @param restFields
 	 */
-	void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields);
+	default void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields) {
+		updateFieldsFromRest(ac, restFields, getSchemaContainerVersion().getSchema());
+	}
+
+	/**
+	 * Use the given map of rest fields to set the data from the map to this container, against the given schema.
+	 * 
+	 * @param ac
+	 * @param restFields
+	 * @param schema target schema
+	 */
+	void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields, FieldSchemaContainer schema);
 
 	/**
 	 * Use the given map of rest fields to set the data from the map to this container.

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/HibFieldContainer.java
@@ -221,18 +221,7 @@ public interface HibFieldContainer extends HibBasicFieldContainer {
 	 * @param ac
 	 * @param restFields
 	 */
-	default void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields) {
-		updateFieldsFromRest(ac, restFields, getSchemaContainerVersion().getSchema());
-	}
-
-	/**
-	 * Use the given map of rest fields to set the data from the map to this container, against the given schema.
-	 * 
-	 * @param ac
-	 * @param restFields
-	 * @param schema target schema
-	 */
-	void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields, FieldSchemaContainer schema);
+	void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields);
 
 	/**
 	 * Use the given map of rest fields to set the data from the map to this container.

--- a/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingBranchDao.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/data/dao/PersistingBranchDao.java
@@ -5,6 +5,7 @@ import static com.gentics.mesh.core.data.perm.InternalPermission.UPDATE_PERM;
 import static com.gentics.mesh.core.rest.error.Errors.conflict;
 import static com.gentics.mesh.core.rest.error.Errors.error;
 import static com.gentics.mesh.core.rest.job.JobStatus.COMPLETED;
+import static com.gentics.mesh.core.rest.job.JobStatus.FAILED;
 import static com.gentics.mesh.core.rest.job.JobStatus.QUEUED;
 import static com.gentics.mesh.event.Assignment.ASSIGNED;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -12,6 +13,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -368,7 +370,30 @@ public interface PersistingBranchDao extends BranchDao, PersistingRootDao<HibPro
 			// Enqueue the schema migration for each found schema version
 			edge.setActive(true);
 			if (currentVersion != null) {
-				job = jobDao.enqueueSchemaMigration(user, branch, currentVersion, schemaVersion);
+				ArrayList<HibSchemaVersion> versionChain = new ArrayList<>(2);
+				versionChain.add(currentVersion);
+				versionChain.add(schemaVersion);
+				if (!schemaVersion.equals(currentVersion.getNextVersion())) {
+					do {
+						HibSchemaVersion nextVersion = currentVersion.getNextVersion();
+						if (nextVersion == null) {
+							// No connection between two versions of the same schema. This should never happen.
+							log.error("No connection between v{} and v{} of the schema `{}`, branch {}. Migration is impossible!", 
+									versionChain.get(0), versionChain.get(versionChain.size()-1), schemaVersion.getSchemaContainer().getName(), branch.getName());
+							edge.setMigrationStatus(FAILED);
+							return job;
+						} else if (!schemaVersion.equals(nextVersion)) {
+							versionChain.add(versionChain.size()-1, nextVersion);
+						}
+						currentVersion = nextVersion;
+					}
+					while (schemaVersion.equals(currentVersion.getNextVersion()));
+				}
+				log.info("Triggering migration chain for the schema `{}`, branch `{}`: [{}]", 
+						schemaVersion.getSchemaContainer().getName(), branch.getName(), versionChain.stream().map(HibSchemaVersion::getVersion).collect(Collectors.joining(" -> ")));
+				for (int i = 0; i < (versionChain.size() - 1); i++) {
+					job = jobDao.enqueueSchemaMigration(user, branch, versionChain.get(i), versionChain.get(i+1));
+				}				
 				edge.setMigrationStatus(QUEUED);
 				edge.setJobUuid(job.getUuid());
 			} else {
@@ -392,7 +417,30 @@ public interface PersistingBranchDao extends BranchDao, PersistingRootDao<HibPro
 			// Enqueue the job so that the worker can process it later on
 			edge.setActive(true);
 			if (currentVersion != null) {
-				job = jobDao.enqueueMicroschemaMigration(user, branch, currentVersion, microschemaVersion);
+				ArrayList<HibMicroschemaVersion> versionChain = new ArrayList<>(2);
+				versionChain.add(currentVersion);
+				versionChain.add(microschemaVersion);
+				if (!microschemaVersion.equals(currentVersion.getNextVersion())) {
+					do {
+						HibMicroschemaVersion nextVersion = currentVersion.getNextVersion();
+						if (nextVersion == null) {
+							// No connection between two versions of the same microschema. This should never happen.
+							log.error("No connection between v{} and v{} of the microschema `{}`, branch {}. Migration is impossible!", 
+									versionChain.get(0), versionChain.get(versionChain.size()-1), microschemaVersion.getSchemaContainer().getName(), branch.getName());
+							edge.setMigrationStatus(FAILED);
+							return job;
+						} else if (!microschemaVersion.equals(nextVersion)) {
+							versionChain.add(versionChain.size()-1, nextVersion);
+						}
+						currentVersion = nextVersion;
+					}
+					while (microschemaVersion.equals(currentVersion.getNextVersion()));
+				}
+				log.info("Triggering migration chain for the microschema `{}`, branch `{}`: [{}]", 
+						microschemaVersion.getSchemaContainer().getName(), branch.getName(), versionChain.stream().map(HibMicroschemaVersion::getVersion).collect(Collectors.joining(" -> ")));
+				for (int i = 0; i < (versionChain.size() - 1); i++) {
+					job = jobDao.enqueueMicroschemaMigration(user, branch, versionChain.get(i), versionChain.get(i+1));
+				}				
 				edge.setMigrationStatus(QUEUED);
 				edge.setJobUuid(job.getUuid());
 			} else {

--- a/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/migration/impl/MigrationStatusHandlerImpl.java
@@ -18,8 +18,8 @@ import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.endpoint.migration.MigrationStatusHandler;
 import com.gentics.mesh.core.migration.MigrationAbortedException;
 import com.gentics.mesh.core.rest.job.JobStatus;
-
 import com.gentics.mesh.core.rest.job.JobWarningList;
+
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -126,9 +126,11 @@ public class MigrationStatusHandlerImpl implements MigrationStatusHandler {
 			setStatus(FAILED);
 			log.error("Error handling migration", error);
 
-			job.setStopTimestamp();
-			job.setError(error);
-			commit(job);
+			if (job != null) {
+				job.setStopTimestamp();
+				job.setError(error);
+				commit(job);
+			}
 		}
 		return this;
 	}

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
@@ -9,11 +9,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERR
 
 import java.util.List;
 
-import com.gentics.mesh.core.data.node.field.nesting.HibMicronodeField;
-import com.gentics.mesh.core.rest.node.FieldMapImpl;
-import com.gentics.mesh.core.rest.schema.SchemaModel;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 
 import com.gentics.mesh.context.BulkActionContext;
@@ -57,6 +52,7 @@ import com.gentics.mesh.core.data.node.field.list.impl.MicronodeGraphFieldListIm
 import com.gentics.mesh.core.data.node.field.list.impl.NodeGraphFieldListImpl;
 import com.gentics.mesh.core.data.node.field.list.impl.NumberGraphFieldListImpl;
 import com.gentics.mesh.core.data.node.field.list.impl.StringGraphFieldListImpl;
+import com.gentics.mesh.core.data.node.field.nesting.HibMicronodeField;
 import com.gentics.mesh.core.data.node.field.nesting.MicronodeGraphField;
 import com.gentics.mesh.core.data.node.field.nesting.NodeGraphField;
 import com.gentics.mesh.core.data.node.impl.MicronodeImpl;
@@ -68,6 +64,9 @@ import com.gentics.mesh.core.rest.node.field.Field;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
 import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.syncleus.ferma.traversals.EdgeTraversal;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Abstract implementation for a field container. A {@link GraphFieldContainer} is used to store {@link GraphField} instances.
@@ -401,8 +400,7 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 	}
 
 	@Override
-	public void updateFieldsFromRest(InternalActionContext ac, FieldMap fieldMap) {
-		FieldSchemaContainer schema = getSchemaContainerVersion().getSchema();
+	public void updateFieldsFromRest(InternalActionContext ac, FieldMap fieldMap, FieldSchemaContainer schema) {
 		schema.assertForUnhandledFields(fieldMap);
 
 		// TODO: This should return an observable

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/AbstractGraphFieldContainerImpl.java
@@ -400,7 +400,8 @@ public abstract class AbstractGraphFieldContainerImpl extends AbstractBasicGraph
 	}
 
 	@Override
-	public void updateFieldsFromRest(InternalActionContext ac, FieldMap fieldMap, FieldSchemaContainer schema) {
+	public void updateFieldsFromRest(InternalActionContext ac, FieldMap fieldMap) {
+		FieldSchemaContainer schema = getSchemaContainerVersion().getSchema();
 		schema.assertForUnhandledFields(fieldMap);
 
 		// TODO: This should return an observable

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/NodeGraphFieldContainerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/NodeGraphFieldContainerImpl.java
@@ -61,6 +61,7 @@ import com.gentics.mesh.core.data.user.HibUser;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.node.FieldMap;
+import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.result.Result;
 import com.gentics.mesh.core.result.TraversalResult;
 import com.gentics.mesh.util.Tuple;
@@ -189,9 +190,14 @@ public class NodeGraphFieldContainerImpl extends AbstractGraphFieldContainerImpl
 
 	@Override
 	public void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields) {
+		updateFieldsFromRest(ac, restFields, getSchemaContainerVersion().getSchema());
+	}
+
+	@Override
+	public void updateFieldsFromRest(InternalActionContext ac, FieldMap fieldMap, FieldSchemaContainer schema) {
 		Tx tx = Tx.get();
 		ContentDao contentDao = tx.contentDao();
-		super.updateFieldsFromRest(ac, restFields);
+		super.updateFieldsFromRest(ac, fieldMap, schema);
 		String branchUuid = tx.getBranch(ac).getUuid();
 
 		contentDao.updateWebrootPathInfo(this, ac, branchUuid, "node_conflicting_segmentfield_update");

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/NodeGraphFieldContainerImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/container/impl/NodeGraphFieldContainerImpl.java
@@ -8,7 +8,6 @@ import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_FIE
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_FIELD_CONTAINER;
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_LIST;
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.HAS_VERSION;
-import static com.gentics.mesh.core.data.relationship.GraphRelationships.MICROSCHEMA_VERSION_KEY_PROPERTY;
 import static com.gentics.mesh.core.data.relationship.GraphRelationships.SCHEMA_CONTAINER_VERSION_KEY_PROPERTY;
 import static com.gentics.mesh.core.data.util.HibClassConverter.toGraph;
 import static com.gentics.mesh.core.rest.common.ContainerType.DRAFT;
@@ -47,13 +46,11 @@ import com.gentics.mesh.core.data.node.field.impl.BinaryGraphFieldImpl;
 import com.gentics.mesh.core.data.node.field.impl.MicronodeGraphFieldImpl;
 import com.gentics.mesh.core.data.node.field.impl.S3BinaryGraphFieldImpl;
 import com.gentics.mesh.core.data.node.field.list.HibMicronodeFieldList;
-import com.gentics.mesh.core.data.node.field.list.MicronodeGraphFieldList;
 import com.gentics.mesh.core.data.node.field.list.impl.MicronodeGraphFieldListImpl;
 import com.gentics.mesh.core.data.node.field.nesting.HibMicronodeField;
 import com.gentics.mesh.core.data.node.field.nesting.MicronodeGraphField;
 import com.gentics.mesh.core.data.node.impl.NodeImpl;
 import com.gentics.mesh.core.data.schema.HibFieldSchemaVersionElement;
-import com.gentics.mesh.core.data.schema.HibMicroschemaVersion;
 import com.gentics.mesh.core.data.schema.HibSchemaVersion;
 import com.gentics.mesh.core.data.schema.impl.SchemaContainerVersionImpl;
 import com.gentics.mesh.core.data.search.BucketableElementHelper;
@@ -61,7 +58,6 @@ import com.gentics.mesh.core.data.user.HibUser;
 import com.gentics.mesh.core.db.Tx;
 import com.gentics.mesh.core.rest.common.ContainerType;
 import com.gentics.mesh.core.rest.node.FieldMap;
-import com.gentics.mesh.core.rest.schema.FieldSchemaContainer;
 import com.gentics.mesh.core.result.Result;
 import com.gentics.mesh.core.result.TraversalResult;
 import com.gentics.mesh.util.Tuple;
@@ -190,14 +186,9 @@ public class NodeGraphFieldContainerImpl extends AbstractGraphFieldContainerImpl
 
 	@Override
 	public void updateFieldsFromRest(InternalActionContext ac, FieldMap restFields) {
-		updateFieldsFromRest(ac, restFields, getSchemaContainerVersion().getSchema());
-	}
-
-	@Override
-	public void updateFieldsFromRest(InternalActionContext ac, FieldMap fieldMap, FieldSchemaContainer schema) {
 		Tx tx = Tx.get();
 		ContentDao contentDao = tx.contentDao();
-		super.updateFieldsFromRest(ac, fieldMap, schema);
+		super.updateFieldsFromRest(ac, restFields);
 		String branchUuid = tx.getBranch(ac).getUuid();
 
 		contentDao.updateWebrootPathInfo(this, ac, branchUuid, "node_conflicting_segmentfield_update");

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/GraphFieldTypes.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/impl/GraphFieldTypes.java
@@ -164,8 +164,7 @@ public enum GraphFieldTypes {
 	 *            Field schema to be used to identify the type of the field
 	 * @param schema
 	 */
-	public void updateField(HibFieldContainer container, InternalActionContext ac, FieldMap fieldMap, String fieldKey,
-		FieldSchema fieldSchema, FieldSchemaContainer schema) {
+	public void updateField(HibFieldContainer container, InternalActionContext ac, FieldMap fieldMap, String fieldKey, FieldSchema fieldSchema, FieldSchemaContainer schema) {
 		updater.update(container, ac, fieldMap, fieldKey, fieldSchema, schema);
 	}
 

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -635,13 +635,12 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			tx.success();
 		}
 
-		grantAdmin();
 		// 1. Drop random fields
 		SchemaUpdateRequest request = tx(() -> JsonUtil.readValue(node.getSchemaContainer().getLatestVersion().getJson(),
 			SchemaUpdateRequest.class));
 		List<FieldSchema> someFields = IntStream.range(0, request.getFields().size()).filter(i -> i % 2 == 0).mapToObj(i -> request.getFields().get(i)).collect(Collectors.toList());
 		request.getFields().removeAll(someFields);
-		call(() -> client().updateSchema(schemaUuid, request, new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false)));
+		adminCall(() -> client().updateSchema(schemaUuid, request, new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false)));
 
 		// 2. Add random fields
 		IntStream.range(0, someFields.size()).forEach(i -> {
@@ -650,8 +649,7 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 			}
 		});
 		request.getFields().addAll(someFields);
-		call(() -> client().updateSchema(schemaUuid, request, new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false)));
-		revokeAdmin();
+		adminCall(() -> client().updateSchema(schemaUuid, request, new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false)));
 
 		try (Tx tx = tx()) {
 			container = tx.schemaDao().findByUuid(schemaUuid);

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/schema/NodeMigrationEndpointTest.java
@@ -19,7 +19,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
@@ -75,6 +78,7 @@ import com.gentics.mesh.etc.config.search.ComplianceMode;
 import com.gentics.mesh.event.EventQueueBatch;
 import com.gentics.mesh.json.JsonUtil;
 import com.gentics.mesh.parameter.impl.PublishParametersImpl;
+import com.gentics.mesh.parameter.impl.SchemaUpdateParametersImpl;
 import com.gentics.mesh.parameter.impl.VersioningParametersImpl;
 import com.gentics.mesh.test.MeshTestSetting;
 import com.gentics.mesh.test.context.AbstractMeshTest;
@@ -596,6 +600,78 @@ public class NodeMigrationEndpointTest extends AbstractMeshTest {
 		JobListResponse status = adminCall(() -> client().findJobs());
 		assertThat(status).listsAll(COMPLETED).hasInfos(2);
 		assertThat(status).containsJobs(jobAUuid);
+	}
+
+	@Test
+	public void testMigrateSkippingVersions() throws Throwable {
+		String oldFieldName = "oldname";
+		String fieldName = "changedfield";
+		HibSchema container;
+		HibSchemaVersion versionA;
+		HibSchemaVersion versionB;
+		HibNode node;
+		String schemaUuid;
+
+		try (Tx tx = tx()) {
+			NodeDao nodeDao = tx.nodeDao();
+			BranchDao branchDao = tx.branchDao();
+			container = createDummySchemaWithChanges(oldFieldName, fieldName, false);
+			versionB = container.getLatestVersion();
+			versionA = versionB.getPreviousVersion();
+			schemaUuid = container.getUuid();
+
+			EventQueueBatch batch = createBatch();
+			branchDao.assignSchemaVersion(project().getLatestBranch(), user(), versionA, batch);
+			Tx.get().commit();
+
+			// create a node and publish
+			node = nodeDao.create(folder("2015"), user(), versionA, project());
+			HibNodeFieldContainer englishContainer = tx.contentDao().createFieldContainer(node, english(), project().getLatestBranch(),
+				user());
+			englishContainer.createString(oldFieldName).setString("content");
+			englishContainer.createString("name").setString("someName");
+			InternalActionContext ac = new InternalRoutingActionContextImpl(mockRoutingContext());
+			nodeDao.publish(node, ac, createBulkContext(), "en");
+			tx.success();
+		}
+
+		grantAdmin();
+		// 1. Drop random fields
+		SchemaUpdateRequest request = tx(() -> JsonUtil.readValue(node.getSchemaContainer().getLatestVersion().getJson(),
+			SchemaUpdateRequest.class));
+		List<FieldSchema> someFields = IntStream.range(0, request.getFields().size()).filter(i -> i % 2 == 0).mapToObj(i -> request.getFields().get(i)).collect(Collectors.toList());
+		request.getFields().removeAll(someFields);
+		call(() -> client().updateSchema(schemaUuid, request, new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false)));
+
+		// 2. Add random fields
+		IntStream.range(0, someFields.size()).forEach(i -> {
+			if (i % 2 == 0) {
+				someFields.get(i).setName("bogus_" + i);
+			}
+		});
+		request.getFields().addAll(someFields);
+		call(() -> client().updateSchema(schemaUuid, request, new SchemaUpdateParametersImpl().setUpdateAssignedBranches(false)));
+		revokeAdmin();
+
+		try (Tx tx = tx()) {
+			container = tx.schemaDao().findByUuid(schemaUuid);
+			versionB = container.getLatestVersion();
+			EventQueueBatch batch = createBatch();
+			tx.branchDao().assignSchemaVersion(project().getLatestBranch(), user(), versionB, batch);
+			tx.success();
+		}
+		doSchemaMigration(versionA, versionB);
+
+		try (Tx tx = tx()) {
+			ContentDao contentDao = tx.contentDao();
+			assertThat(tx.contentDao().getFieldContainer(node, "en")).as("Migrated skipping draft").isOf(versionB).hasVersion("2.0");
+			assertThat(contentDao.getFieldContainer(node, "en", project().getLatestBranch().getUuid(), ContainerType.PUBLISHED))
+				.as("Migrated skipping published")
+				.isOf(versionB).hasVersion("2.0");
+		}
+
+		JobListResponse status = adminCall(() -> client().findJobs());
+		assertThat(status).listsAll(COMPLETED);
 	}
 
 	@Test


### PR DESCRIPTION
## Abstract

It should not be allowed to perform a (micro)node migration over two non-adjacent (micro)schema versions, since there is no way to determine and apply the correct set of changes.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
