### PR TITLE
SUP-19927: Fix of crash of too many parents in children requests via native SQL requests

### DIFF
--- a/changelog/src/changelog/entries/2026/05/8768.SUP-19927.bugfix
+++ b/changelog/src/changelog/entries/2026/05/8768.SUP-19927.bugfix
@@ -1,0 +1,1 @@
+Core: A crash on requesting node children recursively through GraphQL + native filtering has been fixed.

--- a/mdm/hibernate-core/src/main/java/com/gentics/mesh/hibernate/data/dao/NodeDaoImpl.java
+++ b/mdm/hibernate-core/src/main/java/com/gentics/mesh/hibernate/data/dao/NodeDaoImpl.java
@@ -434,9 +434,12 @@ public class NodeDaoImpl extends AbstractHibRootDao<HibNode, NodeResponse, HibNo
 	public Map<HibNode, List<NodeContent>> getChildren(Set<HibNode> nodes, InternalActionContext ac, String branchUuid, List<String> languageTags, ContainerType type, PagingParameters paging, Optional<FilterOperation<?>> maybeNativeFiltering) {
 		InternalPermission perm = type == PUBLISHED ? READ_PUBLISHED_PERM : READ_PERM;
 		Map<HibNode, List<HibNode>> nodeChildrenMap = Optional.of(maybeNativeFiltering.isPresent() || PersistingRootDao.shouldSort(paging)).filter(b -> b)
-				.map(unused -> findAllStream(Tx.get().getProject(ac), ac, perm, paging, 
-								Optional.ofNullable(type), maybeNativeFiltering, Optional.ofNullable(nodes), Optional.empty(), Optional.empty(), Optional.ofNullable(languageTags), Optional.of(UUIDUtil.toJavaUuid(branchUuid)), true, true)
-						.collect(Collectors.groupingBy(p -> p.getParentEdge().getNodeParent(), Collectors.mapping(p -> p.getNode(), Collectors.toList()))))
+				.map(unused -> {
+					int limit = maybeNativeFiltering.map(nf -> nf.toSql().split(" :").length).orElse(1) + paging.getSort().size() + languageTags.size();
+					return SplittingUtils.splitAndMergeInMap(nodes, inQueriesLimitForSplitting(limit), uuids -> findAllStream(Tx.get().getProject(ac), ac, perm, paging, 
+							Optional.ofNullable(type), maybeNativeFiltering, Optional.ofNullable(new HashSet<>(uuids)), Optional.empty(), Optional.empty(), Optional.ofNullable(languageTags), Optional.of(UUIDUtil.toJavaUuid(branchUuid)), true, true)
+					.collect(Collectors.groupingBy(p -> p.getParentEdge().getNodeParent(), Collectors.mapping(p -> p.getNode(), Collectors.toList()))));
+				})
 				.orElseGet(() -> {
 					Map<HibNode, List<HibNode>> children = getChildren(nodes, branchUuid);
 


### PR DESCRIPTION
## Abstract

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
