### PR TITLE
SUP-18399: More HTTPOnly flag occurrences

### DIFF
--- a/changelog/src/changelog/entries/2025/04/8245.SUP-18399.bugfix
+++ b/changelog/src/changelog/entries/2025/04/8245.SUP-18399.bugfix
@@ -1,0 +1,1 @@
+Auth: More occurrences of setting the `mesh.token` cookies have been secured with `HTTPOnly` flag.

--- a/common/src/main/java/com/gentics/mesh/auth/provider/MeshJWTAuthProvider.java
+++ b/common/src/main/java/com/gentics/mesh/auth/provider/MeshJWTAuthProvider.java
@@ -320,6 +320,7 @@ public class MeshJWTAuthProvider implements AuthenticationProvider, JWTAuth {
 				User authenticatedUser = result.getUser();
 				String token = generateToken(authenticatedUser);
 				ac.addCookie(Cookie.cookie(SharedKeys.TOKEN_COOKIE_KEY, token)
+						.setHttpOnly(true)
 						.setMaxAge(meshOptions.getAuthenticationOptions().getTokenExpirationTime()).setPath("/"));
 					ac.send(new TokenResponse(token).toJson());
 			} else {

--- a/core/src/main/java/com/gentics/mesh/auth/MeshBasicAuthLoginHandler.java
+++ b/core/src/main/java/com/gentics/mesh/auth/MeshBasicAuthLoginHandler.java
@@ -107,6 +107,7 @@ public class MeshBasicAuthLoginHandler extends AuthenticationHandlerImpl<MeshJWT
 								InternalActionContext ac = new InternalRoutingActionContextImpl(context);
 								String jwtToken = authProvider.generateToken(authenticatedUser);
 								ac.addCookie(Cookie.cookie(SharedKeys.TOKEN_COOKIE_KEY, jwtToken)
+										.setHttpOnly(true)
 										.setMaxAge(meshOptions.getAuthenticationOptions().getTokenExpirationTime()).setPath("/"));
 								ac.send(new TokenResponse(jwtToken).toJson());
 							} else {


### PR DESCRIPTION
## Abstract

Missing occurrences of `HTTPOnly` flag on a token.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
