### PR TITLE
Hotfix 2.1.x sup 18280

### DIFF
--- a/changelog/src/changelog/entries/2025/03/8207.SUP-18280.bugfix
+++ b/changelog/src/changelog/entries/2025/03/8207.SUP-18280.bugfix
@@ -1,0 +1,1 @@
+Core: When an empty payload is sent to the binary field update function, a new version of a content, being updated, is produced, containing no changes. This has been now fixed, and the content stays old in this case. 

--- a/mdm/api/src/main/java/com/gentics/mesh/core/data/node/field/HibBinaryField.java
+++ b/mdm/api/src/main/java/com/gentics/mesh/core/data/node/field/HibBinaryField.java
@@ -154,22 +154,12 @@ public interface HibBinaryField extends HibImageDataField, HibBasicField<BinaryF
 				matchingMetadata = Objects.equals(graphMetadata, restMetadata);
 			}
 
-			boolean matchingCheckStatus = true;
-
-			if (binaryField.getCheckStatus() != null) {
-				BinaryCheckStatus statusA = getBinary() != null ? getBinary().getCheckStatus() : null;
-				BinaryCheckStatus statusB = binaryField.getCheckStatus();
-
-				matchingCheckStatus = Objects.equals(statusA, statusB);
-			}
-
 			return matchingFilename
 				&& matchingMimetype
 				&& matchingFocalPoint
 				&& matchingDominantColor
 				&& matchingSha512sum
-				&& matchingMetadata
-				&& matchingCheckStatus;
+				&& matchingMetadata;
 		}
 
 		return false;

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/impl/BinaryFieldImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/impl/BinaryFieldImpl.java
@@ -66,7 +66,7 @@ public class BinaryFieldImpl implements BinaryField {
 
 	@JsonProperty(required = true)
 	@JsonPropertyDescription("Status of the external binary check (one of ACCEPTED, DENIED or POSTPONED). The binary field is only accessible when the status is ACCEPTED.")
-	private BinaryCheckStatus checkStatus = BinaryCheckStatus.ACCEPTED;
+	private BinaryCheckStatus checkStatus = BinaryCheckStatus.POSTPONED;
 
 	@JsonIgnore
 	private String checkSecret;

--- a/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/impl/BinaryFieldImpl.java
+++ b/rest-model/src/main/java/com/gentics/mesh/core/rest/node/field/impl/BinaryFieldImpl.java
@@ -66,7 +66,7 @@ public class BinaryFieldImpl implements BinaryField {
 
 	@JsonProperty(required = true)
 	@JsonPropertyDescription("Status of the external binary check (one of ACCEPTED, DENIED or POSTPONED). The binary field is only accessible when the status is ACCEPTED.")
-	private BinaryCheckStatus checkStatus = BinaryCheckStatus.POSTPONED;
+	private BinaryCheckStatus checkStatus = BinaryCheckStatus.ACCEPTED;
 
 	@JsonIgnore
 	private String checkSecret;

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldEndpointTest.java
@@ -565,6 +565,8 @@ public class BinaryFieldEndpointTest extends AbstractFieldEndpointTest {
 		call(() -> client().transformNodeBinaryField(PROJECT_NAME, updatedResponse.getUuid(), updatedResponse.getLanguage(), updatedResponse.getVersion(),
 			"binary", new ImageManipulationParametersImpl().setWidth(250)),
 			NOT_FOUND, "node_error_binary_data_not_found");
+
+		call(() -> client().deleteNode(PROJECT_NAME, createResponse.getUuid()));
 	}
 
 	@Test


### PR DESCRIPTION
## Abstract

Since the introduction of a virus checker, a new field on a binary payload prevents a changed data from being compared to the existing one, as the changed has postponed status by default, which is false for the cases where no virus check is set up. The check status is modified after the basic comparison. 

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
