### PR TITLE
SUP 17916: Remove unnecessary dependency on kubernetes plugin for hazelcast

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -254,11 +254,6 @@
 				<artifactId>hazelcast</artifactId>
 				<version>${hazelcast.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>com.hazelcast</groupId>
-				<artifactId>hazelcast-kubernetes</artifactId>
-				<version>1.5.6</version>
-			</dependency>
 
 			<!-- Test dependencies -->
 			<dependency>

--- a/changelog/src/changelog/entries/2024/12/8096.SUP-17916.bugfix
+++ b/changelog/src/changelog/entries/2024/12/8096.SUP-17916.bugfix
@@ -1,0 +1,1 @@
+Clustering: Autodiscovery of cluster member nodes in a kubernetes environment did not work (Mesh instances failed to start) due to an incorrect dependency, which has been removed now.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -163,11 +163,6 @@
 
 		<!-- Hazelcast -->
 		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-kubernetes</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-mail-client</artifactId>
 		</dependency>

--- a/core/src/main/resources/config/hazelcast.xml
+++ b/core/src/main/resources/config/hazelcast.xml
@@ -13,7 +13,6 @@
 		xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<group>
 		<name>${mesh.clusterName}</name>
-		<password>orientdb</password>
 	</group>
 	<properties>
 		<property name="hazelcast.phone.home.enabled">false</property>

--- a/doc/src/main/hugo/content/docs/clustering.asciidoc
+++ b/doc/src/main/hugo/content/docs/clustering.asciidoc
@@ -91,7 +91,7 @@ Alternatively it is also possible to hardcode the IP addresses of the cluster in
 
 === Kubernetes
 
-Autodiscovery of nodes in a kubernetes environment is built in to hazelcast and just needs to be configured in the `hazelcast.xml` file.
+Autodiscovery of nodes in a kubernetes environment is built into Hazelcast and just needs to be configured in the `hazelcast.xml` file.
 
 Example configuration:
 

--- a/doc/src/main/hugo/content/docs/clustering.asciidoc
+++ b/doc/src/main/hugo/content/docs/clustering.asciidoc
@@ -91,7 +91,7 @@ Alternatively it is also possible to hardcode the IP addresses of the cluster in
 
 === Kubernetes
 
-The link:https://github.com/hazelcast/hazelcast-kubernetes[hazelcast-kubernetes] plugin can be used to enable autodiscovery of nodes in a kubernetes environment. The plugin itself is already part of Gentics Mesh and just needs to be configured in the `hazelcast.xml` file.
+Autodiscovery of nodes in a kubernetes environment is built in to hazelcast and just needs to be configured in the `hazelcast.xml` file.
 
 Example configuration:
 
@@ -105,23 +105,13 @@ Example configuration:
             <!-- deactivate normal discovery -->
             <multicast enabled="false"/>
             <tcp-ip enabled="false" />
-
-            <!-- activate the Kubernetes plugin -->
-            <discovery-strategies>
-                <discovery-strategy enabled="true"
-                        class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-                    <properties>
-                        <property name="service-dns">MY-SERVICE-DNS-NAME</property>
-                        <property name="service-dns-timeout">10</property>
-                    </properties>
-                </discovery-strategy>
-            </discovery-strategies>
+            <kubernetes enabled="true"/>
         </join>
   </network>
 ...
 ----
 
-NOTE: For more details on the setup of the plugin please take a look at the link:https://github.com/hazelcast/hazelcast-kubernetes[documentation].
+NOTE: For more details on the setup please take a look at the link:https://docs.hazelcast.com/hazelcast/latest/kubernetes/kubernetes-auto-discovery[documentation].
 
 == Session distribution
 
@@ -162,26 +152,6 @@ In a master-replica setup this can be useful to delegate write requests on repli
 === Configuration
 
 By default the coordination layer is disabled and first needs to be enabled in the cluster settings.
-
-==== Modes
-
-The `cluster.coordinatorMode` setting or `MESH_CLUSTER_COORDINATOR_MODE` environment variable can control how the coordinator should behave.
-
-* `DISABLED` - In this mode no coordination of requests will be done.
-
-* `CUD` - In this mode only write requests (Create, Update, Delete) will be delegated to the elected master. All other requests will be directly processed by the instance.
-
-* `ALL` - In this mode all requests (CRUD) will be delegated to the elected master.
-
-==== Topology management
-
-The `cluster.coordinatorTopology` setting or `MESH_CLUSTER_COORDINATOR_TOPOLOGY` environment variable controls whether the coordinator will also manage the current cluster topology. By default no cluster topology management will be done.
-
-* `UNMANAGED` - Don't manage cluster topology.
-
-* `MASTER_REPLICA` - Use the elected master also as database master and make other nodes in the cluster replicas.
-
-NOTE: The topology can only be managed when the coordination mode is not disabled. 
 
 === Master Election
 

--- a/mdm/hibernate-core/src/main/java/com/gentics/mesh/changelog/HibernateBootstrapInitializerImpl.java
+++ b/mdm/hibernate-core/src/main/java/com/gentics/mesh/changelog/HibernateBootstrapInitializerImpl.java
@@ -296,9 +296,6 @@ public class HibernateBootstrapInitializerImpl extends AbstractBootstrapInitiali
 			clusterOptions.setNetworkHost(localIp);
 		}
 
-		// This setting will be referenced by the hazelcast configuration
-		System.setProperty("mesh.clusterName", clusterOptions.getClusterName());
-
 		final String defaultHazelcastConfigPath = new File("").getAbsolutePath() + File.separator + "config" + File.separator + "hazelcast.xml";
 		final String hazelcastConfig = System.getProperty("hazelcast.config", defaultHazelcastConfigPath);
 		// This setting is used by the HazelcastClusterManager to identify the path of the hazelcast configuration file

--- a/mdm/hibernate-core/src/main/java/com/gentics/mesh/database/cluster/HibClusterManager.java
+++ b/mdm/hibernate-core/src/main/java/com/gentics/mesh/database/cluster/HibClusterManager.java
@@ -58,6 +58,7 @@ public class HibClusterManager implements ClusterManager {
 			config.setInstanceName(options.getNodeName());
 			config.setClusterName(options.getClusterOptions().getClusterName());
 			config.setClassLoader(Thread.currentThread().getContextClassLoader());
+			config.getMemberAttributeConfig().setAttribute("__vertx.nodeId", options.getNodeName());
 			hazelcastInstance = Hazelcast.getOrCreateHazelcastInstance(config);
 		}
 		return hazelcastInstance;

--- a/plugin-parent/pom.xml
+++ b/plugin-parent/pom.xml
@@ -204,11 +204,6 @@
 			<artifactId>hazelcast</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-kubernetes</artifactId>
-			<scope>provided</scope>
-		</dependency>
 
 		<!-- RX -->
 		<dependency>


### PR DESCRIPTION
## Abstract

Support for kubernetes autodiscovery is now built into hazelcast, so the plugin is not necessary (and is actually incompatible).

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [ ] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
