### PR TITLE
Fix the docu build

### DIFF
--- a/changelog/src/changelog/entries/2025/03/8182.SUP-18177.enhancement
+++ b/changelog/src/changelog/entries/2025/03/8182.SUP-18177.enhancement
@@ -1,0 +1,1 @@
+Documentation: References to the MariaDB official documentation have been added.

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminEndpoint.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/AdminEndpoint.java
@@ -305,7 +305,7 @@ public abstract class AdminEndpoint extends AbstractInternalEndpoint {
 		route.path("/debuginfo");
 		route.method(GET);
 		route.description("Downloads a zip file of various [debug information](/docs/administration-guide/#debuginfo) files.");
-		route.addQueryParameter("include", "Information to include. See the [documentation](/docs/administration-guide/#debuginfo) for possible values.", "-backup,consistencyCheck");
+		route.addQueryParameter("include", "Information to include. See the [documentation](/docs/administration-guide/#debuginfo) for possible usages.", "-log,consistencyCheck");
 		route.handler(rc -> debugInfoHandler.handle(rc));
 	}
 

--- a/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/DebugInfoHandler.java
+++ b/core/src/main/java/com/gentics/mesh/core/endpoint/admin/debuginfo/DebugInfoHandler.java
@@ -34,7 +34,7 @@ public class DebugInfoHandler {
 	private final Database db;
 	private static final Logger log = LoggerFactory.getLogger(DebugInfoHandler.class);
 	private final Set<String> defaultExcluded = Stream.of(
-		"consistencyCheck").collect(Collectors.toSet());
+		"consistencyCheck","backup").collect(Collectors.toSet());
 
 	@Inject
 	public DebugInfoHandler(Set<DebugInfoProvider> debugInfoProviders, Database db) {

--- a/doc/src/main/hugo/content/docs/administration-guide.asciidoc
+++ b/doc/src/main/hugo/content/docs/administration-guide.asciidoc
@@ -116,6 +116,8 @@ storageOptions:
   synchronizeWritesTimeout: 6000
 ----
 
+Please refer to the https://mariadb.org/documentation/[official MariaDB documentation] for the database-specific topics.
+
 === Volumes / Locations
 
 [options="header"]
@@ -381,7 +383,7 @@ NOTE: The admin access can be restored via the use of the `resetAdminPassword` l
 There are currently fours components which can be included in a backup:
 
 * *Database* - The database contains the main content of Gentics Mesh.
-    The backup process of a database depends on an actual RDBMS (MariaDB, HSQLDB etc...) used, and is not a part of Gentics Mesh.
+    The backup process of a database depends on an actual RDBMS (MariaDB, HSQLDB etc...) used, and is _not_ a part of Gentics Mesh. In the case of MariaDB, please refer to the https://mariadb.com/kb/en/backup-and-restore-overview/[official backup/restore documentation]. For all the other cases, a link:../premium-features/premium-db[premium DB documentation] is a good place to start looking.
 
 * *Binary files* - Binaries are currently stored in the filesystem and need to be backed up separately data/binaryFiles)
 

--- a/doc/src/main/hugo/content/docs/administration-guide.asciidoc
+++ b/doc/src/main/hugo/content/docs/administration-guide.asciidoc
@@ -383,7 +383,7 @@ NOTE: The admin access can be restored via the use of the `resetAdminPassword` l
 There are currently fours components which can be included in a backup:
 
 * *Database* - The database contains the main content of Gentics Mesh.
-    The backup process of a database depends on an actual RDBMS (MariaDB, HSQLDB etc...) used, and is _not_ a part of Gentics Mesh. In the case of MariaDB, please refer to the https://mariadb.com/kb/en/backup-and-restore-overview/[official backup/restore documentation]. For all the other cases, a link:../premium-features/premium-db[premium DB documentation] is a good place to start looking.
+    The backup process of a database depends on an actual RDBMS (MariaDB, HSQLDB etc...) used, and is _not_ a part of Gentics Mesh. In the case of MariaDB, please refer to the https://mariadb.com/kb/en/backup-and-restore-overview/[official backup/restore documentation]. For all the other cases, a link:../../premium-features/premium-db[premium DB documentation] is a good place to start looking.
 
 * *Binary files* - Binaries are currently stored in the filesystem and need to be backed up separately data/binaryFiles)
 
@@ -396,12 +396,12 @@ There are currently fours components which can be included in a backup:
 [[debuginfo]]
 == Debug Information
 
-The debug info endpoint (GET {apiLatest}/admin/debuginfo) starts a zip download containing various useful data about the system.
+The debug info endpoint `GET {apiLatest}/admin/debuginfo` starts a zip download containing various useful data about the system.
 
 The documentation below lists all files that are included in the zip.
 
 Per default everything except the consistency check is included in the zip. You can use the `?include` query parameter to include or exclude specific parts.
-For example `{apiLatest}/admin/debuginfo?include=-backup,consistencyCheck` will exclude the database backup and include the consistency checks.
+For example `{apiLatest}/admin/debuginfo?include=-log,consistencyCheck` will exclude application logs and include the consistency checks.
 
 === Active Config
 Query name: `activeConfig`

--- a/doc/src/main/hugo/content/docs/contributing.asciidoc
+++ b/doc/src/main/hugo/content/docs/contributing.asciidoc
@@ -83,6 +83,8 @@ The main components which are used to build Gentics Mesh are:
 | https://google.github.io/dagger/[Dagger 2]    | Dependency injection library
 | https://github.com/ReactiveX/RxJava[RxJava2]  | Library which is used to composing asynchronous requests/processes.
 | https://docs.jboss.org/hibernate/orm/6.5/introduction/html_single/Hibernate_Introduction.html[Hibernate]               | Object relations mapping.
+|======
+
 == Big Picture
 
 Since you are most likely already familiar with the Gentics Mesh link:/docs/api[REST API] I assume it is best to start there.


### PR DESCRIPTION
## Abstract

Fix reusing the docs from Mesh OSS in the EE builds. Add a docu for the backup/restore.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
