### PR TITLE
Add periodic background job for cleaning the binary image cache

### DIFF
--- a/api/src/main/java/com/gentics/mesh/etc/config/ImageManipulatorOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ImageManipulatorOptions.java
@@ -1,6 +1,7 @@
 package com.gentics.mesh.etc.config;
 
 import java.io.File;
+import java.time.Duration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -20,12 +21,18 @@ public class ImageManipulatorOptions implements Option {
 	public static final String MESH_IMAGE_JPEG_QUALITY_ENV = "MESH_IMAGE_JPEG_QUALITY";
 	public static final String MESH_IMAGE_RESAMPLE_FILTER_ENV = "MESH_IMAGE_RESAMPLE_FILTER";
 	public static final String MESH_IMAGE_CACHE_DIRECTORY_ENV = "MESH_IMAGE_CACHE_DIRECTORY";
+	public static final String MESH_IMAGE_CACHE_CLEAN_INTERVAL_ENV = "MESH_IMAGE_CACHE_CLEAN_INTERVAL";
+	public static final String MESH_IMAGE_CACHE_MAX_IDLE_ENV = "MESH_IMAGE_CACHE_MAX_IDLE";
+	public static final String MESH_IMAGE_CACHE_TOUCH_ENV = "MESH_IMAGE_CACHE_TOUCH";
 	public static final String MESH_IMAGE_MANIPULATION_MODE_ENV = "MESH_IMAGE_MANIPULATION_MODE";
 
 	public static final int DEFAULT_MAX_WIDTH = 2048;
 	public static final int DEFAULT_MAX_HEIGHT = 2048;
 	public static final float DEFAULT_JPEG_QUALITY = 0.95f;
 	public static final String DEFAULT_IMAGE_CACHE_DIRECTORY = "data" + File.separator + "binaryImageCache";
+	public static final String DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL = "PT0S";
+	public static final String DEFAULT_IMAGE_CACHE_MAX_IDLE = "PT1M";
+	public static final boolean DEFAULT_IMAGE_CACHE_TOUCH = false;
 	// This is the default filter in ImageMagick
 	public static final ResampleFilter DEFAULT_RESAMPLE_FILTER = ResampleFilter.LANCZOS;
 	public static final ImageManipulationMode DEFAULT_IMAGE_MANIPULATION_MODE = ImageManipulationMode.ON_DEMAND;
@@ -39,6 +46,21 @@ public class ImageManipulatorOptions implements Option {
 	@JsonPropertyDescription("Configure the path for image cache directory. Default: data/binaryImageCache")
 	@EnvironmentVariable(name = MESH_IMAGE_CACHE_DIRECTORY_ENV, description = "Override the path for image cache directory.")
 	private String imageCacheDirectory = DEFAULT_IMAGE_CACHE_DIRECTORY;
+
+	@JsonProperty(defaultValue = DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL)
+	@JsonPropertyDescription("Image cache clean interval in ISO 8601 duration format. Setting this to PT0S will disable the image cache cleanup. Default: " + DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL)
+	@EnvironmentVariable(name = MESH_IMAGE_CACHE_CLEAN_INTERVAL_ENV, description = "Overwrite the image cache clean interval.")
+	private String imageCacheCleanInterval = DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL;
+
+	@JsonProperty(defaultValue = DEFAULT_IMAGE_CACHE_MAX_IDLE)
+	@JsonPropertyDescription("Image cache maximum idle time in ISO 8601 duration format. Default: " + DEFAULT_IMAGE_CACHE_MAX_IDLE)
+	@EnvironmentVariable(name = MESH_IMAGE_CACHE_CLEAN_INTERVAL_ENV, description = "Overwrite the image cache max idle time.")
+	private String imageCacheMaxIdle = DEFAULT_IMAGE_CACHE_MAX_IDLE;
+
+	@JsonProperty(required = false)
+	@JsonPropertyDescription("Whether the Image cache files should be touched when accessed. Default: " + DEFAULT_IMAGE_CACHE_TOUCH)
+	@EnvironmentVariable(name = MESH_IMAGE_CACHE_TOUCH_ENV, description = "Overwrite the image cache touch behaviour.")
+	private boolean imageCacheTouch = DEFAULT_IMAGE_CACHE_TOUCH;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Configure the maximum allowed image resize width. Resizing is a memory intensive operation and thus this limit can help avoid memory issues. Default: "
@@ -70,6 +92,36 @@ public class ImageManipulatorOptions implements Option {
 	@Setter
 	public ImageManipulatorOptions setImageCacheDirectory(String imageCacheDirectory) {
 		this.imageCacheDirectory = imageCacheDirectory;
+		return this;
+	}
+
+	public String getImageCacheCleanInterval() {
+		return imageCacheCleanInterval;
+	}
+
+	@Setter
+	public ImageManipulatorOptions setImageCacheCleanInterval(String imageCacheCleanInterval) {
+		this.imageCacheCleanInterval = imageCacheCleanInterval;
+		return this;
+	}
+
+	public String getImageCacheMaxIdle() {
+		return imageCacheMaxIdle;
+	}
+
+	@Setter
+	public ImageManipulatorOptions setImageCacheMaxIdle(String imageCacheMaxIdle) {
+		this.imageCacheMaxIdle = imageCacheMaxIdle;
+		return this;
+	}
+
+	public boolean isImageCacheTouch() {
+		return imageCacheTouch;
+	}
+
+	@Setter
+	public ImageManipulatorOptions setImageCacheTouch(boolean imageCacheTouch) {
+		this.imageCacheTouch = imageCacheTouch;
 		return this;
 	}
 
@@ -127,5 +179,15 @@ public class ImageManipulatorOptions implements Option {
 	 * Validate the options.
 	 */
 	public void validate(MeshOptions meshOptions) {
+		try {
+			Duration.parse(imageCacheCleanInterval);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("imageCacheCleanInterval must be formatted in ISO 8601 duration format.");
+		}
+		try {
+			Duration.parse(imageCacheMaxIdle);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("imageCacheMaxIdle must be formatted in ISO 8601 duration format.");
+		}
 	}
 }

--- a/changelog/src/changelog/entries/2025/01/8119.SUP-17797.bugfix
+++ b/changelog/src/changelog/entries/2025/01/8119.SUP-17797.bugfix
@@ -1,0 +1,4 @@
+Image Manipulation: A periodic cleanup for files in the image cache has been added, which can be
+configured with the new configuration options `image.imageCacheCleanInterval` (for the interval for running the cleanup)
+and `image.imageCacheMaxIdle` (for the maximum allowed file age). Both values must be set in ISO 8601 duration format.
+By default, `image.imageCacheCleanInterval` is set to `PT0S` (0 seconds), which deactivates the periodic cleanup.

--- a/common/src/main/java/com/gentics/mesh/core/image/spi/AbstractImageManipulator.java
+++ b/common/src/main/java/com/gentics/mesh/core/image/spi/AbstractImageManipulator.java
@@ -7,7 +7,14 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import com.gentics.mesh.core.data.binary.HibBinary;
 import com.gentics.mesh.core.image.CacheFileInfo;
@@ -29,16 +36,41 @@ import io.vertx.reactivex.core.file.FileSystem;
  * Abstract image manipulator implementation.
  */
 public abstract class AbstractImageManipulator implements ImageManipulator {
+	private static final String IMAGE_CACHE_CLEANER_THREAD_NAME = "mesh-image-cache-cleaner";
 
 	private static final Logger log = LoggerFactory.getLogger(AbstractImageManipulator.class);
 
 	protected ImageManipulatorOptions options;
 
+	protected long imageCacheCleanIntervalInSeconds;
+
+	protected long imageCacheMaxIdleInSeconds;
+
 	protected Vertx vertx;
+
+	/**
+	 * Executor service for running the image cache cleaner
+	 */
+	private ScheduledExecutorService imageCacheCleanerService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+		@Override
+		public Thread newThread(Runnable r) {
+			return new Thread(r, IMAGE_CACHE_CLEANER_THREAD_NAME);
+		}
+	});
+
+	/**
+	 * scheduled image cache cleaner
+	 */
+	private ScheduledFuture<?> imageCacheCleaner;
 
 	public AbstractImageManipulator(Vertx vertx, ImageManipulatorOptions options) {
 		this.vertx = vertx;
 		this.options = options;
+
+		imageCacheCleanIntervalInSeconds = Duration.parse(options.getImageCacheCleanInterval()).get(ChronoUnit.SECONDS);
+		imageCacheMaxIdleInSeconds = Duration.parse(options.getImageCacheMaxIdle()).get(ChronoUnit.SECONDS);
+
+		startImageCacheCleaner();
 	}
 
 	@Override
@@ -66,6 +98,11 @@ public abstract class AbstractImageManipulator implements ImageManipulator {
 						.map(CacheFileNotFoundException.class::cast)
 						.map(CacheFileNotFoundException::getFilePath));
 		});
