### PR TITLE
SUP-17450: Duplicated data crash fix

### DIFF
--- a/LTS-CHANGELOG.adoc
+++ b/LTS-CHANGELOG.adoc
@@ -17,6 +17,11 @@ include::content/docs/variables.adoc-include[]
 The LTS changelog lists releases which are only accessible via a commercial subscription.
 All fixes and changes in LTS releases will be released the next minor release. Changes from LTS 1.4.x will be included in release 1.5.0.
 
+[[v1.10.35]]
+== 1.10.35 (27.09.2024)
+
+icon:check[] Core: A crash, caused by duplicated nodes in a GraphQL resulting set, has been fixed.
+
 [[v1.10.34]]
 == 1.10.34 (11.09.2024)
 

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/NodeDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/NodeDaoWrapperImpl.java
@@ -7,6 +7,7 @@ import static com.gentics.mesh.core.rest.common.ContainerType.PUBLISHED;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -223,7 +224,7 @@ public class NodeDaoWrapperImpl extends AbstractRootDaoWrapper<NodeResponse, Hib
 
 	@Override
 	public Map<HibNode, List<HibNode>> getBreadcrumbNodesMap(Collection<HibNode> nodes, InternalActionContext ac) {
-		return nodes.stream().map(node -> Pair.of(node,
+		return new HashSet<>(nodes).stream().map(node -> Pair.of(node,
 				getBreadcrumbNodes(node, ac)
 						.stream()
 						.map(HibNode.class::cast)

--- a/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/NodeDaoWrapperImpl.java
+++ b/mdm/orientdb-wrapper/src/main/java/com/gentics/mesh/core/data/dao/impl/NodeDaoWrapperImpl.java
@@ -109,9 +109,10 @@ public class NodeDaoWrapperImpl extends AbstractRootDaoWrapper<NodeResponse, Hib
 		return toGraph(node).getChildrenStream(ac, perm);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public Map<HibNode, List<HibNode>> getChildren(Collection<HibNode> nodes, String branchUuid) {
-		return nodes.stream()
+		return new HashSet<>(nodes).stream()
 				.map(node -> Pair.of(node, (List<HibNode>) getChildren(node, branchUuid).list()))
 				.collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 	}


### PR DESCRIPTION
## Abstract

A result set of an any intermediate GraphQL processing step may have duplications. One of those causes crashes.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
