### PR TITLE
SUP-19881: Refactor the docugen to be more clear on available options

### DIFF
--- a/api/src/main/java/com/gentics/mesh/etc/config/CacheConfig.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/CacheConfig.java
@@ -18,8 +18,7 @@ public class CacheConfig implements Option {
 	private static final long DEFAULT_PATH_CACHE_SIZE = 20_000;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Set the maximum size of the path cache. A value of 0 will disable the cache. Default: "
-		+ DEFAULT_PATH_CACHE_SIZE)
+	@JsonPropertyDescription("Set the maximum size of the path cache. A value of 0 will disable the cache.")
 	@EnvironmentVariable(name = MESH_CACHE_PATH_SIZE_ENV, description = "Override the path cache size.")
 	private long pathCacheSize = DEFAULT_PATH_CACHE_SIZE;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ClusterOptions.java
@@ -47,7 +47,7 @@ public class ClusterOptions implements Option {
 	private String clusterName;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Port used by Vert.x for the eventbus server. Default: " + DEFAULT_VERTX_PORT)
+	@JsonPropertyDescription("Port used by Vert.x for the eventbus server.")
 	@EnvironmentVariable(name = MESH_CLUSTER_VERTX_PORT_ENV, description = "Override the vert.x eventbus server port.")
 	private Integer vertxPort = DEFAULT_VERTX_PORT;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/ContentConfig.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ContentConfig.java
@@ -20,15 +20,13 @@ public class ContentConfig implements Option {
 	public static final int DEFAULT_BATCH_SIZE = 5000;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Flag which controls the global setting for the auto purge mechanism. The setting can be overriden by the schema 'autoPurge' flag. Default: "
-		+ DEFAULT_AUTO_PURGE)
+	@JsonPropertyDescription("Flag which controls the global setting for the auto purge mechanism. The setting can be overriden by the schema 'autoPurge' flag.")
 	@EnvironmentVariable(name = MESH_CONTENT_AUTO_PURGE_ENV, description = "Override the content versioning flag")
 	private boolean autoPurge = DEFAULT_AUTO_PURGE;
 
 	@JsonProperty(defaultValue = DEFAULT_BATCH_SIZE + " items")
 	@JsonPropertyDescription("The size of a batch for operations over large amount of entities. Setting this to any number lower than 1 will disable batch chunking")
-	@EnvironmentVariable(name = MESH_CONTENT_BATCH_SIZE_ENV, description = "Override the batch page size. Default: "
-		+ DEFAULT_BATCH_SIZE)
+	@EnvironmentVariable(name = MESH_CONTENT_BATCH_SIZE_ENV, description = "Override the batch page size.")
 	private int batchSize = DEFAULT_BATCH_SIZE;
 
 	public ContentConfig() {

--- a/api/src/main/java/com/gentics/mesh/etc/config/DebugInfoOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/DebugInfoOptions.java
@@ -33,7 +33,7 @@ public class DebugInfoOptions implements Option {
 	private boolean logEnabled = true;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The pattern used for each log line. For the detailed pattern format description please refer to the link:https://logback.qos.ch/manual/layouts.html#conversionWord[Logback documentation]. Default value is: " + DEFAULT_LOG_PATTERN)
+	@JsonPropertyDescription("The pattern used for each log line. For the detailed pattern format description please refer to the link:https://logback.qos.ch/manual/layouts.html#conversionWord[Logback documentation].")
 	@EnvironmentVariable(name = "MESH_DEBUGINFO_LOG_PATTERN", description = "Override the log pattern")
 	private String logPattern = DEFAULT_LOG_PATTERN;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/DiskQuotaOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/DiskQuotaOptions.java
@@ -25,12 +25,12 @@ public class DiskQuotaOptions implements Option {
 	public final static String MESH_STORAGE_DISK_QUOTA_READ_ONLY_THRESHOLD_ENV = "MESH_STORAGE_DISK_QUOTA_READ_ONLY_THRESHOLD";
 
 	@JsonProperty(defaultValue = DEFAULT_CHECK_INTERVAL + " ms")
-	@JsonPropertyDescription("Check interval in ms. Setting this to 0 will disable the disk quota check. Default: " + DEFAULT_CHECK_INTERVAL)
+	@JsonPropertyDescription("Check interval in ms. Setting this to 0 will disable the disk quota check.")
 	@EnvironmentVariable(name = MESH_STORAGE_DISK_QUOTA_CHECK_INTERVAL_ENV, description = "Overwrite the disk quota check interval.")
 	private int checkInterval = DEFAULT_CHECK_INTERVAL;
 
 	@JsonProperty(defaultValue = DEFAULT_WARN_THRESHOLD)
-	@JsonPropertyDescription("Threshold for the disk quota warn level. This can be set either as percentage (e.g. 15%) or as absolute disk space (e.g. 10G). If less than the defined disk space is available, warnings will be logged. Default: " + DEFAULT_WARN_THRESHOLD)
+	@JsonPropertyDescription("Threshold for the disk quota warn level. This can be set either as percentage (e.g. 15%) or as absolute disk space (e.g. 10G). If less than the defined disk space is available, warnings will be logged.")
 	@EnvironmentVariable(name = MESH_STORAGE_DISK_QUOTA_WARN_THRESHOLD_ENV, description = "Overwrite the disk quota warn threshold.")
 	private String warnThreshold = DEFAULT_WARN_THRESHOLD;
 
@@ -38,7 +38,7 @@ public class DiskQuotaOptions implements Option {
 	private long warnThresholdAbsolute = -1;
 
 	@JsonProperty(defaultValue = DEFAULT_READ_ONLY_THRESHOLD)
-	@JsonPropertyDescription("Threshold for the disk quota ready only level. This can be set either as percentage (e.g. 10%) or as absolute disk space (e.g. 5G). If less than the defined disk space is available, Mesh will automatically be set to readonly. Default: " + DEFAULT_READ_ONLY_THRESHOLD)
+	@JsonPropertyDescription("Threshold for the disk quota ready only level. This can be set either as percentage (e.g. 10%) or as absolute disk space (e.g. 5G). If less than the defined disk space is available, Mesh will automatically be set to readonly.")
 	@EnvironmentVariable(name = MESH_STORAGE_DISK_QUOTA_READ_ONLY_THRESHOLD_ENV, description = "Overwrite the disk quota ready only threshold.")
 	private String readOnlyThreshold = DEFAULT_READ_ONLY_THRESHOLD;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/GraphQLOptions.java
@@ -22,18 +22,17 @@ public class GraphQLOptions implements Option {
 	public static final String MESH_GRAPHQL_SCHEMA_CACHE_SIZE_ENV = "MESH_GRAPHQL_SCHEMA_CACHE_SIZE";
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Threshold for logging slow graphql queries. Default: " + DEFAULT_SLOW_THRESHOLD + "ms")
+	@JsonPropertyDescription("Threshold for logging slow graphql queries, in milliseconds.")
 	@EnvironmentVariable(name = MESH_GRAPHQL_SLOW_THRESHOLD_ENV, description = "Override the configured slow graphQl query threshold.")
 	private Long slowThreshold = DEFAULT_SLOW_THRESHOLD;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Threshold for waiting for asynchronous graphql queries. Default: "
-			+ DEFAULT_ASYNC_WAIT_TIMEOUT + "ms")
+	@JsonPropertyDescription("Threshold for waiting for asynchronous graphql queries, in milliseconds.")
 	@EnvironmentVariable(name = MESH_GRAPHQL_ASYNC_WAIT_TIMEOUT_ENV, description = "Override the configured graphQl async wait timeout.")
 	private Long asyncWaitTimeout = DEFAULT_ASYNC_WAIT_TIMEOUT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Cache size for graphQl Schema instances. Setting this to 0 will disable the cache. Default: " + DEFAULT_SCHEMA_CACHE_SIZE)
+	@JsonPropertyDescription("Cache size for graphQl Schema instances. Setting this to 0 will disable the cache.")
 	@EnvironmentVariable(name = MESH_GRAPHQL_SCHEMA_CACHE_SIZE_ENV, description = "Override the configured graphQl schema cache size.")
 	private long schemaCacheSize = DEFAULT_SCHEMA_CACHE_SIZE;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/HttpServerConfig.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/HttpServerConfig.java
@@ -65,17 +65,17 @@ public class HttpServerConfig implements Option {
 	public static final int DEFAULT_VERTICLE_AMOUNT = 2 * Runtime.getRuntime().availableProcessors();
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the Gentics Mesh HTTP server port. Default is: " + DEFAULT_HTTP_PORT)
+	@JsonPropertyDescription("Configure the Gentics Mesh HTTP server port.")
 	@EnvironmentVariable(name = MESH_HTTP_PORT_ENV, description = "Override the configured server http port.")
 	private int port = DEFAULT_HTTP_PORT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the Gentics Mesh HTTPS server port. Default is: " + DEFAULT_HTTPS_PORT)
+	@JsonPropertyDescription("Configure the Gentics Mesh HTTPS server port.")
 	@EnvironmentVariable(name = MESH_HTTPS_PORT_ENV, description = "Override the configured server https port.")
 	private int sslPort = DEFAULT_HTTPS_PORT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the Gentics Mesh HTTP server host to bind to. Default is: " + DEFAULT_HTTP_HOST)
+	@JsonPropertyDescription("Configure the Gentics Mesh HTTP server host to bind to.")
 	@EnvironmentVariable(name = MESH_HTTP_HOST_ENV, description = "Override the configured http server host which is used to bind to.")
 	private String host = DEFAULT_HTTP_HOST;
 
@@ -100,12 +100,12 @@ public class HttpServerConfig implements Option {
 	private Boolean enableCors = false;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Flag which indicates whether http server should be enabled. Default: true")
+	@JsonPropertyDescription("Flag which indicates whether http server should be enabled.")
 	@EnvironmentVariable(name = MESH_HTTP_HTTP_ENABLE_ENV, description = "Override the configured http server flag.")
 	private boolean http = true;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Flag which indicates whether https server should be enabled. Default: false")
+	@JsonPropertyDescription("Flag which indicates whether https server should be enabled.")
 	@EnvironmentVariable(name = MESH_HTTP_SSL_ENABLE_ENV, description = "Override the configured https server flag.")
 	private boolean ssl = false;
 
@@ -115,12 +115,12 @@ public class HttpServerConfig implements Option {
 	private String certPath = DEFAULT_CERT_PATH;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Path to the SSL private key. Default: " + DEFAULT_KEY_PATH)
+	@JsonPropertyDescription("Path to the SSL private key.")
 	@EnvironmentVariable(name = MESH_HTTP_SSL_KEY_PATH_ENV, description = "Override the configured SSL enable flag.")
 	private String keyPath = DEFAULT_KEY_PATH;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the client certificate handling mode. Options: none, request, required. Default: none")
+	@JsonPropertyDescription("Configure the client certificate handling mode. Options: none, request, required.")
 	@EnvironmentVariable(name = MESH_HTTP_SSL_CLIENT_AUTH_MODE_ENV, description = "Override the configured client certificate handling mode.")
 	private ClientAuth clientAuthMode = DEFAULT_CLIENT_AUTH_MODE;
 
@@ -129,13 +129,13 @@ public class HttpServerConfig implements Option {
 	@EnvironmentVariable(name = MESH_HTTP_SSL_TRUSTED_CERTS_ENV, description = "Override the configured trusted SSL certificates.")
 	private List<String> trustedCertPaths = new ArrayList<>();
 
-	@JsonProperty(required = false)
-	@JsonPropertyDescription("Amount of rest API verticles to be deployed. Default is 2 * CPU Cores")
+	@JsonProperty(required = false, defaultValue = "2 * CPU Cores")
+	@JsonPropertyDescription("Amount of rest API verticles to be deployed.")
 	@EnvironmentVariable(name = "MESH_HTTP_VERTICLE_AMOUNT", description = "Override the http verticle amount.")
 	private int verticleAmount = DEFAULT_VERTICLE_AMOUNT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Minify JSON responses to save the payload space. Default is true")
+	@JsonPropertyDescription("Minify JSON responses to save the payload space.")
 	@EnvironmentVariable(name = MESH_HTTP_MINIFY_JSON_ENV, description = "Override the minify JSON flag.")
 	private boolean minifyJson = DEFAULT_MINIFY_JSON;
 
@@ -145,7 +145,7 @@ public class HttpServerConfig implements Option {
 	private int maxFormAttributeSize = DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Set the http server tokens flag which controls whether the server should expose version information via headers, REST endpoints and GraphQL. Default is true")
+	@JsonPropertyDescription("Set the http server tokens flag which controls whether the server should expose version information via headers, REST endpoints and GraphQL.")
 	@EnvironmentVariable(name = MESH_HTTP_SERVER_TOKENS_ENV, description = "Override the http server tokens flag.")
 	private boolean serverTokens = DEFAULT_SERVER_TOKENS;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/ImageManipulatorOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/ImageManipulatorOptions.java
@@ -38,50 +38,47 @@ public class ImageManipulatorOptions implements Option {
 	public static final ImageManipulationMode DEFAULT_IMAGE_MANIPULATION_MODE = ImageManipulationMode.ON_DEMAND;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the image manipulation mode. Default: ON_DEMAND.")
+	@JsonPropertyDescription("Configure the image manipulation mode.")
 	@EnvironmentVariable(name = MESH_IMAGE_MANIPULATION_MODE_ENV, description = "Override the image manipulation mode.")
 	private ImageManipulationMode mode = DEFAULT_IMAGE_MANIPULATION_MODE;	
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the path for image cache directory. Default: data/binaryImageCache")
+	@JsonPropertyDescription("Configure the path for image cache directory.")
 	@EnvironmentVariable(name = MESH_IMAGE_CACHE_DIRECTORY_ENV, description = "Override the path for image cache directory.")
 	private String imageCacheDirectory = DEFAULT_IMAGE_CACHE_DIRECTORY;
 
 	@JsonProperty(defaultValue = DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL)
-	@JsonPropertyDescription("Image cache clean interval in ISO 8601 duration format. Setting this to PT0S will disable the image cache cleanup. Default: " + DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL)
+	@JsonPropertyDescription("Image cache clean interval in ISO 8601 duration format. Setting this to PT0S will disable the image cache cleanup.")
 	@EnvironmentVariable(name = MESH_IMAGE_CACHE_CLEAN_INTERVAL_ENV, description = "Overwrite the image cache clean interval.")
 	private String imageCacheCleanInterval = DEFAULT_IMAGE_CACHE_CLEAN_INTERVAL;
 
 	@JsonProperty(defaultValue = DEFAULT_IMAGE_CACHE_MAX_IDLE)
-	@JsonPropertyDescription("Image cache maximum idle time in ISO 8601 duration format. Default: " + DEFAULT_IMAGE_CACHE_MAX_IDLE)
+	@JsonPropertyDescription("Image cache maximum idle time in ISO 8601 duration format.")
 	@EnvironmentVariable(name = MESH_IMAGE_CACHE_CLEAN_INTERVAL_ENV, description = "Overwrite the image cache max idle time.")
 	private String imageCacheMaxIdle = DEFAULT_IMAGE_CACHE_MAX_IDLE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Whether the Image cache files should be touched when accessed. Default: " + DEFAULT_IMAGE_CACHE_TOUCH)
+	@JsonPropertyDescription("Whether the Image cache files should be touched when accessed.")
 	@EnvironmentVariable(name = MESH_IMAGE_CACHE_TOUCH_ENV, description = "Overwrite the image cache touch behaviour.")
 	private boolean imageCacheTouch = DEFAULT_IMAGE_CACHE_TOUCH;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the maximum allowed image resize width. Resizing is a memory intensive operation and thus this limit can help avoid memory issues. Default: "
-		+ DEFAULT_MAX_WIDTH)
+	@JsonPropertyDescription("Configure the maximum allowed image resize width. Resizing is a memory intensive operation and thus this limit can help avoid memory issues.")
 	@EnvironmentVariable(name = MESH_IMAGE_MAX_WIDTH_ENV, description = "Override the max width for image resize operations.")
 	private Integer maxWidth = DEFAULT_MAX_WIDTH;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the maximum allowed image resize height. Resizing is a memory intensive operation and thus this limit can help avoid memory issues. Default: "
-		+ DEFAULT_MAX_HEIGHT)
+	@JsonPropertyDescription("Configure the maximum allowed image resize height. Resizing is a memory intensive operation and thus this limit can help avoid memory issues.")
 	@EnvironmentVariable(name = MESH_IMAGE_MAX_HEIGHT_ENV, description = "Override the max height for image resize operations.")
 	private Integer maxHeight = DEFAULT_MAX_HEIGHT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the quality of the output of JPEG images. Must be a value between inclusive 0 and inclusive 1. Default: "
-		+ DEFAULT_JPEG_QUALITY)
+	@JsonPropertyDescription("Configure the quality of the output of JPEG images. Must be a value between inclusive 0 and inclusive 1.")
 	@EnvironmentVariable(name = MESH_IMAGE_JPEG_QUALITY_ENV, description = "Override the JPEG quality for image resize operations.")
 	private Float jpegQuality = DEFAULT_JPEG_QUALITY;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the filter that is used when resizing images. Default: LANCZOS")
+	@JsonPropertyDescription("Configure the filter that is used when resizing images.")
 	@EnvironmentVariable(name = MESH_IMAGE_RESAMPLE_FILTER_ENV, description = "Override the sample filter for image resize operations.")
 	private ResampleFilter resampleFilter = DEFAULT_RESAMPLE_FILTER;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshOptions.java
@@ -122,8 +122,7 @@ public abstract class MeshOptions implements Option {
 	private String pluginDirectory = "plugins";
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Timeout in seconds which is used for the plugin startup,initialization,de-initialization and stop processes. Default: "
-		+ DEFAULT_PLUGIN_TIMEOUT + " seconds.")
+	@JsonPropertyDescription("Timeout in seconds which is used for the plugin startup,initialization,de-initialization and stop processes.")
 	@EnvironmentVariable(name = MESH_PLUGIN_TIMEOUT_ENV, description = "Override the configured plugin timeout.")
 	private int pluginTimeout = DEFAULT_PLUGIN_TIMEOUT;
 
@@ -148,7 +147,7 @@ public abstract class MeshOptions implements Option {
 	private int migrationMaxBatchSize = 50;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Interval in ms for the automatic migration job trigger. Setting this to a non-positive value will disable automatic job triggering. Default: " + DEFAULT_MIGRATION_TRIGGER_INTERVAL + " ms.")
+	@JsonPropertyDescription("Interval in ms for the automatic migration job trigger. Setting this to a non-positive value will disable automatic job triggering.")
 	@EnvironmentVariable(name = MESH_MIGRATION_TRIGGER_INTERVAL, description = "Override the migration trigger interval")
 	private long migrationTriggerInterval = DEFAULT_MIGRATION_TRIGGER_INTERVAL;
 
@@ -179,7 +178,7 @@ public abstract class MeshOptions implements Option {
 	private String initialAdminPassword = PasswordUtil.humanPassword();
 
 	@JsonIgnore
-	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET_ENV, description = "Control whether a forced password reset should be triggered when creating the initial admin user. Default: true")
+	@EnvironmentVariable(name = MESH_INITIAL_ADMIN_PASSWORD_FORCE_RESET_ENV, description = "Control whether a forced password reset should be triggered when creating the initial admin user.")
 	private boolean forceInitialAdminPasswordReset = true;
 
 	@JsonIgnore

--- a/api/src/main/java/com/gentics/mesh/etc/config/MeshUploadOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MeshUploadOptions.java
@@ -31,8 +31,8 @@ public class MeshUploadOptions implements Option {
 	public static final String MESH_BINARY_METADATA_WHITELIST_ENV = "MESH_BINARY_METADATA_WHITELIST";
 	public static final String MESH_BINARY_CHECK_INTERVAL = "MESH_BINARY_CHECK_INTERVAL";
 
-	@JsonProperty(required = false)
-	@JsonPropertyDescription("The upload size limit in bytes. Default: " + DEFAULT_FILEUPLOAD_BYTE_LIMIT + " (" + DEFAULT_FILEUPLOAD_MB_LIMIT + " MB)")
+	@JsonProperty(required = false, defaultValue = DEFAULT_FILEUPLOAD_BYTE_LIMIT + " (" + DEFAULT_FILEUPLOAD_MB_LIMIT + " MB)")
+	@JsonPropertyDescription("The upload size limit in bytes.")
 	@EnvironmentVariable(name = MESH_BINARY_UPLOAD_LIMIT_ENV, description = "Override the configured binary byte upload limit.")
 
 	private long byteLimit = DEFAULT_FILEUPLOAD_BYTE_LIMIT;
@@ -48,13 +48,12 @@ public class MeshUploadOptions implements Option {
 	private String tempDirectory = DEFAULT_TEMP_DIR;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The parser limit for uploaded documents (pdf, doc, docx). Default: " + DEFAULT_DOCUMENT_PARSER_LIMIT)
+	@JsonPropertyDescription("The parser limit for uploaded documents (pdf, doc, docx).")
 	@EnvironmentVariable(name = MESH_BINARY_DOCUMENT_PARSER_LIMIT_ENV, description = "Override the configured parser limit.")
 	private int parserLimit = DEFAULT_DOCUMENT_PARSER_LIMIT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("If true, the document parser will process uploads and extract metadata and contents. Default: "
-		+ DEFAULT_UPLOAD_PARSER_FLAG)
+	@JsonPropertyDescription("If true, the document parser will process uploads and extract metadata and contents.")
 	@EnvironmentVariable(name = MESH_BINARY_DOCUMENT_PARSER_ENV, description = "Override the document parser enabled flag.")
 	private boolean parser = DEFAULT_UPLOAD_PARSER_FLAG;
 
@@ -64,7 +63,7 @@ public class MeshUploadOptions implements Option {
 	private Set<String> metadataWhitelist;
 
 	@JsonProperty
-	@JsonPropertyDescription("Interval in milliseconds for performing binary check requests for binary fields where a check service URL is defined. For values less than one the check is disabled. (default: 60000).")
+	@JsonPropertyDescription("Interval in milliseconds for performing binary check requests for binary fields where a check service URL is defined. For values less than one the check is disabled.")
 	@EnvironmentVariable(name = MESH_BINARY_CHECK_INTERVAL, description = "Override the binary check interval")
 	private long checkInterval = DEFAULT_CHECK_INTERVAL;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/MonitoringConfig.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/MonitoringConfig.java
@@ -32,32 +32,32 @@ public class MonitoringConfig implements Option {
 	public static final long DEFAULT_GC_TIME_LIMIT = 50;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Enable or disable the monitoring system. Default is: " + DEFAULT_MONITORING_ENABLED)
+	@JsonPropertyDescription("Enable or disable the monitoring system.")
 	@EnvironmentVariable(name = MESH_MONITORING_ENABLED_ENV, description = "Override the configured monitoring enabled flag.")
 	public boolean enabled = DEFAULT_MONITORING_ENABLED;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the Gentics Mesh monitoring HTTP server port. Default is: " + DEFAULT_MONITORING_HTTP_PORT)
+	@JsonPropertyDescription("Configure the Gentics Mesh monitoring HTTP server port.")
 	@EnvironmentVariable(name = MESH_MONITORING_HTTP_PORT_ENV, description = "Override the configured monitoring server http port.")
 	private int port = DEFAULT_MONITORING_HTTP_PORT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the Gentics Mesh monitoring HTTP server host to bind to. Default is: " + DEFAULT_MONITORING_HTTP_HOST)
+	@JsonPropertyDescription("Configure the Gentics Mesh monitoring HTTP server host to bind to.")
 	@EnvironmentVariable(name = MESH_MONITORING_HTTP_HOST_ENV, description = "Override the configured monitoring http server host which is used to bind to.")
 	private String host = DEFAULT_MONITORING_HTTP_HOST;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Enable or disable the measuring of JVM metrics. Default is: " + DEFAULT_JVM_METRICS_ENABLED)
+	@JsonPropertyDescription("Enable or disable the measuring of JVM metrics.")
 	@EnvironmentVariable(name = "MESH_MONITORING_JVM_METRICS_ENABLED", description = "Override the configured JVM metrics enabled flag.")
 	private boolean jvmMetricsEnabled = DEFAULT_JVM_METRICS_ENABLED;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Limit of used memory in percent, which will cause Mesh to become unhealthy. Defaults to " + DEFAULT_MEMORY_LIMIT + "%")
+	@JsonPropertyDescription("Limit of used memory in percent, which will cause Mesh to become unhealthy.")
 	@EnvironmentVariable(name = MESH_MONITORING_MEMORY_LIMIT_ENV, description = "Override the memory limit in percent.")
 	private long memoryLimit = DEFAULT_MEMORY_LIMIT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Limit time used for garbage collections percent, which will cause Mesh to become unhealthy. Defaults to " + DEFAULT_GC_TIME_LIMIT + "%")
+	@JsonPropertyDescription("Limit time used for garbage collections percent, which will cause Mesh to become unhealthy.")
 	@EnvironmentVariable(name = MESH_MONITORING_GC_LIMIT_ENV, description = "Override the garbage collection limit in percent.")
 	private long gcTimeLimit = DEFAULT_GC_TIME_LIMIT;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/VertxEventBusOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/VertxEventBusOptions.java
@@ -25,21 +25,19 @@ public class VertxEventBusOptions implements Option {
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Configure the check interval for the Vert.x eventBus in ms. If set to a positive value, "
-			+ "Mesh will regularly send test events over the eventBus. Default is: " + DEFAULT_CHECK_INTERVAL + " ms.")
+			+ "Mesh will regularly send test events over the eventBus.")
 	@EnvironmentVariable(name = MESH_VERTX_EVENT_BUS_CHECK_INTERVAL_ENV, description = "Override the Vert.x eventBus check interval in ms.")
 	private int checkInterval = DEFAULT_CHECK_INTERVAL;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Configure the warn threshold for the Vert.x eventBus check in ms. If this and the check interval are set to positive values, "
-			+ "and the last test events was received longer than the configured threshold ago, a warn message will be logged. Default is: "
-			+ DEFAULT_WARN_THRESHOLD + " ms.")
+			+ "and the last test events was received longer than the configured threshold ago, a warn message will be logged.")
 	@EnvironmentVariable(name = MESH_VERTX_EVENT_BUS_WARN_THRESHOLD_ENV, description = "Override the Vert.x eventBus warn threshold in ms.")
 	private int warnThreshold = DEFAULT_WARN_THRESHOLD;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Configure the error threshold for the Vert.x eventBus check in ms. If this and the check interval are set to positive values, "
-			+ "and the last test events was received longer than the configured threshold ago, an error message will be logged, and the liveness of the instance will be set to false. Default is: "
-			+ DEFAULT_ERROR_THRESHOLD)
+			+ "and the last test events was received longer than the configured threshold ago, an error message will be logged, and the liveness of the instance will be set to false.")
 	@EnvironmentVariable(name = MESH_VERTX_EVENT_BUS_ERROR_THRESHOLD_ENV, description = "Override the Vert.x eventBus error threshold in ms.")
 	private int errorThreshold = DEFAULT_ERROR_THRESHOLD;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/VertxOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/VertxOptions.java
@@ -27,17 +27,17 @@ public class VertxOptions implements Option {
 	public static final String MESH_VERTX_ORDERED_BLOCKING_HANDLERS_ENV = "MESH_VERTX_ORDERED_BLOCKING_HANDLERS";
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure worker pool size. Default is: " + DEFAULT_WORKER_POOL_SIZE)
+	@JsonPropertyDescription("Configure worker pool size.")
 	@EnvironmentVariable(name = MESH_VERTX_WORKER_POOL_SIZE_ENV, description = "Override the configured Vert.x worker pool size.")
 	private int workerPoolSize = DEFAULT_WORKER_POOL_SIZE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure event pool size. Default is 2 * CPU Cores")
+	@JsonPropertyDescription("Configure event pool size.")
 	@EnvironmentVariable(name = MESH_VERTX_EVENT_POOL_SIZE_ENV, description = "Override the configured Vert.x event pool size.")
 	private int eventPoolSize = DEFAULT_EVENT_POOL_SIZE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure, whether blocking handlers for mutating requests should be ordered. Default is " + DEFAULT_ORDERED_BLOCKING_HANDLERS)
+	@JsonPropertyDescription("Configure, whether blocking handlers for mutating requests should be ordered.")
 	@EnvironmentVariable(name = MESH_VERTX_ORDERED_BLOCKING_HANDLERS_ENV, description = "Override the configured Vert.x blocking handlers ordering setting.")
 	private boolean orderedBlockingHandlers = true;
 

--- a/api/src/main/java/com/gentics/mesh/etc/config/env/EnvironmentVariable.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/env/EnvironmentVariable.java
@@ -32,4 +32,10 @@ public @interface EnvironmentVariable {
 	 * @return
 	 */
 	boolean isSensitive() default false;
+
+	/**
+	 * Whether this variable should not document its YAML field
+	 * @return
+	 */
+	boolean isNoField() default false;
 }

--- a/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
@@ -67,7 +67,7 @@ public class ElasticSearchOptions implements Option {
 	public static final String MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL_ENV = "MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL";
 	public static final String MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT_ENV = "MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT";
 
-	@JsonProperty(required = false, defaultValue = "<pre>" + DEFAULT_URL + "</pre>")
+	@JsonProperty(required = false)
 	@JsonPropertyDescription("Elasticsearch connection url to be used. Set this setting to null will disable the Elasticsearch support.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_URL_ENV, description = "Override the configured elasticsearch server url. The value can be set to null in order to disable the Elasticsearch support.")
 	private String url = DEFAULT_URL;

--- a/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
+++ b/api/src/main/java/com/gentics/mesh/etc/config/search/ElasticSearchOptions.java
@@ -67,7 +67,7 @@ public class ElasticSearchOptions implements Option {
 	public static final String MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL_ENV = "MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL";
 	public static final String MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT_ENV = "MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT";
 
-	@JsonProperty(required = false)
+	@JsonProperty(required = false, defaultValue = "<pre>" + DEFAULT_URL + "</pre>")
 	@JsonPropertyDescription("Elasticsearch connection url to be used. Set this setting to null will disable the Elasticsearch support.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_URL_ENV, description = "Override the configured elasticsearch server url. The value can be set to null in order to disable the Elasticsearch support.")
 	private String url = DEFAULT_URL;
@@ -93,96 +93,87 @@ public class ElasticSearchOptions implements Option {
 	private String caPath;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Flag which controls whether hostname verification should be enabled. Default: " + DEFAULT_HOSTNAME_VERIFICATION)
+	@JsonPropertyDescription("Flag which controls whether hostname verification should be enabled.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_HOSTNAME_VERIFICATION_ENV, description = "Override the configured hostname verification flag.")
 	private boolean hostnameVerification = DEFAULT_HOSTNAME_VERIFICATION;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Timeout for Elasticsearch operations. Default: " + DEFAULT_TIMEOUT + "ms")
+	@JsonPropertyDescription("Timeout for Elasticsearch operations.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_TIMEOUT_ENV, description = "Override the configured elasticsearch server timeout.")
 	private Long timeout = DEFAULT_TIMEOUT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Search server prefix for this installation. Choosing different prefixes for each Gentics Mesh instance will allow you to use a single Elasticsearch cluster for multiple Gentics Mesh instances. Default: "
-		+ DEFAULT_PREFIX)
+	@JsonPropertyDescription("Search server prefix for this installation. Choosing different prefixes for each Gentics Mesh instance will allow you to use a single Elasticsearch cluster for multiple Gentics Mesh instances.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_PREFIX_ENV, description = "Override the configured elasticsearch prefix.")
 	private String prefix = DEFAULT_PREFIX;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Upper limit for the size of bulk requests. Default: " + DEFAULT_BULK_LIMIT)
-	@EnvironmentVariable(name = MESH_ELASTICSEARCH_BULK_LIMIT_ENV, description = "Override the batch bulk limit. Default: " + DEFAULT_BULK_LIMIT)
+	@JsonPropertyDescription("Upper limit for the size of bulk requests.")
+	@EnvironmentVariable(name = MESH_ELASTICSEARCH_BULK_LIMIT_ENV, description = "Override the batch bulk limit.")
 	private int bulkLimit = DEFAULT_BULK_LIMIT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Upper limit for the total encoded string length of the bulk requests. Default: " + DEFAULT_BULK_LENGTH_LIMIT)
-	@EnvironmentVariable(name = MESH_ELASTICSEARCH_BULK_LENGTH_LIMIT_ENV, description = "Override the batch bulk length limit. Default: "
-		+ DEFAULT_BULK_LENGTH_LIMIT)
+	@JsonPropertyDescription("Upper limit for the total encoded string length of the bulk requests.")
+	@EnvironmentVariable(name = MESH_ELASTICSEARCH_BULK_LENGTH_LIMIT_ENV, description = "Override the batch bulk length limit.")
 	private long bulkLengthLimit = DEFAULT_BULK_LENGTH_LIMIT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Upper limit for mesh events that are to be mapped to elastic search requests. Default: "
-		+ DEFAULT_EVENT_BUFFER_SIZE)
+	@JsonPropertyDescription("Upper limit for mesh events that are to be mapped to elastic search requests.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_EVENT_BUFFER_SIZE_ENV, description = "Override the configured event buffer size.")
 	private int eventBufferSize = DEFAULT_EVENT_BUFFER_SIZE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The maximum amount of time in milliseconds between two bulkable requests before they are sent. Default: "
-		+ DEFAULT_BULK_DEBOUNCE_TIME)
+	@JsonPropertyDescription("The maximum amount of time in milliseconds between two bulkable requests before they are sent.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_BULK_DEBOUNCE_TIME_ENV, description = "Override the bulk debounce time.")
 	private int bulkDebounceTime = DEFAULT_BULK_DEBOUNCE_TIME;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The maximum amount of time in milliseconds between two successful requests before the idle event is emitted. Default: "
-		+ DEFAULT_IDLE_DEBOUNCE_TIME)
+	@JsonPropertyDescription("The maximum amount of time in milliseconds between two successful requests before the idle event is emitted.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_IDLE_DEBOUNCE_TIME_ENV, description = "Override the idle debounce time.")
 	private int idleDebounceTime = DEFAULT_IDLE_DEBOUNCE_TIME;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The time in milliseconds between retries of elastic search requests in case of a failure. Default: "
-		+ DEFAULT_RETRY_INTERVAL)
+	@JsonPropertyDescription("The time in milliseconds between retries of elastic search requests in case of a failure.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_RETRY_INTERVAL_ENV, description = "Override the retry interval.")
 	private int retryInterval = DEFAULT_RETRY_INTERVAL;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("The amount of retries on a single request before the request is discarded. Default: "
-		+ DEFAULT_RETRY_LIMIT)
+	@JsonPropertyDescription("The amount of retries on a single request before the request is discarded.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_RETRY_LIMIT_ENV, description = "Override the retry limit.")
 	private int retryLimit = DEFAULT_RETRY_LIMIT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("If true, search endpoints wait for elasticsearch to be idle before sending a response. Default: "
-		+ DEFAULT_WAIT_FOR_IDLE)
+	@JsonPropertyDescription("If true, search endpoints wait for elasticsearch to be idle before sending a response.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_WAIT_FOR_IDLE_ENV, description = "Override the search idle wait flag.")
 	private boolean waitForIdle = DEFAULT_WAIT_FOR_IDLE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("If true, the content and metadata of binary fields will be included in the search index. Default: "
-		+ DEFAULT_INCLUDE_BINARY_FIELDS)
+	@JsonPropertyDescription("If true, the content and metadata of binary fields will be included in the search index.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_INCLUDE_BINARY_FIELDS_ENV, description = "Override the search include binary fields flag.")
 	private boolean includeBinaryFields = DEFAULT_INCLUDE_BINARY_FIELDS;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("This setting controls the mapping mode of fields for Elasticsearch. When set to STRICT only fields which have a custom mapping will be added to Elasticsearch. Mode DYNAMIC will automatically use the Gentics Mesh default mappings which can be supplemented with custom mappings. Default: DYNAMIC")
+	@JsonPropertyDescription("This setting controls the mapping mode of fields for Elasticsearch. When set to STRICT only fields which have a custom mapping will be added to Elasticsearch. Mode DYNAMIC will automatically use the Gentics Mesh default mappings which can be supplemented with custom mappings.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_MAPPING_MODE_ENV, description = "Override the search mapping mode. ")
 	private MappingMode mappingMode = DEFAULT_MAPPING_MODE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("This setting controls the compliance mode for Elasticsearch. Currently supported modes are ES_6, ES_7 and ES_8. Default: ES_6")
+	@JsonPropertyDescription("This setting controls the compliance mode for Elasticsearch. Currently supported modes are ES_6, ES_7 and ES_8.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_COMPLIANCE_MODE_ENV, description = "Override the search compliance mode.")
 	private ComplianceMode complianceMode = DEFAULT_COMPLIANCE_MODE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Configure the index sync batch size. Default: " + DEFAULT_SYNC_BATCH_SIZE)
+	@JsonPropertyDescription("Configure the index sync batch size.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_SYNC_BATCH_SIZE_ENV, description = "Override the search sync batch size")
 	private int syncBatchSize = DEFAULT_SYNC_BATCH_SIZE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Set the interval of index checks in ms. Default: " + DEFAULT_INDEX_CHECK_INTERVAL)
+	@JsonPropertyDescription("Set the interval of index checks in ms.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_INDEX_CHECK_INTERVAL_ENV, description = "Override the interval for index checks")
 	private long indexCheckInterval = DEFAULT_INDEX_CHECK_INTERVAL;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Set the timeout for the cache of index mappings in ms. Default: " + DEFAULT_INDEX_MAPPING_CACHE_TIMEOUT)
+	@JsonPropertyDescription("Set the timeout for the cache of index mappings in ms.")
 	@EnvironmentVariable(name = MESH_ELASTICSEARCH_INDEX_MAPPING_CACHE_TIMEOUT_ENV, description = "Override the timeout for the cache if index mappings")
 	private long indexMappingCacheTimeout = DEFAULT_INDEX_MAPPING_CACHE_TIMEOUT;
 

--- a/changelog/src/changelog/entries/2026/06/8809.SUP-19881.documentation
+++ b/changelog/src/changelog/entries/2026/06/8809.SUP-19881.documentation
@@ -1,0 +1,1 @@
+The documentation generator has been reworked to fix the options' default values, mandatory flags, and environment variables.

--- a/changelog/src/changelog/entries/2026/06/8809.SUP-19881.documentation
+++ b/changelog/src/changelog/entries/2026/06/8809.SUP-19881.documentation
@@ -1,1 +1,1 @@
-The documentation generator has been reworked to fix the options' default values, mandatory flags, and environment variables.
+The documentation generator has been reworked to fix the options' default values, mandatory flags, and environment variables. Some minor documentation fixes included as well.

--- a/doc/build/dockerBuild.sh
+++ b/doc/build/dockerBuild.sh
@@ -35,6 +35,7 @@ cp -Rf $ROOT/src/main/docs/generated/search $CONTENTROOT/content/docs/search
 cp -Rf $ROOT/src/main/docs/generated/models $CONTENTROOT/content/docs/examples/models
 cp -Rf $ROOT/src/main/docs/generated/tables $CONTENTROOT/content/docs/examples/tables
 cp -Rf $ROOT/../CHANGELOG.adoc $CONTENTROOT/content/docs/changelog.asciidoc
+cp -Rf $ROOT/../changelog-2.adoc-include $CONTENTROOT/content/docs/changelog-2.adoc-include  
 cp -Rf $ROOT/../LTS-CHANGELOG.adoc $CONTENTROOT/content/docs/lts-changelog.asciidoc
 
 docker run -v $CONTENTROOT:/site -v $HTMLROOT:/site/docs --user 1000:1000 --rm gentics/hugo-asciidoctor /site/scripts/build.sh

--- a/doc/src/main/hugo/content/docs/features.asciidoc
+++ b/doc/src/main/hugo/content/docs/features.asciidoc
@@ -1767,8 +1767,8 @@ NOTE: Reading published nodes requires the user to be assigned to a role which g
 === Listing versions
 
 Versions of a node can be listed via the ```{apiLatest}/:projectName/nodes/:uuid/versions``` endpoint.
-
-```
+[source, json]
+----
 "versions" : {
     "de" : [ {
       "creator" : {
@@ -1781,11 +1781,9 @@ Versions of a node can be listed via the ```{apiLatest}/:projectName/nodes/:uuid
       "draft" : true,
       "published" : true,
       "branchRoot" : false
-    }
-    …
-  } ]
+    } ]
 }
-```
+----
 
 A version can be used as a `draft` version. This version can also be referenced as a `published` version when published. The `branchRoot` flag indicates whether the version is being referenced as root version in a branch. All these three different kind of versions are not purgeable. Versions which have been made in between can be purged.
 

--- a/doc/src/main/hugo/content/docs/monitoring.asciidoc
+++ b/doc/src/main/hugo/content/docs/monitoring.asciidoc
@@ -41,7 +41,9 @@ When both `memoryLimit` and `gcTimeLimit` are set to positive integers (which is
 spent for garbage collections (in the last 10 seconds). If both amounts exceed the configured limits (in percent), the instance will be considered unhealthy and both the liveness probe
 and the readiness probe will fail. The instance will be unhealthy until used memory and the time spent for garbage collections drop below the configured limits.
 
-TIP: Setting at least one of the values of `memoryLimit` and `gcTimeLimit` to 0 will disable the monitoring of Java Heap Memory and Garbage Collections.
+One can also use `MESH_MONITORING_MEMORY_LIMIT` and `MESH_MONITORING_GC_LIMIT` environment variables, respectively.
+
+TIP: Setting at least one of the values of `memoryLimit` and `gcTimeLimit` to 0 will disable the monitoring of Java Heap Memory and Garbage Collections. 
 
 == Endpoints
 

--- a/doc/src/main/java/com/gentics/mesh/generator/DocGeneratorRunner.java
+++ b/doc/src/main/java/com/gentics/mesh/generator/DocGeneratorRunner.java
@@ -1,12 +1,6 @@
 package com.gentics.mesh.generator;
 
-import com.gentics.mesh.etc.config.env.EnvironmentVariable;
-import com.gentics.mesh.generator.TableGenerator;
-import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.Template;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.reflections.Reflections;
+import static org.reflections.scanners.Scanners.FieldsAnnotated;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,7 +13,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.reflections.scanners.Scanners.FieldsAnnotated;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.reflections.Reflections;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gentics.mesh.etc.config.env.EnvironmentVariable;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
 
 /**
  * Class responsible for invoking all documentation generators.
@@ -63,10 +65,20 @@ public class DocGeneratorRunner {
             for (Field field : reflections.get(FieldsAnnotated.of(EnvironmentVariable.class).as(Field.class))) {
                 EnvironmentVariable envInfo = field.getAnnotation(EnvironmentVariable.class);
                 String name = envInfo.name();
+                String fieldName = field.getName();
+                {
+                	JsonProperty jsonAnnotation = field.getAnnotation(JsonProperty.class);
+	                if (jsonAnnotation != null && StringUtils.isNotBlank(jsonAnnotation.value())) {
+	                	fieldName = jsonAnnotation.value();
+	                }
+                }
                 String description = envInfo.description();
                 Map<String, String> map = new HashMap<>();
                 map.put("name", name);
                 map.put("description", description);
+                if (!envInfo.isNoField()) {
+                	map.put("field", field.getDeclaringClass().getSimpleName() + "." + fieldName);
+                }
                 list.add(map);
             }
 

--- a/doc/src/main/java/com/gentics/mesh/generator/EnvHelpGenerator.java
+++ b/doc/src/main/java/com/gentics/mesh/generator/EnvHelpGenerator.java
@@ -3,14 +3,15 @@ package com.gentics.mesh.generator;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.reflections.Reflections;
-import org.reflections.scanners.FieldAnnotationsScanner;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gentics.mesh.doc.GenerateDocumentation;
 import com.gentics.mesh.etc.config.env.EnvironmentVariable;
 
 /**
@@ -45,23 +46,14 @@ public class EnvHelpGenerator extends AbstractRenderingGenerator {
 	public void run() throws IOException {
 		System.out.println("Writing files to  {" + outputFolder.getAbsolutePath() + "}");
 
-		List<Map<String, String>> list = new ArrayList<>();
-		boolean isEmpty = true;
-		Reflections reflections = new Reflections("com.gentics.mesh.etc.config", new FieldAnnotationsScanner());
-		for (Field field : reflections.getFieldsAnnotatedWith(EnvironmentVariable.class)) {
-			if (field.isAnnotationPresent(EnvironmentVariable.class)) {
-				EnvironmentVariable envInfo = field.getAnnotation(EnvironmentVariable.class);
-				String name = envInfo.name();
-				String description = envInfo.description();
-				Map<String, String> map = new HashMap<>();
-				map.put("name", name);
-				map.put("description", description);
-				list.add(map);
-				isEmpty = false;
-			}
+		Map<String, Map<String, String>> list = new HashMap<>();
+		boolean notEmpty = false;
+		Reflections reflections = new Reflections("com.gentics.mesh.etc.config");
+		for (Class<?> clazz : reflections.getTypesAnnotatedWith(GenerateDocumentation.class)) {
+			notEmpty |= processClass(clazz, list, Optional.empty());
 		}
 
-		if (isEmpty) {
+		if (!notEmpty) {
 			throw new RuntimeException("Generator was unable to find any annotated fields");
 		}
 
@@ -71,4 +63,38 @@ public class EnvHelpGenerator extends AbstractRenderingGenerator {
 		writeFile("mesh-env.adoc-include", table);
 	}
 
+	protected boolean processClass(Class<?> clazz, Map<String, Map<String, String>> list, Optional<String> maybePrefix) {
+		boolean notEmpty = false;
+		for (Field field: clazz.getDeclaredFields()) {
+			String fieldName = field.getName();
+            {
+            	JsonProperty jsonAnnotation = field.getAnnotation(JsonProperty.class);
+                if (jsonAnnotation != null && StringUtils.isNotBlank(jsonAnnotation.value())) {
+                	fieldName = jsonAnnotation.value();
+                }
+            }
+            if (field.isAnnotationPresent(EnvironmentVariable.class)) {
+				EnvironmentVariable envInfo = field.getAnnotation(EnvironmentVariable.class);
+				String name = envInfo.name();
+				String description = envInfo.description();
+				Map<String, String> map = list.getOrDefault(maybePrefix, new HashMap<>());
+				map.put("name", name);
+				map.put("description", description);
+				if (!envInfo.isNoField()) {
+					if (!map.getOrDefault("field", StringUtils.EMPTY).contains(".")) {
+						map.put("field", maybePrefix.map(p -> p + ".").orElse(StringUtils.EMPTY) + fieldName);
+					}
+				}
+                list.putIfAbsent(name, map);
+				notEmpty |= true;
+			} else if (field.getType().isAnnotationPresent(GenerateDocumentation.class)) {
+				notEmpty |= processClass(field.getType(), list, Optional.of(fieldName + maybePrefix.map(p -> p + ".").orElse(StringUtils.EMPTY)));
+			}
+		}
+		Class<?> superclass = clazz.getSuperclass();
+		if (superclass != null && superclass != Object.class) {
+			notEmpty |= processClass(superclass, list, maybePrefix);
+		}
+		return notEmpty;
+	}
 }

--- a/doc/src/main/java/com/gentics/mesh/generator/EnvHelpGenerator.java
+++ b/doc/src/main/java/com/gentics/mesh/generator/EnvHelpGenerator.java
@@ -3,9 +3,12 @@ package com.gentics.mesh.generator;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
 import org.reflections.Reflections;
@@ -46,13 +49,12 @@ public class EnvHelpGenerator extends AbstractRenderingGenerator {
 	public void run() throws IOException {
 		System.out.println("Writing files to  {" + outputFolder.getAbsolutePath() + "}");
 
-		Map<String, Map<String, String>> list = new HashMap<>();
+		Map<String, Map<String, String>> list = new TreeMap<>(new MeshFirstComparator());
 		boolean notEmpty = false;
 		Reflections reflections = new Reflections("com.gentics.mesh.etc.config");
 		for (Class<?> clazz : reflections.getTypesAnnotatedWith(GenerateDocumentation.class)) {
 			notEmpty |= processClass(clazz, list, Optional.empty());
 		}
-
 		if (!notEmpty) {
 			throw new RuntimeException("Generator was unable to find any annotated fields");
 		}
@@ -77,7 +79,7 @@ public class EnvHelpGenerator extends AbstractRenderingGenerator {
 				EnvironmentVariable envInfo = field.getAnnotation(EnvironmentVariable.class);
 				String name = envInfo.name();
 				String description = envInfo.description();
-				Map<String, String> map = list.getOrDefault(maybePrefix, new HashMap<>());
+				Map<String, String> map = list.getOrDefault(name, new HashMap<>());
 				map.put("name", name);
 				map.put("description", description);
 				if (!envInfo.isNoField()) {
@@ -96,5 +98,24 @@ public class EnvHelpGenerator extends AbstractRenderingGenerator {
 			notEmpty |= processClass(superclass, list, maybePrefix);
 		}
 		return notEmpty;
+	}
+
+	class MeshFirstComparator implements Comparator<String> {
+
+		@Override
+		public int compare(String o1, String o2) {
+			if (o1 != null && o2 != null) {
+				boolean o1IsMesh = o1.startsWith("MESH_");
+				boolean o2IsMesh = o2.startsWith("MESH_");
+				if (o1IsMesh && !o2IsMesh) {
+					return -1;
+				}
+				if (o2IsMesh && !o1IsMesh) {
+					return 1;
+				}
+				return o1.compareTo(o2);
+			}
+			return Comparator.comparing((String s) -> s).compare(o1, o2);
+		}		
 	}
 }

--- a/doc/src/main/java/com/gentics/mesh/generator/TableGenerator.java
+++ b/doc/src/main/java/com/gentics/mesh/generator/TableGenerator.java
@@ -268,10 +268,14 @@ public class TableGenerator extends AbstractRenderingGenerator {
 			} else {
 				try {
 					Field field = clazz.getDeclaredField(key);
-					field.setAccessible(true);
-					defaultValue = Objects.toString(field.get(clazz.newInstance()), null);
-					if (StringUtils.isNotBlank(defaultValue)) {
-						attr.put("default", defaultValue);
+					if (field.getType().isAnnotationPresent(GenerateDocumentation.class)) {
+						flattenSchema(field.getType(), list, key, new JsonObject(JsonUtil.getJsonSchema(field.getType())));
+					} else {
+						field.setAccessible(true);
+						defaultValue = Objects.toString(field.get(clazz.newInstance()), null);
+						if (StringUtils.isNotBlank(defaultValue)) {
+							attr.put("default", defaultValue);
+						}
 					}
 				} catch (Throwable e) {
 				}

--- a/doc/src/main/java/com/gentics/mesh/generator/TableGenerator.java
+++ b/doc/src/main/java/com/gentics/mesh/generator/TableGenerator.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -110,18 +111,21 @@ public class TableGenerator extends AbstractRenderingGenerator {
 			boolean isRequired = false;
 			Object defaultValue = null;
 			try {
+				field.setAccessible(true);
 				defaultValue = field.get(instance);
 			} catch (IllegalArgumentException e) {
-
 			}
 			for (Annotation annotation : field.getAnnotations()) {
-				if (annotation instanceof JsonProperty) {
-					JsonProperty propAnn = (JsonProperty) annotation;
+				if (annotation instanceof JsonProperty propAnn) {
 					String name = propAnn.value();
 					if (!StringUtils.isEmpty(name)) {
 						fieldName = name;
 					}
 					isRequired = propAnn.required();
+					String propDefault = propAnn.defaultValue();
+					if (StringUtils.isNotBlank(propDefault)) {
+						defaultValue = propDefault;
+					}
 				}
 				if (annotation instanceof JsonPropertyDescription) {
 					JsonPropertyDescription descAnn = (JsonPropertyDescription) annotation;
@@ -139,8 +143,8 @@ public class TableGenerator extends AbstractRenderingGenerator {
 				entries.put("key", fieldName);
 				entries.put("description", description);
 				entries.put("type", type.toLowerCase());
-				entries.put("defaultValue", String.valueOf(defaultValue));
-				entries.put("required", String.valueOf(isRequired));
+				entries.put("default", String.valueOf(defaultValue));
+				entries.put("required", Boolean.toString(isRequired));
 				rows.add(entries);
 			}
 		}
@@ -158,6 +162,11 @@ public class TableGenerator extends AbstractRenderingGenerator {
 	 * @param template
 	 * @return Rendered table
 	 * @throws IOException
+	 * @throws SecurityException 
+	 * @throws NoSuchFieldException 
+	 * @throws InstantiationException 
+	 * @throws IllegalAccessException 
+	 * @throws IllegalArgumentException 
 	 */
 	public String renderModelTableViaSchema(Class<?> clazz, String template) throws IOException {
 		String name = clazz.getSimpleName();
@@ -221,6 +230,11 @@ public class TableGenerator extends AbstractRenderingGenerator {
 	 *            Current key of the element being flattened
 	 * @param obj
 	 *            Current object being flattened
+	 * @throws SecurityException 
+	 * @throws NoSuchFieldException 
+	 * @throws InstantiationException 
+	 * @throws IllegalAccessException 
+	 * @throws IllegalArgumentException 
 	 */
 	private void flattenSchema(Class<?> clazz, List<Map<String, String>> list, String key, JsonObject obj) {
 		// Check whether the current object already describes a property
@@ -231,13 +245,36 @@ public class TableGenerator extends AbstractRenderingGenerator {
 			String type = obj.getString("type");
 			String description = obj.getString("description");
 			Boolean required = obj.getBoolean("required");
+			String defaultValue = obj.getString("defaultValue");
 			Map<String, String> attr = new HashMap<>();
 			attr.put("type", type);
 			attr.put("description", description);
 			attr.put("key", key);
-			String requiredStr = "false";
-			if (required != null) {
-				requiredStr = String.valueOf(required);
+			String requiredStr = "no";
+			if (required == null) {
+				// The JSON properties are either absent or not parsed
+				try {
+					Field field = clazz.getDeclaredField(key);
+					JsonProperty jsonProperty = field.getAnnotation(JsonProperty.class);
+					required = jsonProperty.required();
+					defaultValue = jsonProperty.defaultValue();
+				} catch (Throwable e) {
+					required = false;
+				}
+			}
+			requiredStr = required ? "yes" : "no";
+			if (StringUtils.isNotBlank(defaultValue)) {
+				attr.put("default", defaultValue);
+			} else {
+				try {
+					Field field = clazz.getDeclaredField(key);
+					field.setAccessible(true);
+					defaultValue = Objects.toString(field.get(clazz.newInstance()), null);
+					if (StringUtils.isNotBlank(defaultValue)) {
+						attr.put("default", defaultValue);
+					}
+				} catch (Throwable e) {
+				}
 			}
 			attr.put("required", requiredStr);
 			list.add(attr);

--- a/doc/src/main/resources/env-table.hbs
+++ b/doc/src/main/resources/env-table.hbs
@@ -1,11 +1,11 @@
 [options="header",cols="10%,70%"]
 |======
 
-| Variable
+| Variable (and its YAML field, if exists)
 | Description
 
 {{#each entries}}
-| *{{this.name}}*
+| *{{this.name}}*  {{#if this.field}}({{this.field}}){{/if}}
 | {{this.description}}
 {{/each}}
 |======

--- a/doc/src/main/resources/env-table.hbs
+++ b/doc/src/main/resources/env-table.hbs
@@ -1,11 +1,11 @@
 [options="header",cols="10%,70%"]
 |======
 
-| Variable (and its YAML field, if exists)
-| Description
+| Variable
+| Description _(and its YAML config field, if exists)_
 
 {{#each entries}}
-| *{{this.name}}*  {{#if this.field}}({{this.field}}){{/if}}
-| {{this.description}}
+| *{{this.name}}*
+| {{this.description}}  {{#if this.field}}_({{this.field}})_{{/if}}
 {{/each}}
 |======

--- a/doc/src/main/resources/model-props-table.hbs
+++ b/doc/src/main/resources/model-props-table.hbs
@@ -10,6 +10,6 @@
 | {{this.key}}
 | {{this.required}}
 | {{this.type}}
-| {{this.description}}{{#if this.default}} Default: *{{this.default}}*. {{/if}}
+| {{this.description}}{{#if this.default}}  Default: *{{this.default}}*.{{/if}}
 {{/each}}
 |======

--- a/doc/src/main/resources/model-props-table.hbs
+++ b/doc/src/main/resources/model-props-table.hbs
@@ -10,6 +10,6 @@
 | {{this.key}}
 | {{this.required}}
 | {{this.type}}
-| {{this.description}}
+| {{this.description}}{{#if this.default}} Default: *{{this.default}}*. {{/if}}
 {{/each}}
 |======

--- a/doc/src/main/resources/param-props-table.hbs
+++ b/doc/src/main/resources/param-props-table.hbs
@@ -8,8 +8,8 @@
 
 {{#each entries}}
 | {{this.name}}
-| {{this.type}} {{#if this.default}} (default: {{this.default}}) {{/if}}
+| {{this.type}}
 | {{this.required}}
-| {{this.description}}
+| {{this.description}}{{#if this.default}} Default: {{this.default}}. {{/if}}
 {{/each}}
 |======

--- a/mdm/hibernate-api/src/main/java/com/gentics/mesh/etc/config/hibernate/HibernateCacheConfig.java
+++ b/mdm/hibernate-api/src/main/java/com/gentics/mesh/etc/config/hibernate/HibernateCacheConfig.java
@@ -56,32 +56,28 @@ public class HibernateCacheConfig extends CacheConfig {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Set the maximum size of field container cache. A value of null will disable the cache. "
 			+ "A value ended with K/M/G will mean an absolute value in [kil|mega|giga]bytes correspondingly. "
-			+ "A value ended with % will mean a percent of maximum memory Mesh is allowed to use. "
-			+ "Default: " + DEFAULT_FIELD_CONTAINER_CACHE_SIZE)
+			+ "A value ended with % will mean a percent of maximum memory Mesh is allowed to use.")
 	@EnvironmentVariable(name = MESH_FIELD_CONTAINER_CACHE_SIZE, description = "Override the field container cache size.")
 	private String fieldContainerCacheSize = DEFAULT_FIELD_CONTAINER_CACHE_SIZE;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Set the maximum size of the list field cache. A value of null will disable the cache. "
 			+ "A value ended with K/M/G will mean an absolute value in [kil|mega|giga]bytes correspondingly. "
-			+ "A value ended with % will mean a percent of maximum memory Mesh is allowed to use. "
-			+ "Default: " + DEFAULT_MESH_LIST_FIELD_CACHE_SIZE)
+			+ "A value ended with % will mean a percent of maximum memory Mesh is allowed to use.")
 	@EnvironmentVariable(name = MESH_LIST_FIELD_CACHE_SIZE, description = "Override the  list field cache size.")
 	private String listFieldCacheSize = DEFAULT_MESH_LIST_FIELD_CACHE_SIZE;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Set the minimum required amount of free heap memory for the eviction policy of the hibernate cache when using clustering. "
 			+ "A value ended with K/M/G will mean an absolute value in [kil|mega|giga]bytes correspondingly. "
-			+ "A value ended with % will mean a percent of mininum free memory. "
-			+ "Default: " + DEFAULT_MESH_CLUSTERED_HIBERNATE_CACHE_HEAP_FREE)
+			+ "A value ended with % will mean a percent of mininum free memory.")
 	@EnvironmentVariable(name = MESH_CLUSTERED_HIBERNATE_CACHE_HEAP_FREE, description = "Override the minimum required free heap memory for the eviction policy of the hibernate cache when using clustering.")
 	private String clusteredHibernateCacheHeapFree = DEFAULT_MESH_CLUSTERED_HIBERNATE_CACHE_HEAP_FREE;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Set the maximum size of the hibernate cache. A value of null will disable the cache. "
 			+ "A value ended with K/M/G will mean an absolute value in [kil|mega|giga]bytes correspondingly. "
-			+ "A value ended with % will mean a percent of maximum memory Mesh is allowed to use. "
-			+ "Default: " + DEFAULT_MESH_NON_CLUSTERED_HIBERNATE_CACHE_SIZE)
+			+ "A value ended with % will mean a percent of maximum memory Mesh is allowed to use.")
 	@EnvironmentVariable(name = MESH_NON_CLUSTERED_HIBERNATE_CACHE_SIZE, description = "Override the field container cache size.")
 	private String nonClusteredHibernateCacheSize = DEFAULT_MESH_NON_CLUSTERED_HIBERNATE_CACHE_SIZE;
 

--- a/mdm/hibernate-api/src/main/java/com/gentics/mesh/etc/config/hibernate/HibernateStorageOptions.java
+++ b/mdm/hibernate-api/src/main/java/com/gentics/mesh/etc/config/hibernate/HibernateStorageOptions.java
@@ -73,7 +73,7 @@ public class HibernateStorageOptions implements Option {
 	public static final String MESH_HIBERNATE_NATIVE_QUERY_FILTERING = "MESH_HIBERNATE_NATIVE_QUERY_FILTERING";
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Enables the native database level filtering for queries. Default: ON_DEMAND")
+	@JsonPropertyDescription("Enables the native database level filtering for queries.")
 	@EnvironmentVariable(name = MESH_HIBERNATE_NATIVE_QUERY_FILTERING, description = "Override the configured native query filtering.")
 	private NativeQueryFiltering nativeQueryFiltering = DEFAULT_NATIVE_QUERY_FILTERING;
 
@@ -142,12 +142,12 @@ public class HibernateStorageOptions implements Option {
 	private HikariCPOptions hikariOptions = new HikariCPOptions();
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Flag which controls whether writes to the database should be synchronized. Setting this flag improves the stability of massive database updates, by the cost of overall performance. Default: " + DEFAULT_SYNC_WRITES)
+	@JsonPropertyDescription("Flag which controls whether writes to the database should be synchronized. Setting this flag improves the stability of massive database updates, by the cost of overall performance.")
 	@EnvironmentVariable(name = MESH_DB_SYNC_WRITES_ENV, description = "Override the database sync writes flag.")
 	private boolean synchronizeWrites = DEFAULT_SYNC_WRITES;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Set the timeout in milliseconds for the sync write lock. Default: " + DEFAULT_SYNC_WRITES_TIMEOUT)
+	@JsonPropertyDescription("Set the timeout in milliseconds for the sync write lock.")
 	@EnvironmentVariable(name = MESH_DB_SYNC_WRITES_TIMEOUT_ENV, description = "Override the database sync write timeout.")
 	private long synchronizeWritesTimeout = DEFAULT_SYNC_WRITES_TIMEOUT;
 
@@ -163,12 +163,12 @@ public class HibernateStorageOptions implements Option {
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Global query timeout limit in milliseconds. A timeout value of zero means there is no query timeout.")
-	@EnvironmentVariable(name = MESH_HIBERNATE_QUERY_TIMEOUT, description = "Query timeout for hibernate. Default: " + DEFAULT_QUERY_TIMEOUT)
+	@EnvironmentVariable(name = MESH_HIBERNATE_QUERY_TIMEOUT, description = "Query timeout for hibernate.")
 	private long queryTimeout = DEFAULT_QUERY_TIMEOUT;
 
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("Define a threshold in milliseconds, upon which a SQL query is considered slow and produces a log warning.")
-	@EnvironmentVariable(name = MESH_HIBERNATE_SLOW_SQL_THRESHOLD, description = "Slow SQL query threshold in milliseconds. Default: " + DEFAULT_SLOW_SQL_THRESHOLD)
+	@EnvironmentVariable(name = MESH_HIBERNATE_SLOW_SQL_THRESHOLD, description = "Slow SQL query threshold in milliseconds.")
 	private long slowSqlThreshold = DEFAULT_SLOW_SQL_THRESHOLD;
 
 	@JsonProperty(required = false)
@@ -179,7 +179,7 @@ public class HibernateStorageOptions implements Option {
 	@JsonProperty(required = false)
 	@JsonPropertyDescription("SQL parameter number limit.")
 	@EnvironmentVariable(name = MESH_DB_SQL_PARAMETERS_LIMIT_ENV, description = "Limit the number of SQL parameters in selected lookup queries. Can be either `" 
-							+ SQL_PARAMETERS_LIMIT_OPTION_DB_DEFINED + "` or `" + SQL_PARAMETERS_LIMIT_OPTION_UNLIMITED + "` or a custom number (greater than zero). Default is: " + DEFAULT_SQL_PARAMETERS_LIMIT)
+							+ SQL_PARAMETERS_LIMIT_OPTION_DB_DEFINED + "` or `" + SQL_PARAMETERS_LIMIT_OPTION_UNLIMITED + "` or a custom number (greater than zero).")
 	private String sqlParametersLimit = DEFAULT_SQL_PARAMETERS_LIMIT;
 
 	@JsonProperty(required = false)

--- a/mdm/hibernate-api/src/main/java/com/gentics/mesh/etc/config/hibernate/HikariCPOptions.java
+++ b/mdm/hibernate-api/src/main/java/com/gentics/mesh/etc/config/hibernate/HikariCPOptions.java
@@ -35,53 +35,53 @@ public class HikariCPOptions implements Option {
 	private static final String HIKARI_CP_LEAK_DETECTION_THRESHOLD = "HIKARI_CP_LEAK_DETECTION_THRESHOLD";
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Connection auto-commit behavior.")
-	@EnvironmentVariable(name = HIKARI_CP_AUTOCOMMIT, description = "This property controls the default auto-commit behavior of connections returned from the pool. It is a boolean value.")
+	@JsonPropertyDescription("This property controls the default auto-commit behavior of connections returned from the pool. It is a boolean value.")
+	@EnvironmentVariable(name = HIKARI_CP_AUTOCOMMIT, description = "Override the HikariCP connection auto-commit behavior.")
 	private boolean autocommit = DEFAULT_AUTOCOMMIT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Connection timeout.")
-	@EnvironmentVariable(name = HIKARI_CP_CONNECTION_TIMEOUT, description = "This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. Lowest acceptable connection timeout is 250 ms.")
+	@JsonPropertyDescription("This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. Lowest acceptable connection timeout is 250 ms.")
+	@EnvironmentVariable(name = HIKARI_CP_CONNECTION_TIMEOUT, description = "Override the HikariCP connection timeout.")
 	private Integer connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Idle timeout.")
-	@EnvironmentVariable(name = HIKARI_CP_IDLE_TIMEOUT, description = "This property controls the maximum amount of time that a connection is allowed to sit idle in the pool. This setting only applies when minimumIdle is defined to be less than maximumPoolSize. Idle connections will not be retired once the pool reaches minimumIdle connections. Whether a connection is retired as idle or not is subject to a maximum variation of +30 seconds, and average variation of +15 seconds. A connection will never be retired as idle before this timeout. A value of 0 means that idle connections are never removed from the pool. The minimum allowed value is 10000ms (10 seconds).")
+	@JsonPropertyDescription("This property controls the maximum amount of time that a connection is allowed to sit idle in the pool. This setting only applies when minimumIdle is defined to be less than maximumPoolSize. Idle connections will not be retired once the pool reaches minimumIdle connections. Whether a connection is retired as idle or not is subject to a maximum variation of +30 seconds, and average variation of +15 seconds. A connection will never be retired as idle before this timeout. A value of 0 means that idle connections are never removed from the pool. The minimum allowed value is 10000ms (10 seconds).")
+	@EnvironmentVariable(name = HIKARI_CP_IDLE_TIMEOUT, description = "Override the HikariCP idle timeout.")
 	private Integer idleTimeout = DEFAULT_IDLE_TIMEOUT;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Max lifetime.")
-	@EnvironmentVariable(name = HIKARI_CP_MAX_LIFETIME, description = "This property controls the maximum lifetime of a connection in the pool. An in-use connection will never be retired, only when it is closed will it then be removed. On a connection-by-connection basis, minor negative attenuation is applied to avoid mass-extinction in the pool. We strongly recommend setting this value, and it should be several seconds shorter than any database or infrastructure imposed connection time limit. A value of 0 indicates no maximum lifetime (infinite lifetime), subject of course to the idleTimeout setting. The minimum allowed value is 30000ms (30 seconds).")
+	@JsonPropertyDescription("This property controls the maximum lifetime of a connection in the pool. An in-use connection will never be retired, only when it is closed will it then be removed. On a connection-by-connection basis, minor negative attenuation is applied to avoid mass-extinction in the pool. We strongly recommend setting this value, and it should be several seconds shorter than any database or infrastructure imposed connection time limit. A value of 0 indicates no maximum lifetime (infinite lifetime), subject of course to the idleTimeout setting. The minimum allowed value is 30000ms (30 seconds).")
+	@EnvironmentVariable(name = HIKARI_CP_MAX_LIFETIME, description = "Override the HikariCP max lifetime.")
 	private Integer maxLifetime = DEFAULT_MAX_LIFETIME;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Minimum idle connections in the pool.")
-	@EnvironmentVariable(name = HIKARI_CP_MIN_IDLE_CONNECTION, description = "This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool. If the idle connections dip below this value and total connections in the pool are less than maximumPoolSize, HikariCP will make a best effort to add additional connections quickly and efficiently. However, for maximum performance and responsiveness to spike demands, we recommend not setting this value and instead allowing HikariCP to act as a fixed size connection pool.")
+	@JsonPropertyDescription("This property controls the minimum number of idle connections that HikariCP tries to maintain in the pool. If the idle connections dip below this value and total connections in the pool are less than maximumPoolSize, HikariCP will make a best effort to add additional connections quickly and efficiently. However, for maximum performance and responsiveness to spike demands, we recommend not setting this value and instead allowing HikariCP to act as a fixed size connection pool.")
+	@EnvironmentVariable(name = HIKARI_CP_MIN_IDLE_CONNECTION, description = "Override the HikariCP minimum idle connections in the pool.")
 	private Integer minimumIdleConnection = DEFAULT_MIN_IDLE_CONNECTION;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Maximum pool size.")
-	@EnvironmentVariable(name = HIKARI_CP_MAX_POOL_SIZE, description = "This property controls the maximum size that the pool is allowed to reach, including both idle and in-use connections. Basically this value will determine the maximum number of actual connections to the database backend. A reasonable value for this is best determined by your execution environment. When the pool reaches this size, and no idle connections are available, calls to getConnection() will block for up to connectionTimeout milliseconds before timing out.")
+	@JsonPropertyDescription("This property controls the maximum size that the pool is allowed to reach, including both idle and in-use connections. Basically this value will determine the maximum number of actual connections to the database backend. A reasonable value for this is best determined by your execution environment. When the pool reaches this size, and no idle connections are available, calls to getConnection() will block for up to connectionTimeout milliseconds before timing out.")
+	@EnvironmentVariable(name = HIKARI_CP_MAX_POOL_SIZE, description = "Override the HikariCP maximum pool size.")
 	private Integer maxPoolSize = DEFAULT_MAX_POOL_SIZE;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Name of the connection pool.")
-	@EnvironmentVariable(name = HIKARI_CP_POOL_NAME, description = "This property represents a user-defined name for the connection pool and appears mainly in logging and JMX management consoles to identify pools and pool configurations.")
+	@JsonPropertyDescription("This property represents a user-defined name for the connection pool and appears mainly in logging and JMX management consoles to identify pools and pool configurations.")
+	@EnvironmentVariable(name = HIKARI_CP_POOL_NAME, description = "Override the HikariCP name of the connection pool.")
 	private String poolName = DEFAULT_POOL_NAME;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Register JMX Management Beans.")
-	@EnvironmentVariable(name = HIKARI_CP_REGISTER_MBEANS, description = "This property controls whether or not JMX Management Beans (\"MBeans\") are registered or not.")
+	@JsonPropertyDescription("This property controls whether or not JMX Management Beans (\\\"MBeans\\\") are registered or not.")
+	@EnvironmentVariable(name = HIKARI_CP_REGISTER_MBEANS, description = "Override the HikariCP Register JMX Management Beans.")
 	private Boolean registerMBeans = DEFAULT_REGISTER_MBEANS;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Transaction isolation level.")
-	@EnvironmentVariable(name = HIKARI_CP_TRANSACTION_ISOLATION_LEVEL, description = "This property controls the default transaction isolation level of connections returned from the pool. If this property is not specified, the default transaction isolation level defined by the JDBC driver is used. Only use this property if you have specific isolation requirements that are common for all queries. The value of this property is the constant name from the Connection class such as TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ. Setting it to null defaults to isolation level defined in the JDBC driver.")
+	@JsonPropertyDescription("This property controls the default transaction isolation level of connections returned from the pool. If this property is not specified, the default transaction isolation level defined by the JDBC driver is used. Only use this property if you have specific isolation requirements that are common for all queries. The value of this property is the constant name from the Connection class such as TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ. Setting it to null defaults to isolation level defined in the JDBC driver.")
+	@EnvironmentVariable(name = HIKARI_CP_TRANSACTION_ISOLATION_LEVEL, description = "Override the HikariCP transaction isolation level.")
 	private Integer transactionIsolationLevel = DEFAULT_TRANSACTION_ISOLATION_LEVEL;
 
 	@JsonProperty(required = false)
-	@JsonPropertyDescription("Leak detection threshold.")
-	@EnvironmentVariable(name = HIKARI_CP_LEAK_DETECTION_THRESHOLD, description = "This property controls the amount of time that a connection can be out of the pool before a message is logged indicating a possible connection leak. A value of 0 means leak detection is disabled. Lowest acceptable value for enabling leak detection is 2000 (2 seconds).")
+	@JsonPropertyDescription("This property controls the amount of time that a connection can be out of the pool before a message is logged indicating a possible connection leak. A value of 0 means leak detection is disabled. Lowest acceptable value for enabling leak detection is 2000 (2 seconds).")
+	@EnvironmentVariable(name = HIKARI_CP_LEAK_DETECTION_THRESHOLD, description = "Override the HikariCP leak detection threshold.")
 	private Integer leakDetectionThreshold = DEFAULT_LEAK_DETECTION_THRESHOLD;
 
 	public boolean isAutocommit() {


### PR DESCRIPTION
## Abstract
Fixes:

1. Actually used default values are now shown. No need to mention these explicitly (can be forgotten, misspelled etc).
2. The ENV vars now host the corresponding options value they override.
3. Missing configs are now documented.

## Checklist

### General

* [x] Added abstract that describes the change
* [x] Added changelog entry to `/CHANGELOG.adoc`
* [x] Ensured that the change is covered by tests
* [x] Ensured that the change is documented in the docs

### On API Changes

* [x] Checked if the changes are breaking or not
* [x] Added GraphQL API if applicable
* [x] Added Elasticsearch mapping if applicable