+	}
+
+	@Override
+	public void shutdown() {
+		stopImageCacheCleaner();
 	}
 
 	protected Single<CacheFileInfo> getCacheFilePathNew(HibBinary binary, ImageManipulation parameters) {
@@ -214,6 +251,34 @@ public abstract class AbstractImageManipulator implements ImageManipulator {
 		}
 		info.setDominantColor(colorHex);
 		return info;
+	}
+
+	/**
+	 * Start the image cache cleaner, if configured to do so and not started before
+	 */
+	private void startImageCacheCleaner() {
+		if (imageCacheCleaner == null && options.getImageCacheDirectory() != null
+				&& imageCacheCleanIntervalInSeconds > 0) {
+			if (log.isDebugEnabled()) {
+				log.debug("Starting image cache cleaner");
+			}
+			imageCacheCleaner = imageCacheCleanerService.scheduleAtFixedRate(
+					new ImageCacheCleaner(new File(options.getImageCacheDirectory()), imageCacheMaxIdleInSeconds), 0,
+					imageCacheCleanIntervalInSeconds, TimeUnit.SECONDS);
+		}
+	}
+
+	/**
+	 * Stop the image cache cleaner (if started before)
+	 */
+	private void stopImageCacheCleaner() {
+		if (imageCacheCleaner != null) {
+			if (log.isDebugEnabled()) {
+				log.debug("Stopping image cache cleaner");
+			}
+			imageCacheCleaner.cancel(true);
+			imageCacheCleaner = null;
+		}
 	}
 
 	@Deprecated

