### PR TITLE
Fix floating point comparisons

### DIFF
--- a/changelog/src/changelog/entries/2025/04/8250.SUP-18468.bugfix
+++ b/changelog/src/changelog/entries/2025/04/8250.SUP-18468.bugfix
@@ -1,0 +1,2 @@
+Image Manipulation: Creating image variants with a focal point or focal zoom value failed with an internal server error when using MariaDB.
+This has been fixed.

--- a/mdm/hibernate-core/src/main/java/com/gentics/mesh/hibernate/data/domain/HibImageVariantImpl.java
+++ b/mdm/hibernate-core/src/main/java/com/gentics/mesh/hibernate/data/domain/HibImageVariantImpl.java
@@ -148,9 +148,9 @@ import com.gentics.mesh.parameter.image.ResizeMode;
 )
 public class HibImageVariantImpl extends AbstractImageDataImpl implements HibImageVariantSetter, Serializable {
 
-	static final String COMMON_FETCH_FILTER = " ((:fpx is null and v.fpx is null) or v.fpx = :fpx) and "
-			+ " ((:fpy is null and v.fpy is null) or v.fpy = :fpy) and "
-			+ " ((:fpz is null and v.fpz is null) or v.fpz = :fpz) and "
+	static final String COMMON_FETCH_FILTER = " ((:fpx is null and v.fpx is null) or abs(v.fpx - :fpx) < 0.0000001) and "
+			+ " ((:fpy is null and v.fpy is null) or abs(v.fpy - :fpy) < 0.0000001) and "
+			+ " ((:fpz is null and v.fpz is null) or abs(v.fpz - :fpz) < 0.0000001) and "
 			+ " ((:cropX is null and v.cropX is null) or v.cropX = :cropX) and "
 			+ " ((:cropY is null and v.cropY is null) or v.cropY = :cropY) and "
 			+ " ((:cropWidth is null and v.cropWidth is null) or v.cropWidth = :cropWidth) and "

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldVariantsTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/binary/BinaryFieldVariantsTest.java
@@ -76,7 +76,7 @@ public class BinaryFieldVariantsTest extends AbstractMeshTest implements MeshOpt
 				defaultAutoVariant1 = new ImageVariantResponse();
 				defaultAutoVariant1.setHeight(null).setWidth(8).setAuto(true);
 				defaultAutoVariant2 = new ImageVariantResponse();
-				defaultAutoVariant2.setHeight(24).setWidth(null).setAuto(true);
+				defaultAutoVariant2.setHeight(24).setWidth(null).setAuto(true).setFocalZoom(Float.valueOf(1.4f));
 			}
 		} else {
 			call(() -> client().clearNodeBinaryFieldImageVariants(PROJECT_NAME, nodeUuid, "binary"));
@@ -164,7 +164,7 @@ public class BinaryFieldVariantsTest extends AbstractMeshTest implements MeshOpt
 		BufferedImage image1 = ImageIO.read(binary1response.getStream());
 		assertThat(image1.getWidth()).isEqualTo(8);
 
-		MeshBinaryResponse binary2response = call(() -> client().downloadBinaryField(PROJECT_NAME, nodeUuid, "en", "binary", new ImageManipulationParametersImpl().setHeight(24)));
+		MeshBinaryResponse binary2response = call(() -> client().downloadBinaryField(PROJECT_NAME, nodeUuid, "en", "binary", new ImageManipulationParametersImpl().setHeight(24).setFocalPointZoom(Float.valueOf(1.4f))));
 		BufferedImage image2 = ImageIO.read(binary2response.getStream());
 		assertThat(image2.getHeight()).isEqualTo(24);
 
@@ -183,7 +183,7 @@ public class BinaryFieldVariantsTest extends AbstractMeshTest implements MeshOpt
 		BufferedImage image1 = ImageIO.read(binary1response.getBinaryResponse().getStream());
 		assertThat(image1.getWidth()).isEqualTo(8);
 
-		MeshWebrootFieldResponse binary2response = call(() -> client().webrootField(PROJECT_NAME, "binary", nodePath.getPath(), new ImageManipulationParametersImpl().setHeight(24)));
+		MeshWebrootFieldResponse binary2response = call(() -> client().webrootField(PROJECT_NAME, "binary", nodePath.getPath(), new ImageManipulationParametersImpl().setHeight(24).setFocalPointZoom(Float.valueOf(1.4f))));
 		BufferedImage image2 = ImageIO.read(binary2response.getBinaryResponse().getStream());
 		assertThat(image2.getHeight()).isEqualTo(24);
 
@@ -202,7 +202,7 @@ public class BinaryFieldVariantsTest extends AbstractMeshTest implements MeshOpt
 		BufferedImage image1 = ImageIO.read(binary1response.getBinaryResponse().getStream());
 		assertThat(image1.getWidth()).isEqualTo(8);
 
-		MeshWebrootResponse binary2response = call(() -> client().webroot(PROJECT_NAME, nodePath.getPath(), new ImageManipulationParametersImpl().setHeight(24)));
+		MeshWebrootResponse binary2response = call(() -> client().webroot(PROJECT_NAME, nodePath.getPath(), new ImageManipulationParametersImpl().setHeight(24).setFocalPointZoom(Float.valueOf(1.4f))));
 		BufferedImage image2 = ImageIO.read(binary2response.getBinaryResponse().getStream());
 		assertThat(image2.getHeight()).isEqualTo(24);
 


### PR DESCRIPTION
## Abstract

Comparison of floating point values for equality in MariaDB does not yield the expected results, so the comparison has been modified to abs(field - value) < 0.0000001

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
