### PR TITLE
SUP-18746: Fix the parsing of both ISO-8601 variants

### DIFF
--- a/changelog/src/changelog/entries/2025/07/8331.SUP-18746.bugfix
+++ b/changelog/src/changelog/entries/2025/07/8331.SUP-18746.bugfix
@@ -1,0 +1,1 @@
+REST API: Now Mesh accepts both ISO-8601 standards of a date/time string representation, with and without trailing Z or timezone value.

--- a/mdm/hibernate-core/src/main/java/com/gentics/mesh/contentoperation/DynamicContentColumn.java
+++ b/mdm/hibernate-core/src/main/java/com/gentics/mesh/contentoperation/DynamicContentColumn.java
@@ -11,6 +11,7 @@ import com.gentics.mesh.core.rest.common.FieldTypes;
 import com.gentics.mesh.core.rest.schema.FieldSchema;
 import com.gentics.mesh.core.rest.schema.ListFieldSchema;
 import com.gentics.mesh.hibernate.data.node.field.impl.HibNumberFieldImpl;
+import com.gentics.mesh.util.DateUtils;
 
 /**
  * A dynamic content column, that is, a column that is not common to all the content table, but is rather
@@ -86,7 +87,7 @@ public class DynamicContentColumn implements ContentColumn, Serializable {
 			return HibNumberFieldImpl.convertToDouble((Number)value);
 		} else if (fieldType == FieldTypes.DATE) {
 			if (value instanceof String) {
-				return Instant.parse(value.toString());
+				return Instant.ofEpochMilli(DateUtils.fromISO8601(value.toString()));
 			} else if (value instanceof Long) {
 				return Instant.ofEpochMilli((long) value);
 			} else if (value instanceof Timestamp) {

--- a/rest-model/src/main/java/com/gentics/mesh/util/DateUtils.java
+++ b/rest-model/src/main/java/com/gentics/mesh/util/DateUtils.java
@@ -22,11 +22,11 @@ public final class DateUtils {
 
 	private static final Logger log = LoggerFactory.getLogger(DateUtils.class);
 
-	static ZoneOffset zoneOffset;
+	public static final ZoneOffset ZONE_OFFSET;
 
 	static {
 		OffsetDateTime odt = OffsetDateTime.now(ZoneId.systemDefault());
-		zoneOffset = odt.getOffset();
+		ZONE_OFFSET = odt.getOffset();
 	}
 
 	/**
@@ -92,7 +92,7 @@ public final class DateUtils {
 			}
 			try {
 				// We also support date strings which do not include an offset. We apply the system offset in those cases.
-				Long date = LocalDateTime.parse(dateString).toInstant(zoneOffset).toEpochMilli();
+				Long date = LocalDateTime.parse(dateString).toInstant(ZONE_OFFSET).toEpochMilli();
 				return date;
 			} catch (DateTimeParseException e2) {
 				if (log.isDebugEnabled()) {

--- a/tests/tests-core/src/main/java/com/gentics/mesh/core/field/date/DateFieldEndpointTest.java
+++ b/tests/tests-core/src/main/java/com/gentics/mesh/core/field/date/DateFieldEndpointTest.java
@@ -10,6 +10,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,6 +33,7 @@ import com.gentics.mesh.core.rest.node.field.impl.DateFieldImpl;
 import com.gentics.mesh.core.rest.schema.DateFieldSchema;
 import com.gentics.mesh.core.rest.schema.impl.DateFieldSchemaImpl;
 import com.gentics.mesh.test.MeshTestSetting;
+import com.gentics.mesh.util.DateUtils;
 
 @MeshTestSetting(testSize = FULL, startServer = true)
 public class DateFieldEndpointTest extends AbstractFieldEndpointTest {
@@ -139,9 +144,29 @@ public class DateFieldEndpointTest extends AbstractFieldEndpointTest {
 	}
 
 	@Test
-	public void testDateFormat() {
+	public void testDateFormatInvalidValue() {
 		String invalidDate = "2017-08-21T10:46:26+0200";
 		updateNodeFailure(FIELD_NAME, new DateFieldImpl().setDate(invalidDate), BAD_REQUEST, "error_date_format_invalid", invalidDate);
+	}
+
+	@Test
+	public void testDateFormatValidInstant() {
+		Instant now = Instant.now();
+		String nowInstant = DateTimeFormatter.ISO_INSTANT.format(now);
+		Long nowEpoch = fromISO8601(toISO8601(now.toEpochMilli()));
+		NodeResponse response = createNode(FIELD_NAME, new DateFieldImpl().setDate(nowInstant));
+		DateField field = response.getFields().getDateField(FIELD_NAME);
+		assertEquals(toISO8601(nowEpoch), field.getDate());
+	}
+
+	@Test
+	public void testDateFormatValidLocal() {
+		LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
+		String nowInstant = DateTimeFormatter.ISO_DATE_TIME.format(now);
+		Long nowEpoch = fromISO8601(toISO8601(now.toInstant(DateUtils.ZONE_OFFSET).toEpochMilli()));
+		NodeResponse response = createNode(FIELD_NAME, new DateFieldImpl().setDate(nowInstant));
+		DateField field = response.getFields().getDateField(FIELD_NAME);
+		assertEquals(toISO8601(nowEpoch), field.getDate());
 	}
 
 	/**


### PR DESCRIPTION
## Abstract

As we already have the date parser, use it.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