--- a/common/src/main/java/com/gentics/mesh/core/image/spi/ImageCacheCleaner.java
+++ b/common/src/main/java/com/gentics/mesh/core/image/spi/ImageCacheCleaner.java
@@ -1,0 +1,104 @@
+package com.gentics.mesh.core.image.spi;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.gentics.mesh.etc.config.ImageManipulatorOptions;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * The Image Cache Cleaner will check all files in the configured image cache directory.
+ * Files older than the configured {@link ImageManipulatorOptions#getImageCacheMaxIdle()} will be deleted.
+ * The "age" of a file is either the last access time or last modification time of the file, depending on which is newer.
+ */
+public class ImageCacheCleaner implements Runnable {
+	private static final Logger log = LoggerFactory.getLogger(ImageCacheCleaner.class);
+
+	protected File imageCacheDirectory;
+
+	protected long maxIdleInSeconds;
+
+	/**
+	 * Create an instance for cleaning the image cache directory
+	 * @param imageCacheDirectory image cache directory
+	 * @param maxIdleInSeconds max allowed file age in seconds
+	 */
+	public ImageCacheCleaner(File imageCacheDirectory, long maxIdleInSeconds) {
+		this.imageCacheDirectory = imageCacheDirectory;
+		this.maxIdleInSeconds = maxIdleInSeconds;
+	}
+
+	@Override
+	public void run() {
+		long start = System.currentTimeMillis();
+		AtomicLong checkCounter = new AtomicLong();
+		AtomicLong cleanCounter = new AtomicLong();
+		FileTime oldestAllowedAccessTime = FileTime.from(System.currentTimeMillis() / 1000L - maxIdleInSeconds, TimeUnit.SECONDS);
+
+		if (log.isDebugEnabled()) {
+			log.debug("Start cleaning image cache {} from all files accessed before {}", imageCacheDirectory.getAbsolutePath(), oldestAllowedAccessTime);
+		}
+
+		try {
+			Files.walkFileTree(imageCacheDirectory.toPath(), new FileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					checkCounter.incrementAndGet();
+
+					// get the last access time or last modified time, depending on which is later
+					// since some filesystems will not set the last access time
+					FileTime lastAccessTime = attrs.lastAccessTime();
+					FileTime lastModifiedTime = attrs.lastModifiedTime();
+					FileTime referenceTime = lastAccessTime.compareTo(lastModifiedTime) > 0 ? lastAccessTime
+							: lastModifiedTime;
+
+					if (referenceTime.toMillis() > 0) {
+						if (referenceTime.compareTo(oldestAllowedAccessTime) < 0) {
+							if (log.isTraceEnabled()) {
+								log.trace("{} was last accessed at {} and will be removed", file, referenceTime);
+							}
+							Files.delete(file);
+							cleanCounter.incrementAndGet();
+						}
+					}
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			log.error("Error while cleaning image cache {}", e, imageCacheDirectory.getAbsolutePath());
+		} finally {
+			long duration = System.currentTimeMillis() - start;
+
+			if (log.isDebugEnabled()) {
+				log.debug("Finished cleaning image cache {}. Duration; {} ms, checked {} files, cleaned {} files.",
+						imageCacheDirectory.getAbsolutePath(), duration, checkCounter.get(), cleanCounter.get());
+			}
+		}
+	}
+}

--- a/core/src/main/java/com/gentics/mesh/cli/MeshImpl.java
+++ b/core/src/main/java/com/gentics/mesh/cli/MeshImpl.java
@@ -411,6 +411,10 @@ public class MeshImpl implements Mesh {
 			log.error("Error while stopping Vert.x", t);
 		}
 
+		// image manipulator
+		log.info("Stopping image manipulator");
+		meshInternal.imageManipulator().shutdown();
+
 		// database
 		try {
 			log.info("Stopping and closing database provider");

--- a/mdm/common/src/main/java/com/gentics/mesh/core/image/ImageManipulator.java
+++ b/mdm/common/src/main/java/com/gentics/mesh/core/image/ImageManipulator.java
@@ -87,6 +87,11 @@ public interface ImageManipulator {
 	Single<Map<String, String>> getMetadata(InputStream ins);
 
 	/**
+	 * Shut down the image manipulator
+	 */
+	void shutdown();
+
+	/**
 	 * Apply the default manipulation to the image variant being created.
 	 * 
 	 * @param <T>

--- a/services/image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulator.java
+++ b/services/image-imgscalr/src/main/java/com/gentics/mesh/image/ImgscalrImageManipulator.java
@@ -64,6 +64,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.WorkerExecutor;
+import io.vertx.reactivex.core.file.FileSystem;
 
 /**
  * The ImgScalr Manipulator uses a pure java imageio image resizer.
@@ -340,6 +341,9 @@ public class ImgscalrImageManipulator extends AbstractImageManipulator {
 
 		return getCacheFilePath(binary, parameters).flatMap(cacheFileInfo -> {
 			if (cacheFileInfo.exists) {
+				if (options.isImageCacheTouch()) {
+					new File(cacheFileInfo.path).setLastModified(System.currentTimeMillis());
+				}
 				return Single.just(cacheFileInfo.path);
 			} else {
 				// TODO handle execution timeout

--- a/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ImageCacheTest.java
+++ b/tests/tests-service-image-imgscalr/src/main/java/com/gentics/mesh/image/ImageCacheTest.java
@@ -1,0 +1,141 @@
+package com.gentics.mesh.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.gentics.mesh.core.data.binary.HibBinary;
+import com.gentics.mesh.core.data.storage.BinaryStorage;
+import com.gentics.mesh.core.image.spi.ImageCacheCleaner;
+import com.gentics.mesh.etc.config.ImageManipulatorOptions;
+import com.gentics.mesh.parameter.impl.ImageManipulationParametersImpl;
+import com.gentics.mesh.util.FileUtils;
+import com.gentics.mesh.util.UUIDUtil;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.reactivex.core.Vertx;
+
+/**
+ * Test cases for the image cache
+ */
+public class ImageCacheTest extends AbstractImageTest {
+	private BinaryStorage mockedBinaryStorage;
+
+	private HibBinary mockedBinary;
+
+	private ImgscalrImageManipulator manipulator;
+
+	@Before
+	public void setup() {
+		super.setup();
+
+		ImageManipulatorOptions options = new ImageManipulatorOptions();
+		// when running the test on windows, we set the option to touch the cache file when accessing it
+		// the reason for this is that on windows, setting the last access time is typically disabled by default
+		options.setImageCacheTouch(SystemUtils.IS_OS_WINDOWS);
+
+		String binaryUUID = UUIDUtil.randomUUID();
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try (InputStream in = getClass().getResourceAsStream("/pictures/blume.jpg")) {
+			IOUtils.copy(in, out);
+		} catch (IOException e) {
+			fail("Generating hash failed", e);
+		}
+		String hash = FileUtils.hash(Buffer.buffer(out.toByteArray())).blockingGet();
+		mockedBinary = mock(HibBinary.class);
+		when(mockedBinary.getUuid()).thenReturn(binaryUUID);
+		when(mockedBinary.getSHA512Sum()).thenReturn(hash);
+
+		options.setImageCacheDirectory(cacheDir.getAbsolutePath());
+		mockedBinaryStorage = mock(BinaryStorage.class);
+		try {
+			when(mockedBinaryStorage.openBlockingStream(binaryUUID)).thenAnswer(new Answer<InputStream>() {
+				@Override
+				public InputStream answer(InvocationOnMock invocation) throws Throwable {
+					return getClass().getResourceAsStream("/pictures/blume.jpg");
+				}
+			});
+		} catch (IOException e) {
+			fail("Mocking binary storage failed", e);
+		}
+
+		manipulator = new ImgscalrImageManipulator(Vertx.vertx(), options, mockedBinaryStorage, null);
+	}
+
+	/**
+	 * Test that resizing an image creates a file in the cache and that the file is used when getting the same resized image again
+	 * @throws IOException
+	 */
+	@Test
+	public void testFileInCache() throws IOException {
+		// resize the image
+		String cachePath = manipulator.handleResize(mockedBinary, new ImageManipulationParametersImpl().setWidth(200)).blockingGet();
+		// we expect that this fetched the inputstream of the binary
+		verify(mockedBinaryStorage).openBlockingStream(Mockito.anyString());
+
+		// cache file must now exist
+		assertThat(cachePath).as("Cache path").isNotNull();
+		assertThat(new File(cachePath)).as("Cache file").exists();
+
+		// resize the image again (with same parameters)
+		String cachePathSecondCall = manipulator.handleResize(mockedBinary, new ImageManipulationParametersImpl().setWidth(200)).blockingGet();
+
+		// the returned path must be the same as before
+		assertThat(cachePathSecondCall).as("Cache path from second call").isEqualTo(cachePath);
+		// we expect that this did not fetch the inputstream again (because file was found in the cache)
+		verify(mockedBinaryStorage).openBlockingStream(Mockito.anyString());
+	}
+
+	/**
+	 * Test that the cleaner removes too old files
+	 * @throws IOException
+	 * @throws InterruptedException 
+	 */
+	@Test
+	public void testCleaner() throws IOException, InterruptedException {
+		// resize the image
+		String cachePath = manipulator.handleResize(mockedBinary, new ImageManipulationParametersImpl().setWidth(200)).blockingGet();
+		assertThat(new File(cachePath)).as("Cache file").exists();
+
+		// run the image cache cleaner with allowed idle time of 1 hour
+		new ImageCacheCleaner(cacheDir, Duration.of(1, ChronoUnit.HOURS).get(ChronoUnit.SECONDS)).run();
+		// cache file should still exist
+		assertThat(new File(cachePath)).as("Cache file").exists();
+
+		// wait 2 seconds
+		Thread.sleep(Duration.of(2, ChronoUnit.SECONDS).getSeconds() * 1000L);
+
+		// access the image again (should set the last access time)
+		manipulator.handleResize(mockedBinary, new ImageManipulationParametersImpl().setWidth(200)).blockingGet();
+
+		// run the image cache cleaner with allowed idle time of 1 second
+		new ImageCacheCleaner(cacheDir, 1).run();
+		// cache file should still exist
+		assertThat(new File(cachePath)).as("Cache file").exists();
+
+		// wait 2 seconds
+		Thread.sleep(Duration.of(2, ChronoUnit.SECONDS).getSeconds() * 1000L);
+
+		// run the image cache cleaner with allowed idle time of 1 second
+		new ImageCacheCleaner(cacheDir, 1).run();
+		// cache file should be removed now
+		assertThat(new File(cachePath)).as("Cache file").doesNotExist();
+	}
+}


### PR DESCRIPTION
## Abstract

Before this fix, files in the binary image cache were never removed by Mesh, so the disk usage could grow indefinitely.
This fix adds a configurable periodic job that removes files from the binary image cache folder, if they were not accessed/modified within a given timespan.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
