### PR TITLE
SUP-18069: Unit test filtering string field against UUID value

### DIFF
--- a/tests/tests-core/src/main/resources/graphql/filtering/nodes-string-field-native
+++ b/tests/tests-core/src/main/resources/graphql/filtering/nodes-string-field-native
@@ -193,6 +193,19 @@
 			...output
 		}
 	}
+	nameIsNotUUID: nodes(filter: {
+		schema: {is: folder}
+		fields: {
+			folder: {
+				name: {notEquals: "b660375495454667b34e385ab6fa7e4c"}
+			}
+		}
+	}) {
+		# [$.data.nameIsNotUUID.elements.length()=9]
+		elements {
+			...output
+		}
+	}
 }
 # [$.errors=<is-undefined>]
 


### PR DESCRIPTION
## Abstract

Add a UT for a case when a GraphQL filter value can be parsed as UUID.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
